### PR TITLE
CI scripts updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: groovy
-script: bash ci-build.sh
+script: bash scripts/ci-build.sh
 before_install:
   - wget https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-1-amd64.deb
   - sudo dpkg -i pandoc-2.2.1-1-amd64.deb
@@ -11,13 +11,13 @@ addons:
     - unzip
 deploy:
 - provider: script
-  script: bash ci-deploy.sh
+  script: bash scripts/ci-deploy.sh
   skip_cleanup: true
   on:
     all_branches: true
     condition: "$TRAVIS_BRANCH =~ ^[[:digit:]].*x$"
 - provider: script
-  script: bash ci-deploy.sh
+  script: bash scripts/ci-deploy.sh
   skip_cleanup: true
   on:
     tags: true

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -4,15 +4,16 @@
 set -euo pipefail
 IFS=$'\n\t'
 readonly ARGS=("$@")
+SCPTDIR=$( cd "$(dirname "$0")" && pwd)
 
-. ci-common.sh
+. "$SCPTDIR/ci-common.sh"
 
 # script for travis
 
 build(){
 	parse_travis_version
 	
-	if [ -z $VERSION ] ; then
+	if [ -z "$VERSION" ] ; then
 		read_version 
 	fi
 

--- a/scripts/ci-common.sh
+++ b/scripts/ci-common.sh
@@ -30,14 +30,17 @@ parse_travis_version(){
 		local tvers=${TRAVIS_TAG:1}
 		local ttag=GA
 		local release=yes
-		if [[ $tvers =~ -[[:alpha:][:digit:]]+$ ]] ; then
+		if [[ $tvers =~ -[[:alpha:][:digit:]-]+$ ]] ; then
 			ttag=${tvers#*-}
-			tvers=${tvers%-*}
+			tvers=${tvers%%-*}
 			release=no
 		fi
 		if [[ $ttag =~ ^maint ]] ; then
-			ttag=GA
 			release=no
+			if [[ $ttag =~ .*latest ]] ; then
+				release=yes
+			fi
+			ttag=GA
 		fi
 		read_version ${tvers} ${ttag}
 		PUBLISH_TAG=yes

--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -4,8 +4,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 readonly ARGS=("$@")
+SCPTDIR=$( cd "$(dirname "$0")" && pwd)
 
-. ci-common.sh
+. "$SCPTDIR/ci-common.sh"
 
 DRYRUN=false
 WORKSPACE=$(pwd)


### PR DESCRIPTION
* relocate to scripts/ dir
* update ci-common: allow tags like `v#.#-maint#-latest` to also publish the tag as latest GA (sets release=yes)