### PR TITLE
Fix some links in docs, add page generation feature for page links

### DIFF
--- a/en/administration/configuration/database/mysql.md
+++ b/en/administration/configuration/database/mysql.md
@@ -136,9 +136,9 @@ Enable DB storage for Project configurations, and Key Storage. Optionally enable
 
 For more info refer to:
 
-* [Administrator Guide - Key Storage](http://rundeck.org/docs/administration/key-storage.html)
-* [Plugins User Guide - Storage Plugins - Jasypt Encryption](http://rundeck.org/docs/plugins-user-guide/storage-plugins.html#jasypt-encryption-converter-plugin)
-* [Plugins User Guide - Configuring - Storage Plugins](http://rundeck.org/docs/plugins-user-guide/configuring.html#storage-plugins)
+* [Administrator Guide - Security - Key Storage](../../security/key-storage.html)
+* [Administrator Guide - Rundeck Configuration - Configuring Plugins - Bundled Plugins](../plugins/bundled-plugins.html#jasypt-encryption-plugin)
+* [Administrator Guide - Rundeck Configuration - Storage Facility](../storage-facility.html)
 
 Modify `rundeck-config.properties`
     

--- a/en/administration/configuration/database/mysql.md
+++ b/en/administration/configuration/database/mysql.md
@@ -136,28 +136,9 @@ Enable DB storage for Project configurations, and Key Storage. Optionally enable
 
 For more info refer to:
 
-* [Administrator Guide - Security - Key Storage](../../security/key-storage.html)
-* [Administrator Guide - Rundeck Configuration - Configuring Plugins - Bundled Plugins](../plugins/bundled-plugins.html#jasypt-encryption-plugin)
-* [Administrator Guide - Rundeck Configuration - Storage Facility](../storage-facility.html)
-
-Modify `rundeck-config.properties`
-    
-    # Enables DB for Project configuration storage
-    rundeck.projectsStorageType=db
-
-    # Encryption for project config storage
-    rundeck.config.storage.converter.1.type=jasypt-encryption
-    rundeck.config.storage.converter.1.path=projects
-    rundeck.config.storage.converter.1.config.password=mysecret
-
-    # Enable DB for Key Storage
-    rundeck.storage.provider.1.type=db
-    rundeck.storage.provider.1.path=keys
-
-    # Encryption for Key Storage
-    rundeck.storage.converter.1.type=jasypt-encryption
-    rundeck.storage.converter.1.path=keys
-    rundeck.storage.converter.1.config.password=mysecret
+* [[page:administration/security/key-storage.md]]
+* [[page:administration/configuration/plugins/bundled-plugins.md#jasypt-encryption-plugin]]
+* [[page:administration/configuration/storage-facility.md]]
 
 ## Start up Rundeck
 

--- a/en/administration/configuration/database/postgres.md
+++ b/en/administration/configuration/database/postgres.md
@@ -32,7 +32,7 @@ You may also have to add a pg_hba.conf entry for this user. See [pg_hba.conf doc
 
 ## Configure Rundeck
 
-Now you need to configure Rundeck to connect to this DB as described earlier in this document: [Customize the Datasource](#customize-the-datasource).
+Now you need to configure Rundeck to connect to this DB as described in: [Administrator Guide - Rundeck Configuration - Database - Customize the Datasource](index.html#customize-the-datasource).
 
 Update your `rundeck-config.properties` and configure the datasource:
 

--- a/en/administration/configuration/plugins/bundled-plugins.md
+++ b/en/administration/configuration/plugins/bundled-plugins.md
@@ -122,7 +122,7 @@ and Project Configuration stored in the DB or on disk.
 This plugin provides password based encryption for storage contents.  
 It uses the [Jasypt][] encryption library. The built in Java JCE is used unless another provider is specified, [Bouncycastle][] can be used by specifying the 'BC' provider name.
 
-[Jasypt]: (http://jasypt.org)
+[Jasypt]: http://jasypt.org
 [Bouncycastle]: https://www.bouncycastle.org/
 
 Password, algorithm, provider, etc can be specified directly, or via environment variables (the `*EnvVarName` properties), or Java System properties (the `*SysPropName` properties).

--- a/en/administration/configuration/plugins/bundled-plugins.md
+++ b/en/administration/configuration/plugins/bundled-plugins.md
@@ -114,7 +114,7 @@ Provides a Workflow Step:
 
 File: `rundeck-flow-control-plugin-${VERSION}.jar`
 
-## Jasypt Encryption Plugin
+## Jasypt Encryption Plugin {#jasypt-encryption-plugin}
 
 Provides an encryption [storage converter](../storage-facility.html#storage-converters) for the Storage facility.  Can be used to encrypt the contents of Key Storage,
 and Project Configuration stored in the DB or on disk.

--- a/en/administration/configuration/storage-facility.md
+++ b/en/administration/configuration/storage-facility.md
@@ -85,4 +85,4 @@ To develop your own storage converter plugin, see:
 
 Rundeck provides a bundled Storage Converter plugin implementation:
 
-* `jasypt-encryption` - encrypts the storage contents: [Configuration > Bundled Plugins > Jasypt Encryption Plugin](plugins/bundled-plugins.html#jasypt-encryption-plugin)
+* `jasypt-encryption` - encrypts the storage contents: [[page:administration/configuration/plugins/bundled-plugins.md#jasypt-encryption-plugin]]

--- a/en/pro/index.md
+++ b/en/pro/index.md
@@ -35,17 +35,17 @@ granted if a user's group membership meets the requirements of the policy.
 
 ## License
 
-[License](../administration/configuration/license-pro.html)
+See: [Rundeck Pro Licensing and Support](../administration/configuration/license-pro.html)
 
 ## General configuration
 
-Rundeck Pro supports all properties described in the [OSS version](http://rundeck.org/docs/administration/configuration-file-reference.html).
+Rundeck Pro supports all properties described in the [OSS version](../administration/configuration/configuration-file-reference.html).
 
-## Node Sources
+## Node Model Sources
 
 Node Sources allow you to import metadata about the nodes you want to run
 Rundeck jobs on. Node Sources are configured on Rundeck Pro in the same was as
-the OSS version, described in [Managing Node Sources](http://rundeck.org/docs/administration/managing-node-sources.html).
+the OSS version, described in [Node Model Sources](../administration/projects/resource-model-sources/index.html).
 
 ## Authentication
 
@@ -58,7 +58,7 @@ For more details, see [Authenticating Users](../administration/security/authenti
 
 Similar to OSS Rundeck, Rundeck Pro can securely store private keys that the Rundeck Node Executor and use for sessions.
 
-For momre details, see [Key Storage](http://rundeck.org/docs/administration/key-storage.html)
+For momre details, see [Key Storage](../administration/security/key-storage.html)
 
 ## Remote job execution (Pro-only)
 
@@ -75,10 +75,7 @@ For more details, see [Remote Job Execution](../administration/configuration/rem
 
 ### Database
 
-* [mysql](../administration/configuration/storage/using-mysql-as-a-database-backend.html)
-* [postgres](../administration/configuration/storage/using-postgres-as-a-database-backend.html)
-* [oracle](../administration/configuration/storage/using-oracle-as-a-database-backend.html)
-* [mssql](../administration/configuration/storage/using-microsoft-sql-server-as-a-database-backend.html)
+See: [Database Backends](../administration/configuration/database/index.html).
 
 ### Loadbalancer (Pro-only)
 

--- a/en/pro/quickstart.md
+++ b/en/pro/quickstart.md
@@ -40,7 +40,8 @@ Encrypted key/config storage enabled by default. The default encryption algorith
 
 Note: If you receive an error message about encryption policy strength with creating projects or keys you will need to upgrade your Java 1.8 version, or set the encryption algorithm in `rundeck-config.properties` to a lower strength algorithm such as `PBEWithMD5AndDES`
 
-Further information about encrypted key/config storage on [this](http://rundeck.org/docs/plugins-user-guide/bundled-plugins.html#jasypt-encryption-plugin) link.
+Further information about encrypted key/config storage on [this](../administration/configuration/plugins/bundled-plugins.html#jasypt-encryption-plugin) link.
 
 ### What is next? 
-Next, learn how to [create your first Rundeck Pro project](http://rundeck.org/docs/manual/getting-started.html#project-setup)
+
+Next, learn how to [create your first Rundeck Pro project](../manual/getting-started.html#project-setup)


### PR DESCRIPTION
Fix some links.

Allows markdown link references using the page path:

    [my text][page:path/to/other/file.md]

Also allows full link generation with correct page title:

    [[page:path/to/other/file.md]]

Currently the path must be from the common root dir