### PR TITLE
Update javadoc version for 3.0.5-20180828

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ RVERSION=$(VERSION)-$(TAG)
 else
 RVERSION=$(VERSION)
 endif
-VERSION_DATE=$(VERSION)-$(RELDATE)
+VERSION_FULL=$(VERSION)-$(RELDATE)
 
 .PHONY: all clean
 
@@ -34,12 +34,12 @@ dist/rundeck-docs-$(RVERSION).zip: all
 
 all: $(DIRS)
 	for i in $^ ; do \
-	$(MAKE) VERSION=$(VERSION) TAG=$(TAG) VERSION_DATE=$(VERSION_DATE) -C $$i ; \
+	$(MAKE) VERSION=$(VERSION) TAG=$(TAG) VERSION_FULL=$(VERSION_FULL) -C $$i ; \
 	done ;
 
 clean: $(DIRS)
 	for i in $^ ; do \
-	$(MAKE) VERSION=$(VERSION) TAG=$(TAG) VERSION_DATE=$(VERSION_DATE) -C $$i clean ; \
+	$(MAKE) VERSION=$(VERSION) TAG=$(TAG) VERSION_FULL=$(VERSION_FULL) -C $$i clean ; \
 	done ;
 	rm -rf dist
 

--- a/en/Makefile
+++ b/en/Makefile
@@ -24,7 +24,7 @@ RVERSION=$(VERSION)-$(TAG)
 else
 RVERSION=$(VERSION)
 endif
-VERSION_DATE=$(VERSION_DATE)
+VERSION_FULL=$(VERSION_FULL)
 
 
 EDAM=groovy ../scripts/edam.groovy
@@ -40,7 +40,7 @@ man :
 
 html: 
 	mkdir -p $(DIST)/html
-	$(EDAM) -o $(DIST)/html  -r -O 'recurseDirPatternIgnore=(dist|figures|temp)' -V "VERSION_DATE=$(VERSION_DATE)" -V "VERSION=$(RVERSION)" -V "APIVERS=$(APIVERS)" -V "DATE=$(DATE)" -V "HRDATE=$(HRDATE)" -V "DATE_YEAR=$(DATE_YEAR)"
+	$(EDAM) -o $(DIST)/html  -r -O 'recurseDirPatternIgnore=(dist|figures|temp)' -V "VERSION_FULL=$(VERSION_FULL)" -V "VERSION=$(RVERSION)" -V "APIVERS=$(APIVERS)" -V "DATE=$(DATE)" -V "HRDATE=$(HRDATE)" -V "DATE_YEAR=$(DATE_YEAR)"
 
 
 resources :  $(CSS) ../figures/*.png $(JS)

--- a/en/administration/configuration/plugins/bundled-plugins.md
+++ b/en/administration/configuration/plugins/bundled-plugins.md
@@ -45,7 +45,7 @@ For more detail see [Script Plugin](../../../manual/node-execution/script-node-e
 
 Executes an external script file to perform the command, useful for developing your own plugin with the [Script Plugin Development](../../../developer/plugin-development.html#script-plugin-development) model.
 
-File: `rundeck-script-plugin-${VERSION}.jar`
+File: `rundeck-script-plugin-${VERSION_FULL}.jar`
 
 ## Stub Plugin
 
@@ -80,13 +80,13 @@ You could, for example, disable or test an entire project's workflows or jobs by
 simply setting the `project.properties` node executor provider to `stub`.
 
 
-File: `rundeck-stub-plugin-${VERSION}.jar`
+File: `rundeck-stub-plugin-${VERSION_FULL}.jar`
 
 ## Local Execution Plugin
 
 A Node Step plugin which executes a command locally instead of on a target node.
 
-File: `rundeck-localexec-plugin-${VERSION}.jar`
+File: `rundeck-localexec-plugin-${VERSION_FULL}.jar`
 
 ## Job State Plugin
 
@@ -94,7 +94,7 @@ Provides a Workflow Step:
 
 * Job State Conditional: Can query and assert the state of another Job, such as running, succeeded, failed, etc, and optionally halt the current execution.
 
-File: `rundeck-job-state-plugin-${VERSION}.jar`
+File: `rundeck-job-state-plugin-${VERSION_FULL}.jar`
 
 ## Flow Control Plugin
 
@@ -102,7 +102,7 @@ Provides a Workflow Step:
 
 * Flow Control: Can halt the execution with a custom status, useful as an Error handler.
 
-File: `rundeck-flow-control-plugin-${VERSION}.jar`
+File: `rundeck-flow-control-plugin-${VERSION_FULL}.jar`
 
 ## Jasypt Encryption Plugin {#jasypt-encryption-plugin}
 
@@ -176,7 +176,7 @@ Example configuration for the Project Configuration storage facility:
 	rundeck.config.storage.converter.1.config.provider=BC
 
 
-File: `rundeck-jasypt-encryption-plugin-${VERSION}.jar`
+File: `rundeck-jasypt-encryption-plugin-${VERSION_FULL}.jar`
 
 ## Git Plugin
 
@@ -184,10 +184,10 @@ File: `rundeck-jasypt-encryption-plugin-${VERSION}.jar`
 
 Provides SCM Export and SCM Import providers for Git.
 
-File: `rundeck-git-plugin-${VERSION}.jar`
+File: `rundeck-git-plugin-${VERSION_FULL}.jar`
 
 ## Copy File Plugin
 
 Provides a Node Step that can copy a file to a node, using the Node's File Copier.
 
-File: `rundeck-copyfile-plugin-${VERSION}.jar`
+File: `rundeck-copyfile-plugin-${VERSION_FULL}.jar`

--- a/en/developer/01-plugin-development.md
+++ b/en/developer/01-plugin-development.md
@@ -50,8 +50,8 @@ Rundeck's core jar is published to the central Maven repository, so you can simp
 For gradle, use:
 
 ~~~~~ {.java}
-compile(group:'org.rundeck', name: 'rundeck-core', version: '${VERSION}')
 ~~~~~~~~~
+compile(group:'org.rundeck', name: 'rundeck-core', version: '${VERSION_FULL}')
 
 For maven use:
 
@@ -60,7 +60,7 @@ For maven use:
    <dependency>
       <groupId>org.rundeck</groupId>
       <artifactId>rundeck-core</artifactId>
-      <version>${VERSION}</version>
+      <version>${VERSION_FULL}</version>
       <scope>compile</scope>
    </dependency>
 </dependencies>

--- a/en/developer/01-plugin-development.md
+++ b/en/developer/01-plugin-development.md
@@ -45,7 +45,13 @@ the same name and type is defined.
 
 ### Build dependencies
 
-Rundeck's core jar is published to the central Maven repository, so you can simply specify a dependency in your build file.
+Rundeck's jars are published to the central Maven repository, and [jCenter](https://jcenter.bintray.com), so you can simply specify a dependency in your build file.
+
+* `rundeck-core` is the primary build dependency for most plugin types
+    * [org.rundeck:rundeck-core:${VERSION_FULL}](https://search.maven.org/artifact/org.rundeck/rundeck-core/${VERSION_FULL}/jar)
+* `rundeck-storage-api` is also required for [[page:developer/07-storage-plugin.md]].
+    * [org.rundeck:rundeck-storage-api:${VERSION_FULL}](https://search.maven.org/artifact/org.rundeck/rundeck-storage-api/${VERSION_FULL}/jar)
+  
 
 For gradle, use:
 

--- a/en/developer/01-plugin-development.md
+++ b/en/developer/01-plugin-development.md
@@ -56,8 +56,8 @@ Rundeck's jars are published to the central Maven repository, and [jCenter](http
 For gradle, use:
 
 ~~~~~ {.java}
-~~~~~~~~~
 compile(group:'org.rundeck', name: 'rundeck-core', version: '${VERSION_FULL}')
+~~~~~
 
 For maven use:
 
@@ -70,7 +70,7 @@ For maven use:
       <scope>compile</scope>
    </dependency>
 </dependencies>
-~~~~~~~~~
+~~~~~~
 
 * Rundeck's core jar is published to the central Maven repository, so you can now declare a build dependency more easily.
 
@@ -165,7 +165,7 @@ Each plugin class must have the
 public class MyProvider implements NodeExecutor {
 ...
 }
-~~~~~~~
+~~~~~
 
 Your provider class must have at least a zero-argument constructor, and optionally
 can have a single-argument constructor with a
@@ -289,7 +289,7 @@ import  com.dtolabs.rundeck.plugins.notification.NotificationPlugin
 rundeckPlugin(NotificationPlugin){
     //plugin definition goes here...
 }
-~~~~~~~~~~
+~~~~~~~
 
 In this case we use the same `NotificationPlugin` interface used for Java [Notfiication Plugins].
 
@@ -312,7 +312,7 @@ description='Does some action'
 version = "0.0.1"
 url = "http://example"
 author = "© 2018, me"
-~~~~~~~~~
+~~~~~
 
 *Configuration*
 
@@ -322,7 +322,7 @@ Use a `configuration` closure to define configuration properties:
 configuration{
     //property definitions go here...
 }
-~~~~~~~~
+~~~~~
 
 Note: not all plugin types support `configuration`.
 
@@ -334,7 +334,7 @@ User configuration properties can be defined in a few ways. To define a property
 
 ~~~~~ {.java}
 myproperty (title: "My Property", description: "Something", type: 'Integer')
-~~~~~~~~~
+~~~~~
 
 2. assignment form. This form guesses the data type and sets the defaultValue, but does not add any other attributes.
 
@@ -346,7 +346,7 @@ myproperty2(defaultValue:"default value", type: 'String')
 myproperty3=["value","another","text"]
 //the above is equivalent to:
 myproperty3(type:'FreeSelect',values:["value","another","text"])
-~~~~~~~~
+~~~~~
 
 Each property has several attributes you can define, but only `name` and `type` are required:
 
@@ -372,7 +372,7 @@ To define a validation check for a property, use the first form and supply a clo
 phone_number(title: "Phone number"){
    it.replaceAll(/[^\d]/,'')==~/^\d{10}$/
 }
-~~~~~~~
+~~~~~~
 
 **A Note about Scopes and Validation**:
 
@@ -455,7 +455,7 @@ providers:
       script-interpreter: [interpreter]
       script-file: [script file name]
       script-args: [script file args]
-~~~~~~~~~~~~
+~~~~~~~
 
 The main metadata that is required:
 
@@ -598,7 +598,7 @@ providers:
           description: "Must be present"
           default: '123'
           scope: Framework
-~~~~~~~~~~~~
+~~~~~~~
 
 ### How script plugin providers are invoked
 

--- a/en/developer/01-plugin-development.md
+++ b/en/developer/01-plugin-development.md
@@ -380,19 +380,12 @@ The user is presented with any `Instance` scoped properties in the Rundeck GUI w
 
 ### Supported Groovy Plugin Types 
 
-* [Notification Plugins]
-* [Streaming Log Writer Plugin]
-* [Streaming Log Reader Plugin]
-* [Execution File Storage Plugin]
-* [Log Filter Plugin]
-* [Content Converter Plugin]
-
-[Notificaton Plugins]: notification-plugins.html
-[Streaming Log Writer Plugin]: logging-plugins.html#groovy-streaminglogreader
-[Streaming Log Reader Plugin]: logging-plugins.html#groovy-streaminglogwriter
-[Execution File Storage Plugin]: logging-plugins.html#groovy-executionfilestorage
-[Log Filter Plugin]: log-filter-plugins.html#groovy-logfilter
-[Content Converter Plugin]: content-converter-plugins.html#groovy-contentconverter
+* [[page:developer/05-notification-plugins.md#groovy-plugin-type]]
+* [Streaming Log Reader][page:developer/06-logging-plugins.md#groovy-streaminglogreader]
+* [Streaming Log Writer][page:developer/06-logging-plugins.md#groovy-streaminglogwriter]
+* [Execution File Storage][page:developer/06-logging-plugins.md#groovy-executionfilestorage]
+* [Log Filter][page:developer/log-filter-plugins.md#groovy-logfilter]
+* [Content Converter Plugin][page:developer/content-converter-plugins.md#groovy-contentconverter]
 
 ## Script Plugin Development
 

--- a/en/developer/01-plugin-development.md
+++ b/en/developer/01-plugin-development.md
@@ -399,8 +399,6 @@ These Services support Script Plugins:
 * [ResourceModelSource](resource-model-source-plugin.html#script-plugin-type)
 * [WorkflowNodeStep](workflow-step-plugin.html#script-plugin-type) and RemoteScriptNodeStep
 
->Note, the ResourceFormatParser and ResourceFormatGenerator services *do not* support the Script Plugin type.
-
 ### UI Plugin Development
 
 UI Plugins are supported with a `ui` plugin type, which is similar to a Script Plugin.

--- a/en/developer/07-storage-plugin.md
+++ b/en/developer/07-storage-plugin.md
@@ -20,8 +20,21 @@ See: [Configuring the Storage Plugins](../administration/security/key-storage.ht
 
 * *Note*: Refer to [Java Development](plugin-development.html#java-plugin-development) for information about developing a Java plugin for Rundeck.
 
-The plugin interface is [StoragePlugin](${javadocbase}/com/dtolabs/rundeck/plugins/storage/StoragePlugin.html).  This simply extends [Tree](${javadocbase}/org/rundeck/storage/api/Tree.html) to store resource of type [ResourceMeta](${javadocbase}/com/dtolabs/rundeck/core/storage/ResourceMeta.html).
+**Plugin Interface**
 
-Refer to the [Rundeck Storage API javadocs](${javadocbase}/org/rundeck/storage/api/package-frame.html) for more information about the underlying storage API.
+* [StoragePlugin](${javadocbase}/com/dtolabs/rundeck/plugins/storage/StoragePlugin.html)
 
-The service name is [`Storage`](${javadocbase}/com/dtolabs/rundeck/plugins/ServiceNameConstants.html#Storage).
+This simply extends [Tree](${javadocbase}/org/rundeck/storage/api/Tree.html) to store resource of type [ResourceMeta](${javadocbase}/com/dtolabs/rundeck/core/storage/ResourceMeta.html).
+
+Refer to the [Rundeck Storage API javadocs](${javadocstoragetop}) for more information about the underlying storage API.
+
+**Service Name**
+
+* [`Storage`](${javadocbase}/com/dtolabs/rundeck/plugins/ServiceNameConstants.html#Storage)
+
+**Additional Compile-time Dependency**
+
+Your build tool will need to include `org.rundeck:rundeck-storage-api:${VERSION_FULL}` as a dependency.
+
+See: [org.rundeck:rundeck-storage-api:${VERSION_FULL}](https://search.maven.org/artifact/org.rundeck/rundeck-storage-api/${VERSION_FULL}/jar)
+  

--- a/en/edam.conf
+++ b/en/edam.conf
@@ -4,6 +4,6 @@
 -O srcpagelink=Edit this page
 -O bugpageurl=https://github.com/rundeck/docs/issues/new?labels=bug&title=Documentation+bug
 -O bugpagelink=Report a problem
--V javadoctop=https://javadoc.io/doc/org.rundeck/rundeck-core/3.0.1-20180803
--V javadocbase=https://javadoc.io/page/org.rundeck/rundeck-core/3.0.1-20180803
--V javadocstoragetop=https://javadoc.io/doc/org.rundeck/rundeck-storage-api/3.0.1-20180803
+-V javadoctop=https://javadoc.io/doc/org.rundeck/rundeck-core/${VERSION_FULL}
+-V javadocbase=https://javadoc.io/page/org.rundeck/rundeck-core/${VERSION_FULL}
+-V javadocstoragetop=https://javadoc.io/doc/org.rundeck/rundeck-storage-api/${VERSION_FULL}

--- a/en/pro/quickstart.md
+++ b/en/pro/quickstart.md
@@ -17,12 +17,12 @@ What differentiates Rundeck Pro from the OSS Rundeck version is . . . .
 1. Once the download is finished verify that the file's checksum matches the expected checksum:
 
     ```
-    shasum -a 1 ~/Downloads/rundeckpro-launcher-cluster-${VERSION}.jar
+    shasum -a 1 ~/Downloads/rundeckpro-launcher-cluster-${VERSION_FULL}.jar
     ```
 1. Run the `.jar` file:
 
     ```
-    java -XX:MaxPermSize=256m -Xmx1024m -jar ~/Downloads/rundeckpro-launcher-cluster-${VERSION}.jar
+    java -XX:MaxPermSize=256m -Xmx1024m -jar ~/Downloads/rundeckpro-launcher-cluster-${VERSION_FULL}.jar
     ```
 1. Once you see something similar to following log output, you know the server is ready:
 

--- a/scripts/edam.groovy
+++ b/scripts/edam.groovy
@@ -850,7 +850,12 @@ def parseArgs(pargs){
                 case '-V':
                     def arr=pargs[x+1].split('=',2)
                     if(arr.length>1){
-                        pagevars[arr[0]]=arr[1]
+                        def value=arr[1]
+                        if(value.indexOf('${')){
+                            //process embedded vars
+                            value=replaceParams(value, pagevars)
+                        }
+                        pagevars[arr[0]]=value
                     }
                     x++
                     break

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
-version.number=3.0.1
+version.number=3.0.5
 version.release.number=1
 version.tag=GA
-release.date=20180803
+version.date=20180828


### PR DESCRIPTION
* correct the version used for Javadoc links
* add `VERSION_FULL` variable to pagevars for edam
* correct the version used in referencing java artifacts to use `${VERSION_FULL}`
* fix numerous links
* update some development guide pages and links