### PR TITLE
Replaced forwardticks with apostrophes

### DIFF
--- a/en/administration/configuration/database/mysql.md
+++ b/en/administration/configuration/database/mysql.md
@@ -120,7 +120,7 @@ Perform this command to log in as root:
 Then execute this sql:
 
     > create database rundeck
-    > grant ALL on rundeck.* to ‘rundeckuser’@‘localhost’ identified by ‘rundeckpassword’
+    > grant ALL on rundeck.* to 'rundeckuser'@'localhost' identified by 'rundeckpassword'
 
 
 ## Configure rundeck-config.properties


### PR DESCRIPTION
Right now it's not possible to copy&paste and execute the command because forward ticks aren't syntactically correct and the execution raises an error.