### PR TITLE
WEB-INF/web.xml not longer needed

### DIFF
--- a/en/administration/security/authentication.md
+++ b/en/administration/security/authentication.md
@@ -704,9 +704,7 @@ This method can be enabled with this config in `rundeck-config.properties`:
 
 This configuration requires some additional setup to enable:
 
-1. The file `WEB-INF/web.xml` inside the war contents **must** be modified to remove the `<auth-constraint>` element.  This disables the behavior which causes the Container to trigger its authentication mechanism when a user browses to a Rundeck page requiring authorization.
-
-2. Apache HTTPD and Tomcat must be configured to communicate so that a list of User Roles is sent to Tomcat as a request Attribute with the given "attributeName".
+1. Apache HTTPD and Tomcat must be configured to communicate so that a list of User Roles is sent to Tomcat as a request Attribute with the given "attributeName".
 
 For Tomcat and Apache HTTPd with `mod_proxy_ajp`, here are some additional instructions:
 


### PR DESCRIPTION
As per the changelog at version 3.0, Editing the WEB-INF/web.xml file is no longer needed for preauthenticated method. The file also no longer exist. (I spent hours on this)