### PR TITLE
Fix: edit page link goes to wrong branch

### DIFF
--- a/en/edam.conf
+++ b/en/edam.conf
@@ -1,6 +1,6 @@
 -O pageFileName=${title}
 -O chapterNumbers=false
--O srcbaseurl=https://github.com/rundeck/docs/edit/3.0.x/en/
+-O srcbaseurl=https://github.com/rundeck/docs/edit/3.1.x/en/
 -O srcpagelink=Edit this page
 -O bugpageurl=https://github.com/rundeck/docs/issues/new?labels=bug&title=Documentation+bug+in+file+${pagesrcpath}&template=documentation-bug.md
 -O bugpagelink=Report a problem


### PR DESCRIPTION
3.1.x branch should be used for 3.1.x docs