### PR TITLE
WIP: add mermaid for graphs

### DIFF
--- a/docs/.vuepress/components/mermaid.vue
+++ b/docs/.vuepress/components/mermaid.vue
@@ -1,0 +1,19 @@
+
+<template>
+  <div class="mermaid">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  beforeMount() {
+    import("mermaid/dist/mermaid").then(m => {
+      m.initialize({
+        startOnLoad: true
+      });
+      m.init();
+    });
+  }
+};
+</script>

--- a/docs/manual/content-converters/index.md
+++ b/docs/manual/content-converters/index.md
@@ -13,23 +13,16 @@ the content correctly when you view it in the GUI. Rundeck also knows how to cha
 to produce `text/html` output for the Log View. This allows some plugins to
 simply parse formatted data such as CSV, and another plugin to render it as HTML.
 
-<pre class="diagram">
-
- .----------------.      +----------------+
-| input: text/json +---->| JSON converter |
- '----------------'      +-------+--------+
-                                 |
-                                 v
-                         .------------------.    +----------------------+
-                        | result: x-java-map +-->| HTML Table converter |
-                         '------------------'    +----------+-----------+
-                                                            |
-                                                            v
-                                                   .------------------.
-						                          | result: text/html  |
-						                           '------------------'
-
-</pre>
+<mermaid>
+graph TD
+  A(" text/json   ") --> B[JSON Converter]
+  B --> C("result: x-java-map")
+  C --> D[HTML Table converter]
+  D --> E("result: text/html   ")
+  style A fill:#eee
+  style C fill:#eee
+  style E fill:#eee
+</mermaid>
 
 Normally Content Converters are not used directly. However,
 Step plugins can include metadata in their log output that will invoke

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "core-js": "^2.6.5",
     "glob": "^7.1.4",
+    "mermaid": "^8.3.1",
     "vue": "^2.6.10",
     "vuepress-bar": "^0.1.0",
     "vuepress-sidebar-generator": "^0.1.1"


### PR DESCRIPTION
Attempt to use [mermaid](https://knsv.github.io/mermaid/#/) to replace Markdeep that was used before for ascii diagrams.

Unfortunately, the rendering seems to cut off some of the text as seen here: 

![Screen Shot 2019-10-16 at 6 32 20 AM](https://user-images.githubusercontent.com/55603/66924022-bd58c380-efde-11e9-8f1e-100b5aeb0d43.png)

For reference, here is the markdeep svg rendering as seen in the [3.0 docs](https://docs.rundeck.com/3.0.26/manual/content-converters/index.html)

![Screen Shot 2019-10-16 at 6 34 37 AM](https://user-images.githubusercontent.com/55603/66924203-0c9ef400-efdf-11e9-9e75-d5d5f805c3c7.png)
