### PR TITLE
JettyRolePropertyFileLoginModule supports hotReload

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -645,6 +645,7 @@ It then looks the username up in the Properties file, and applies any roles for 
 
 Configuration properties:
 
+- `hotReload` - `hotReload="true"` enables the ability to modify the user list specified by `file` without having to restart Rundeck. The refresh interval for checking the file is 5 seconds. This is not configurable.
 - `file` - path to a Java Property formatted file in the format defined under [realm.properties](#PropertyFileLoginModule)
 - `caseInsensitive` - true/false. If true, usernames are converted to lowercase before being looked up in the property file, otherwise they are compared as entered. Default: true.
 


### PR DESCRIPTION
According to testing and [source ](https://github.com/rundeck/rundeck/blob/0a5da63c4edad686cad40799e482f722c1df64ad/rundeckapp/src/test/groovy/org/rundeck/jaas/jetty/JettyRolePropertyFileLoginModuleTest.groovy) this login module supports hot reloading, same as JettyAuthPropertyFileLoginModule.