### PR TITLE
Fix typos and clarify wording.

### DIFF
--- a/docs/manual/job-plugins.md
+++ b/docs/manual/job-plugins.md
@@ -5,8 +5,8 @@
 - [Jira Node Step Plugins (Enterprise)](/manual/node-steps/jira.md)
 - [Command step](/manual/node-steps/builtin.md#command-step)
 - [Script step](/manual/node-steps/builtin.md#script-step)
-- [Scipt file](/manual/node-steps/builtin.md#script-file-step)
-- [Script url](/manual/node-steps/builtin.md#script-url-step)
+- [Script file](/manual/node-steps/builtin.md#script-file-step)
+- [Script URL](/manual/node-steps/builtin.md#script-url-step)
 - [Job reference](/manual/node-steps/builtin.md#job-reference-step)
 - [Copy file](/manual/node-steps/builtin.md#copy-file-step)
 - [Local command](/manual/node-steps/builtin.md#local-command-step)
@@ -25,7 +25,7 @@
 - [Log data step](/manual/workflow-steps/builtin.md#log-data-step)
 - [Refresh project nodes](/manual/workflow-steps/builtin.md#refresh-project-nodes)
 - [Data step](/manual/workflow-steps/builtin.md#data-step)
-- [File Transfer ()](/manual/workflow-steps/file-transfer.md)
+- [File Transfer (Enterprise)](/manual/workflow-steps/file-transfer.md)
 - [Github (Enterprise)](/manual/workflow-steps/github.md)
 - [Jira Workflow Step Plugins (Enterprise)](/manual/workflow-steps/jira.md)
 - [Progress Badge (Enterprise)](/manual/workflow-steps/progress-badge.md#progress-badge-workflow-step-plugin)
@@ -34,9 +34,7 @@
 
 ## Notifications
 
-Notification plugins determine what Rundeck does when a Job Execution
-starts or finishes, with either success or failure. For a general
-explanation on how job notifications work, see [Creating jobs#Job Notifications](/manual/creating-jobs.md#job-notifications)
+Notification plugins allow Rundeck to communicate changes in job execution state and notify other users of successful or failed runs. For a general explanation on how job notifications work, see [Job Notifications](/manual/creating-jobs.md#job-notifications).
 
 - [Email](/manual/notifications/email.md)
 - [Jira Notification Plugins (Enterprise)](/manual/notifications/jira.md)
@@ -50,18 +48,16 @@ The Workflow Strategy determines how the steps are processed within a Job's Work
 
 ## Node Orchestrator
 
-An Orchestrator plugin can determine how to use the Nodes selected by your Job Filter. By default, all of the filtered nodes will be used,
-in the order specified in your Job definition.
+Typically, Rundeck processes nodes in the exact order that they are specified within a Job definition. An *Orchestrator Plugin* allows this run order to be modified by selecting a subset of nodes. This would be useful in order to limit concurrent executions during a deployment or gradually role out a new job to allow for testing.
 
-However an Orchestrator plugin can choose which of the nodes should be used, and when. For example,
-to limit concurrent execution to a subset of the nodes, or to skip certain nodes.
+The Bundled plugins support random selection, ordering by ranked tier, or specifying a percentage of nodes to target. If more logic or specificity is required, the Enterprise edition supports the selection of a single node based upon the value of an attribute.
 
 - [Bundled Orchestrator Plugins](/manual/orchestrator-plugins/bundled.md)
 - [Highest/Lowest Attribute Value (Enterprise)](/manual/orchestrator-plugins/highest-lowest.md)
 
 ## Log Filters
 
-Log Filters can filter/process/read output from specific Workflow Steps, or all Workflow Steps of a Job.
+Log Filters can transform or aggregate output from one or more Workflow states.
 
 - [Mask Passwords](/manual/log-filters/mask-passwords.md)
 - [Render Formatted Data](/manual/log-filters/render-formatted-data.md)
@@ -72,6 +68,6 @@ Log Filters can filter/process/read output from specific Workflow Steps, or all 
 
 ## Content Converters
 
-Content Converters are not added directly to Jobs, but can be used by Log Filters and Step plugins.
+Content Converters are not added directly to Jobs, but can be used by Log Filters and Step plugins to render log output as HTML or Markdown within the Rundeck User Interface.
 
 See [Content Converter Plugins](/manual/content-converters/index.md).


### PR DESCRIPTION
This began to correct the spelling of script in the script file link, and I proceeded to reword most of the text on the page to use a more active voice and more direct language.