### PR TITLE
Revert incorrectly merged change from #342

### DIFF
--- a/docs/administration/security/authorization.md
+++ b/docs/administration/security/authorization.md
@@ -438,8 +438,7 @@ Type Properties Actions Description
 | "       |                                   | `toggle_execution` | Enable/disable the job for execution                                                |
 | "       |                                   | `scm_create`       | Create a Job only using SCM import plugin                                           |
 | "       |                                   | `scm_update`       | Import changes to a job using SCM import plugin                                     |
-| "       |                                   | `scm_delete`       | Delete a job only using SCM import plugin                                           |
-| "       |                                   | `view_history`     | View job executions history                                                         |
+| "       |                                   | `scm_delete`       | Delete a job only using SCM import plugin                                           |                          |
 | `node`  | "rundeck_server", "nodename", ... | `read`             | View the node in the UI (see [Node resource properties](#node-resource-properties)) |
 | "       |                                   | `run`              | Run jobs/adhoc on the node                                                          |
 


### PR DESCRIPTION
the acl change is not active in the code for 3.2.0+

this should not have been added until https://github.com/rundeck/rundeck/pull/5281 is merged