### PR TITLE
Include a note about java version new OS like debian 10 auto install Ja…

### DIFF
--- a/docs/administration/install/linux-deb.md
+++ b/docs/administration/install/linux-deb.md
@@ -20,6 +20,25 @@ sudo apt-get update
 sudo apt-get install rundeck
 ```
 
+Note: When rundeck repository is configured in your system and you install a new fresh rundeck[pro*], you will be asked to install OpenJDK 11 (which is not supported with rundeck). It's recommended to :
+
+1. Install Java 1.8 .
+
+2. Verify java 1.8 version is installed
+
+Example 
+```bash
+java -version
+openjdk version "1.8.0_242"
+OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_242-b08)
+OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.242-b08, mixed mode)
+```
+
+3. Install Rundeck 
+```bash
+sudo apt-get install rundeck
+```
+
 ### Install deb package directly
 
 Download deb package: http://rundeck.org/download/deb/ and run:


### PR DESCRIPTION
…va 11

If java is not installed in for example Debian 10 and rundeck repository is set. It will automatically install OpenJDK11. 

Example: 

# apt-get install rundeckpro-cluster
Reading package lists... Done
Building dependency tree       
Reading state information... Done

The following NEW packages will be installed:
java-common openjdk-11-jre-headless >>>>>>>

0 upgraded, 5 newly installed, 0 to remove and 2 not upgraded.
Need to get 366 MB of archives.
After this operation, 514 MB of additional disk space will be used.
Do you want to continue? [Y/n]