### PR TITLE
Improve documentation to use ldaps with Rundeck 3.X

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -585,7 +585,7 @@ c:\>  openssl s_client -connect ldaps_server.example:63 > C:\rundeck\certs.out
 ```bash
 c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass changeit -keystore "C:\Program Files\Java\jre1.8.0_xxx\lib\security\cacerts" -alias host_ext
 ```
-3. Import in rundeck ( Optional if using SSL with rundeck)
+3. Import in rundeck (Optional if using Rundeck with SSL)
 ```bash
 c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass adminadmin -keystore "C:\rundeck\etc\truststore" -alias ldapsserver
 ```

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -579,7 +579,7 @@ Finally, in your `ldap-activedirectory.conf` be sure to change the _providerUrl_
 ### Communicating over secure ldap using Windows(ldaps://)
 1. Download certificate from remote site 
 ```bash
-c:\>  openssl s_client -connect ldaps_server.example:686 > C:\rundeck\certs.out
+c:\>  openssl s_client -connect ldaps_server.example:636 > C:\rundeck\certs.out
 ```
 2. Import the file to keystore in Java home  . 
 ```bash

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -575,6 +575,22 @@ Refer to: https://docs.oracle.com/javase/1.5.0/docs/tooldocs/solaris/keytool.htm
 
 Finally, in your `ldap-activedirectory.conf` be sure to change the _providerUrl_ to be `ldaps://ad-server`. Including the port is optional as the default is 686.
 
+
+### Communicating over secure ldap using Windows(ldaps://)
+1. Download certificate from remote site 
+```bash
+c:\>  openssl s_client -connect ldaps_server.example:63 > C:\rundeck\certs.out
+```
+2. Import the file to keystore in Java home  . 
+```bash
+c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass changeit -keystore "C:\Program Files\Java\jre1.8.0_xxx\lib\security\cacerts" -alias host_ext
+```
+3. Import the file to keystore in rundeck . 
+```bash
+c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass adminadmin -keystore "C:\rundeck\etc\truststore" -alias ldapsserver
+```
+
+
 ## PAM
 
 Rundeck includes a [PAM](https://en.wikipedia.org/wiki/Pluggable_authentication_module) JAAS login module, which uses [libpam4j](https://github.com/kohsuke/libpam4j) to authenticate.

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -579,7 +579,7 @@ Finally, in your `ldap-activedirectory.conf` be sure to change the _providerUrl_
 ### Communicating over secure ldap using Windows(ldaps://)
 1. Download certificate from remote site 
 ```bash
-c:\>  openssl s_client -connect ldaps_server.example:63 > C:\rundeck\certs.out
+c:\>  openssl s_client -connect ldaps_server.example:582 > C:\rundeck\certs.out
 ```
 2. Import the file to keystore in Java home  . 
 ```bash

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -585,7 +585,7 @@ c:\>  openssl s_client -connect ldaps_server.example:63 > C:\rundeck\certs.out
 ```bash
 c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass changeit -keystore "C:\Program Files\Java\jre1.8.0_xxx\lib\security\cacerts" -alias host_ext
 ```
-3. Import the file to keystore in rundeck . 
+3. Import in rundeck ( Optional if using SSL with rundeck)
 ```bash
 c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass adminadmin -keystore "C:\rundeck\etc\truststore" -alias ldapsserver
 ```

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -579,7 +579,7 @@ Finally, in your `ldap-activedirectory.conf` be sure to change the _providerUrl_
 ### Communicating over secure ldap using Windows(ldaps://)
 1. Download certificate from remote site 
 ```bash
-c:\>  openssl s_client -connect ldaps_server.example:582 > C:\rundeck\certs.out
+c:\>  openssl s_client -connect ldaps_server.example:686 > C:\rundeck\certs.out
 ```
 2. Import the file to keystore in Java home  . 
 ```bash


### PR DESCRIPTION
ldaps + rundeck (tested in Rundeck 3.0.26 PRO)

------ LINUX -------
1. Download the external certificate from remote server 
```
# echo -n | openssl s_client -connect ldapvb.cl:636 > certif.out
# keytool -importcert -trustcacerts -file certif.out -alias srvldap -keystore etc/truststore 

password: adminadmin
```

2. Import cert in JAVA HOME
```
#keytool -importcert -trustcacerts -file certif.out -alias srvldap -keystore /usr/lib/jvm/jdk1.8.0_231/jre/lib/security/cacerts

password: 
changeit
```

3. Import in rundeck ( Optional if using SSL with rundeck)
```
# keytool -importcert -trustcacerts -file certif.out -alias srvldap -keystore etc/truststore 
```


------ WINDOWS -------
1. Download certificate from remote site 
c:\>  openssl s_client -connect ldaps_server.example:63 > C:\rundeck\certs.out

2. Import the file to keystore in Java home  . 
c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass changeit -keystore "C:\Program Files\Java\jre1.8.0_xxx\lib\security\cacerts" -alias host_ext

3. Optional if Rundeck uses SSL . Import the file to keystore in rundeck . 
c:\> keytool -importcert -file "C:\rundeck\certs.out" -storepass adminadmin -keystore "C:\rundeck\etc\truststore" -alias ldapsserver