### PR TITLE
Improved Static authentication tokens

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -119,6 +119,11 @@ The `tokens.properties` file should contain static authentication tokens you wis
     username2: token_string2
     ...
 
+or include roles
+
+    username: token_string,role1,role2
+    ...
+
 The token_strings can be used as Authentication tokens to the [API](/api/rundeck-api.md#token-authentication).
 
 ### Global execution variables


### PR DESCRIPTION
I spent an hour or so failing to work with the static token properly because I didn't realise you could also specify the roles applied to the token and be able to use the format
username: token_string,role1,role2
I was using this with docker and automated testing so wanted the tokens in there with roles similar as if the admin had created the token in the UI