### PR TITLE
broken link

### DIFF
--- a/docs/administration/maintenance/tuning-rundeck.md
+++ b/docs/administration/maintenance/tuning-rundeck.md
@@ -123,7 +123,7 @@ You can change this value, by updating the
 Please refer to the Quartz site for detailed information:
 [Quartz - Configure ThreadPool Settings][1].
 
-[1]: http://www.quartz-scheduler.org/documentation/quartz-2.x/configuration/ConfigThreadPool.html#configure-threadpool-settings
+[1]: http://www.quartz-scheduler.org/documentation/2.3.1-SNAPSHOT/configuration.html#configuration-of-threadpool-tune-resources-for-job-execution
 
 #### Update rundeck-config
 


### PR DESCRIPTION
Broken link >>> "Please refer to the Quartz site for detailed information: Quartz - Configure ThreadPool Settings. "

broken link in Line 126 

I think the correct link should be > http://www.quartz-scheduler.org/documentation/2.3.1-SNAPSHOT/configuration.html#configuration-of-threadpool-tune-resources-for-job-execution