### PR TITLE
Add an Overview link for Manual index file

### DIFF
--- a/docs/.vuepress/navbar-menus/user-guide.js
+++ b/docs/.vuepress/navbar-menus/user-guide.js
@@ -1,4 +1,7 @@
 module.exports = [{
+    link: '/manual/index',
+    text: 'Overview'
+  },{
     link: '/manual/01-introduction',
     text: 'Introduction'
   },

--- a/docs/.vuepress/sidebar-menus/user-guide.js
+++ b/docs/.vuepress/sidebar-menus/user-guide.js
@@ -3,6 +3,7 @@ module.exports = [{
   collapsable: false,
   sidebarDepth: 0,
   children: [
+    '/manual/',
     '/manual/01-introduction',
     '/manual/02-getting-help',
     '/manual/03-getting-started',

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -1,4 +1,4 @@
-# User Guide
+# Overview
 
 This the Rundeck _User Guide_.
 
@@ -21,3 +21,4 @@ For information about Rundeck Administration, see the [Administrator Guide](/adm
 - [User](/manual/10-user.md)
 - [Node Filters](/manual/11-node-filters.md)
 - [Webhooks](/manual/12-webhooks.md)
+- [Document Formats](/manual/document-format-reference/)


### PR DESCRIPTION
Adds explicitly links to the manual/index called Overview. Otherwise, this file has no links to it from nav.

![Screen Shot 2020-03-25 at 4 46 08 PM](https://user-images.githubusercontent.com/55603/77596106-45a99180-6eb8-11ea-8bd7-a31f20ca6297.png)
