### PR TITLE
Update the OAuth2 SSO docs to reflect the changes made for 3.3.0

### DIFF
--- a/docs/administration/security/sso.md
+++ b/docs/administration/security/sso.md
@@ -8,6 +8,29 @@ To configure the Okta SSO plugin for your Rundeck installation
 you will need to add a new application to your Okta Applications,
 and then add some properties to your rundeck-config.properties file.
 
+### Upgrade notes for 3.3.0
+   
+:::warning
+YOU MUST CHANGE YOUR CONFIGURED REDIRECT URL IN YOUR OAUTH PROVIDER
+:::
+The Login Redirect URI has changed.  
+Change it from `<rundeck base url>/user/oauth/<providerId>` to `<rundeck base url>/login/oauth2/code/<providerId>`  
+For example. If you use Okta.  
+Change from `<rundeck base url>/user/oauth/okta` to `<rundeck base url>/login/oauth2/code/okta`
+
+:::warning
+In order to enhance the security of the communication between your oauth provider and Rundeck, you must supply
+an additional `jwkSetUri` property. This allows Rundeck to obtain the signing keys necessary to verify the jwt tokens
+sent from your oauth provider.
+:::
+
+:::tip
+The Rundeck Oauth2 configuration now has support for auto configuration from your OIDC compliant provider.
+To use the auto configuration you only need to supply the base url to your oauth provider endpoint, your client id and client secret, and Rundeck will do the rest.
+Please see the documentation below for detailed instructions.
+:::
+
+
 ### Okta Application Configuration
 
 Log into your Okta web portal and configure a new application.
@@ -15,7 +38,7 @@ Log into your Okta web portal and configure a new application.
 - Create a new web application.
   - Configure the application with "Authorization Code" Grant type allowed.
   - Add the following URL to `Login Redirect URIs` (you can add more than one):
-    `<rundeck base url>/user/oauth/okta`. Example: `http://localhost:4440/user/oauth/okta`
+    `<rundeck base url>/login/oauth2/code/okta`. Example: `http://localhost:4440/login/oauth2/code/okta`
   - Copy the Client ID and Client Secret provided by Okta so that you can use them for the rundeck configuration.
 - Create groups with the same name as the roles configured on Rundeck. Map users to those groups.
 - Under the API menu, open the Authorization Servers configuration and add a new claim with the following information:
@@ -28,6 +51,37 @@ Log into your Okta web portal and configure a new application.
 
 Once you've set up the application in Okta you can configure Rundeck to use that
 application.
+
+#### Add the login button to Rundeck
+
+```properties
+#These properties control the appearance and url of the button on the login page
+rundeck.sso.loginButton.enabled=true
+rundeck.sso.loginButton.title=Login with Okta
+rundeck.sso.loginButton.url=oauth/okta
+```
+
+#### Auto Configuration Method (3.3.0 and above)
+```properties
+#Enable the OAuth SSO feature
+rundeck.security.oauth.enabled=true
+#The first two come from the Client Credentials section on your Application configuration page in Okta
+rundeck.security.oauth.okta.clientId = (Okta Client ID)
+rundeck.security.oauth.okta.clientSecret = (Okta Secret Key)
+
+#Auto Configuration Url
+#This is a url that will be appended with /.well-known/openid-configuration to retrieve the information needed to configure the OAuth2 connection
+rundeck.security.oauth.okta.autoConfigUrl = <okta service url>
+#example
+#rundeck.security.oauth.okta.autoConfigUrl = https://dev-877856.oktapreview.com
+
+# or if you are using a custom authorization server
+#rundeck.security.oauth.okta.autoConfigUrl = <okta service url>/oauth2/<authServerId>
+#example
+#rundeck.security.oauth.okta.autoConfigUrl = https://dev-877856.oktapreview.com/oauth2/default
+```
+
+#### Manual Configuration Method
 
 Add the following properties to your rundeck-config.properties file:
 
@@ -45,15 +99,10 @@ rundeck.security.oauth.okta.clientSecret = (Okta Secret Key)
 rundeck.security.oauth.okta.accessTokenUri = <okta service url>/v1/token
 rundeck.security.oauth.okta.userAuthorizationUri = <okta service url>/v1/authorize
 rundeck.security.oauth.okta.userInfoUri = <okta service url>/v1/userinfo
+rundeck.security.oauth.okta.jwkSetUri = <okta service url>/v1/keys
 
-#Copy These verbatim
-rundeck.security.oauth.okta.clientAuthenticationScheme = form
-rundeck.security.oauth.okta.scope = openid profile email
-
-#These properties control the appearance and url of the button on the login page
-rundeck.sso.loginButton.enabled=true
-rundeck.sso.loginButton.title=Login with Okta
-rundeck.sso.loginButton.url=oauth/okta
+#This is the default scope setting. Only add it if you need to customize the scopes
+#rundeck.security.oauth.okta.scope = openid profile email my_custom_scope
 ```
 
 After completing the configuration of your rundeck-config.properties file, restart Rundeck.
@@ -104,7 +153,7 @@ The Ping products you have purchased will determine how the application is set u
 
 #### Ping OIDC Application Setup
 When setting up the OIDC Application be sure to choose to generate a client secret, and choose the grant type: Authorization Code.
-The Redirect callback url will be: `https://{your-rundeck-host}/user/oauth/ping` (Ping requires this to be an https endpoint)
+The Redirect callback url will be: `https://{your-rundeck-host}/login/oauth2/code/ping` (Ping requires this to be an https endpoint)
 Specify the `openid`, `profile`, and `email` scopes for the application.
 
 _Note:_ The following Attribute Mappings must be set up in Ping on your OIDC Application.
@@ -121,6 +170,29 @@ After you have set up the OIDC application in Ping you will need the following p
 
 From the values you recorded above populate your `rundeck-config.properties` file.
 
+#### SSO Login button
+
+```properties
+#These properties control the appearance and url of the SSO login button on the login page
+rundeck.sso.loginButton.enabled=true
+rundeck.sso.loginButton.title=Login with Ping
+rundeck.sso.loginButton.url=oauth/ping
+```
+
+#### Auto Configuration (3.3.0 and above)
+
+```properties
+#Enable the OAuth SSO feature
+rundeck.security.oauth.enabled=true
+
+rundeck.security.oauth.ping.clientId = YOUR_CLIENT_ID_HERE
+rundeck.security.oauth.ping.clientSecret = YOUR_CLIENT_SECRET_HERE
+rundeck.security.oauth.ping.autoConfigUrl = https://sso.connect.pingidentity.com
+rundeck.security.oauth.ping.authorityProperty = YOUR_MAPPED_GROUPS_ATTRIBUTE
+```
+
+#### Manual Configuration
+
 Example:
 
 ```properties
@@ -132,16 +204,15 @@ rundeck.security.oauth.ping.clientSecret = YOUR_CLIENT_SECRET_HERE
 rundeck.security.oauth.ping.accessTokenUri = 	https://sso.connect.pingidentity.com/sso/as/token.oauth2
 rundeck.security.oauth.ping.userAuthorizationUri = https://sso.connect.pingidentity.com/sso/as/authorization.oauth2
 rundeck.security.oauth.ping.userInfoUri = 	https://sso.connect.pingidentity.com/sso/idp/userinfo.openid
-rundeck.security.oauth.ping.clientAuthenticationScheme = header
-rundeck.security.oauth.ping.scope = openid profile email
+rundeck.security.oauth.ping.jwkSetUri = 	https://sso.connect.pingidentity.com/sso/as/jwks
 rundeck.security.oauth.ping.principleKeys=sub
+
+#Only override if you need additional scopes
+#rundeck.security.oauth.ping.scope = openid profile email
+
 #The name of the attribute that hold's the users groups
 rundeck.security.oauth.ping.authorityProperty = YOUR_MAPPED_GROUPS_ATTRIBUTE
 
-#These properties control the appearance and url of the SSO login button on the login page
-rundeck.sso.loginButton.enabled=true
-rundeck.sso.loginButton.title=Login with Ping
-rundeck.sso.loginButton.url=oauth/ping
 ```
 
 After completing the configuration, restart Rundeck and attempt to login with Ping.
@@ -156,8 +227,22 @@ will send the correct url, but in some cases you will need to specify the redire
 This can be done by setting the following property in your Rundeck configuration file.
 
 ```properties
-rundeck.security.oauth.YOUR_OAUTH2_PROVIDER.customRedirectUri=https://YOUR_RUNDECK_SERVER/user/oauth/PROVIDER
+rundeck.security.oauth.YOUR_OAUTH2_PROVIDER.customRedirectUri=https://YOUR_RUNDECK_SERVER/login/oauth2/code/PROVIDER
 #example
-rundeck.security.oauth.okta.customRedirectUri=https://ssl_terminating_proxy.com/user/oauth/okta
-rundeck.security.oauth.ping.customRedirectUri=https://ssl_terminating_proxy.com/user/oauth/ping
+rundeck.security.oauth.okta.customRedirectUri=https://ssl_terminating_proxy.com/login/oauth2/code/okta
+rundeck.security.oauth.ping.customRedirectUri=https://ssl_terminating_proxy.com/login/oauth2/code/ping
 ```
+
+## Sync User Profile From OAuth2
+
+With Rundeck 3.3.0 you can set Rundeck to sync the information provided by your OAuth2 provider with the profile information inside Rundeck.
+
+Add the following property to your `rundeck-config.properties` file
+
+```properties
+rundeck.security.syncOauthUser=true
+```
+
+On SSO login, the jwt token sent by your Oauth2 provider will be examined for the `email` `given_name` and `family_name` attributes
+which should be populated if you are using the default scopes (`openid email profile`). 
+Rundeck will save this information to the appropriate fields in the user's Rundeck profile.


### PR DESCRIPTION
Helps a user upgrade their OAuth setup to work with Rundeck 3.3.0.