### PR TITLE
Fix database password variable name

### DIFF
--- a/docs/administration/install/docker.md
+++ b/docs/administration/install/docker.md
@@ -22,7 +22,7 @@ docker run \
     -v data:/home/rundeck/server/data \
     -e RUNDECK_DATABASE_DRIVER=com.mysql.jdbc.Driver \
     -e RUNDECK_DATABASE_USERNAME="${DB_USERNAME}" \
-    -e RUNDECK_DATABASE_PASSWPRD="${DB_PASSWORD}" \
+    -e RUNDECK_DATABASE_PASSWORD="${DB_PASSWORD}" \
     -e RUNDECK_DATABASE_URL="${DB_URL}" \
     rundeckpro/enterprise:{{{rundeckVersion}}}
 ```


### PR DESCRIPTION
Minor change to the documentation

Fix database password variable name

based on documentation here : https://hub.docker.com/r/rundeck/rundeck/