### PR TITLE
server session timeout property change

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -235,7 +235,7 @@ used. Specified from [jaas-loginmodule.conf](#jaas-loginmodule-conf).
 
 See [rundeck-config.properties > Server Settings](#server-settings)
 
-Or set `server.session.timeout` via [System Properties Configuration](/administration/configuration/system-properties.md).
+Or set `server.servlet.session.timeout` via [System Properties Configuration](/administration/configuration/system-properties.md).
 
 ## rundeck-config.properties
 
@@ -417,7 +417,7 @@ will suppress the non-SSO login form.
 
 ### Server Settings
 
-- `server.session.timeout`: timeout in seconds.
+- `server.servlet.session.timeout`: timeout in seconds.
 
 Note: This setting applies _only_ to the embedded Jetty server, which is used for standalone war launcher, rpm or deb installs. It does not work for Tomcat installation.
 

--- a/docs/administration/configuration/system-properties.md
+++ b/docs/administration/configuration/system-properties.md
@@ -10,7 +10,7 @@ If you are using [Executable War](/administration/install/jar.md) to start Runde
 on the commandline, using the `-Dpropertyname=value` syntax. Add a `-D` for each property:
 
 ```sh
-java -server -Dserver.session.timeout=3600 -Dserver.port=8080 -jar rundeck-{{{rundeckVersionFull}}}.war
+java -server -Dserver.servlet.session.timeout=3600 -Dserver.port=8080 -jar rundeck-{{{rundeckVersionFull}}}.war
 ```
 
 ## Properties Reference

--- a/docs/upgrading/upgrading-to-rundeck-3.3.md
+++ b/docs/upgrading/upgrading-to-rundeck-3.3.md
@@ -124,5 +124,5 @@ Clients using API version `10` or earlier should upgrade to use API version `11`
 
 ## Server session timeout property name change
 
-If you have customized the `server.servlet.timeout` property in your installation, please update the property name to `server.servlet.session.timeout`
+If you have customized the `server.session.timeout` property in your installation, please update the property name to `server.servlet.session.timeout`
 as this is the new correct property name.

--- a/docs/upgrading/upgrading-to-rundeck-3.3.md
+++ b/docs/upgrading/upgrading-to-rundeck-3.3.md
@@ -121,3 +121,8 @@ A [bug fix](https://github.com/rundeck/rundeck/pull/6118) changes the behavior o
 API Version `11` is the current **API Deprecation Level**, and will become the **API Minimum Version** in future Rundeck release version `3.4.0`.
 
 Clients using API version `10` or earlier should upgrade to use API version `11` minimum before then.
+
+## Server session timeout property name change
+
+If you have customized the `server.servlet.timeout` property in your installation, please update the property name to `server.servlet.session.timeout`
+as this is the new correct property name.


### PR DESCRIPTION
Add note about the server session timeout property change introduced by the grails 4 upgrade(spring boot 2).