### PR TITLE
Docs for license storage tree pointed to an incorrect property prefix for configuring the storage tree.

### DIFF
--- a/docs/administration/configuration/license.md
+++ b/docs/administration/configuration/license.md
@@ -81,16 +81,16 @@ on the filesystem.
 If you would like to store your license in a storage tree, you can configure a storage tree using the standard 
 storage tree config options.  
 
-Turn on license storage tree usage then provide your configuration using the prefix: `rundeck.license.storageTreeConfig`
+Turn on license storage tree usage then provide your configuration using the prefix: `rundeck.license.storage`
 
 Example storing the license in Amazon S3
 
 ```
 rundeck.license.useStorageTree=true
-rundeck.license.storageTreeConfig.provider.1.type=object
-rundeck.license.storageTreeConfig.provider.1.path=/license
-rundeck.license.storageTreeConfig.provider.1.config.bucket=rundeck
-rundeck.license.storageTreeConfig.provider.1.config.objectStoreUrl=https://s3.amazonaws.com
-rundeck.license.storageTreeConfig.provider.1.config.secretKey=YOUR_SECRET_KEY
-rundeck.license.storageTreeConfig.provider.1.config.accessKey=YOUR_ACCESS_KEY
+rundeck.license.storage.provider.1.type=object
+rundeck.license.storage.provider.1.path=/
+rundeck.license.storage.provider.1.config.bucket=rundeck
+rundeck.license.storage.provider.1.config.objectStoreUrl=https://s3.amazonaws.com
+rundeck.license.storage.provider.1.config.secretKey=YOUR_SECRET_KEY
+rundeck.license.storage.provider.1.config.accessKey=YOUR_ACCESS_KEY
 ```


### PR DESCRIPTION
Fix storage tree config for license information.