### PR TITLE
Adding on documentation the reason to why not use custom UUID in order to avoid inconsistencies in job loading

### DIFF
--- a/docs/manual/04-jobs.md
+++ b/docs/manual/04-jobs.md
@@ -63,7 +63,7 @@ your job in your job definition, it will modify the correct job in the server.
 The UUID is also useful when porting Job definitions between Rundeck instances.
 
 ::: warning
-Be careful not to use custom UUIDs as this can lead to inconsistencies in job loading. A possible problem, as documented in this [GitHub issue](https://github.com/rundeck/rundeck/issues/6150), occurs when customizing UUID using only numbers, it may cause a problem with database and the jobs can be displayed with crossed information.
+We do not require that this field is compliant with the UUID format but be careful creating custom UUIDs as this can lead to inconsistencies in job loading.
 :::
 
 ## Listing and filtering Jobs

--- a/docs/manual/04-jobs.md
+++ b/docs/manual/04-jobs.md
@@ -62,6 +62,10 @@ your job in your job definition, it will modify the correct job in the server.
 
 The UUID is also useful when porting Job definitions between Rundeck instances.
 
+::: warning
+Be careful not to use custom UUIDs as this can lead to inconsistencies in job loading. A possible problem, as documented in this [GitHub issue](https://github.com/rundeck/rundeck/issues/6150), occurs when customizing UUID using only numbers, it may cause a problem with database and the jobs can be displayed with crossed information.
+:::
+
 ## Listing and filtering Jobs
 
 All Job activity begins on the main "Jobs" page inside Rundeck. After


### PR DESCRIPTION
Fixes https://github.com/rundeck/rundeck/issues/6150

Using custom uuids may cause issue on databases although the use of customized UUIDs is allowed on Rundeck. So, was included a warning to mention the risk of changing a job's UUID