### PR TITLE
added working example for S3 Logs method using AWS credentials file

### DIFF
--- a/docs/administration/cluster/logstore/s3.md
+++ b/docs/administration/cluster/logstore/s3.md
@@ -24,7 +24,8 @@ externally configure the credentials in any of three ways:
 
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`
 2. Java system properties `aws.accessKeyId` and `aws.secretKey`
-3. Instance Profile credentials, if you are running on EC2. (See [the IAM user guide][1]).
+3. AWS credentials file
+4. Instance Profile credentials, if you are running on EC2. (See [the IAM user guide][1]).
 
 [1]: http://docs.aws.amazon.com/IAM/latest/UserGuide/role-usecase-ec2app.html
 
@@ -83,6 +84,21 @@ framework.plugin.ExecutionFileStorage.org.rundeck.amazon-s3.bucket=test-rundeck-
 
 #path to store the logs
 framework.plugin.ExecutionFileStorage.org.rundeck.amazon-s3.path=logs/${job.project}/${job.execid}.log
+```
+
+To use an AWS credentials file, you must not use the `AWSAccessKeyId`, `AWSSecretKey` or `AWSCredentialsFile` properties. Instead, create a `credentials` file in the Rundeck user's home directory under ~/.aws/credentials . This allows you to use full AWS AIM identities for authentication to AWS.
+
+An example of a working configuration:
+
+```
+[userauthentication]
+aws_access_key_id = AKIWWWWWWWWWWWWWW
+aws_secret_access_key = wo9........pYq
+
+[default]
+role_arn = arn:aws:iam::012345678900:role/yourrolehere
+source_profile = userauthentication
+region = us-east-2
 ```
 
 ## Using with Rundeck SSL Configuration


### PR DESCRIPTION
Added an example for using an AWS-style credentials file for the S3 logs plugin.