### PR TITLE
Update upgrading.md (server.servlet.context-path)

### DIFF
--- a/docs/upgrading/upgrading.md
+++ b/docs/upgrading/upgrading.md
@@ -130,4 +130,4 @@ mv rundeck-{{{rundeckVersionFull}}}.war $tomcat.base/webapps/rundeck.war
 
 - Due to changes in authentication, `tomcat-users.xml` and other Tomcat's authentication modules no longer work, you should configure users as described in [Authenticating Users](/administration/security/authentication.md#authenticating-users).
 - If you do not have `-Drundeck.config.location` defined or configured in `$tomcat.base/bin/setenv.sh` file (`tomcat.base\bin\setenv.bat` for Windows), Rundeck will read its config file from this location: `$rdeck.base/server/config/rundeck-config.properties`.
-- You **must** define the `server.contextPath` value in `rundeck-config.properties` to properly tell Rundeck about the context path used by tomcat. See [Installation on Tomcat](/administration/install/tomcat.md).
+- You **must** define the `server.servlet.context-path` (`server.contextPath` for versions prior to 3.3) value in `rundeck-config.properties` to properly tell Rundeck about the context path used by tomcat. See [Installation on Tomcat](/administration/install/tomcat.md).


### PR DESCRIPTION
Added a note that 'server.servlet.context-path' replaced 'server.contextPath' since version 3.3.
( Fixed/better version of https://github.com/rundeck/docs/pull/714 )