### PR TITLE
Adding doc for new property setting rundeck.gui.matchedNodesMaxCount

### DIFF
--- a/docs/administration/configuration/gui-customization.md
+++ b/docs/administration/configuration/gui-customization.md
@@ -229,6 +229,12 @@ Enables login status in user summary page.
 
 Sets the default value for users logged status to show on summary page (it will only work with rundeck.gui.userSummaryShowLoginStatus=true).
 
+### rundeck.gui.matchedNodesMaxCount
+- Example: ```(Default: 100)```
+- min version: 3.4.4
+
+Sets the maximum number of nodes to be displayed on [Matched Nodes](/manual/creating-jobs.md#node-dispatching-and-filtering) session in job edit page.
+
 
 ## Other Customizations
 The `rundeck.gui.errorpage.hidestacktrace` can also be set to true via a Java system property defined at system startup:

--- a/docs/manual/creating-jobs.md
+++ b/docs/manual/creating-jobs.md
@@ -143,6 +143,10 @@ In the GUI, the "Dispatch to Nodes" checkbox lets you enable node dispatching. W
 You can click the different filter fields "Name", and "Tags" to enter filter values for those fields. As you update the values you will see the "Matched Nodes" section updated to reflect the list of nodes that will match the inputs. You can click "More" to see more of the available inclusion filters, and you can click "Extended Filters" to enter
 exclusion filters for the same fields.
 
+::: tip
+By default, the "Matched Nodes" section will show a maximum of 100 nodes in the search result. To customize this maximum value, you should set the property `rundeck.gui.matchedNodesMaxCount` on rundeck-config.property file
+:::
+
 #### Threadcount
 
 You can set the maximum number of simultaneous threads to use by changing the "Thread Count" box. A value of 1 means all node dispatches happen sequentially, and any greater value means that the node dispatches will happen in parallel.


### PR DESCRIPTION
The property `rundeck.gui.matchedNodesMaxCount` was included to define maximum number of nodes to be shown on Matched Nodes section

PR: https://github.com/rundeck/rundeck/pull/7215