### PR TITLE
Google groups email fix

### DIFF
--- a/docs/introduction/getting-help.md
+++ b/docs/introduction/getting-help.md
@@ -20,7 +20,7 @@ Live Rundeck support on the first Thursday of every month. Deep dive product dem
 
 If you find problems with Rundeck, or if you have questions, remarks, or
 ideas about it, please send an email to the Rundeck mailing list.
-[rundeck-discuss@groups.google.com](mailto:rundeck-discuss@groups.google.com).
+[rundeck-discuss@googlegroups.com](mailto:rundeck-discuss@googlegroups.com).
 
 ## Bugs
 


### PR DESCRIPTION
Just a small fix, replacing "rundeck-discuss@groups.google.com" by "rundeck-discuss@googlegroups.com"