### PR TITLE
RUN-462: Advanced smtp settings using .properties format

### DIFF
--- a/docs/administration/configuration/email-settings.md
+++ b/docs/administration/configuration/email-settings.md
@@ -33,7 +33,7 @@ see the grails Mail plugin configuration:
 [Grails Mail Configuration](https://gpc.github.io/grails-mail/guide/2.%20Configuration.html)
 
 :::tip
-For the extended configuration properties, it needs to be appended to the property prefix `grails.mail.props.<key_props>`. For example, to enable `startttl`, the property should be `grails.mail.props.mail.smtp.starttls.enable=true`
+For the extended configuration properties, it needs to be appended to the property prefix `grails.mail.props.<key_props>`. For example, to enable `starttls`, the property should be `grails.mail.props.mail.smtp.starttls.enable=true`
 :::
 
 ## Notification email settings

--- a/docs/administration/configuration/email-settings.md
+++ b/docs/administration/configuration/email-settings.md
@@ -32,9 +32,9 @@ If you need more advanced configuration (e.g., authenticated and secured over SS
 see the grails Mail plugin configuration:
 [Grails Mail Configuration](https://gpc.github.io/grails-mail/guide/2.%20Configuration.html)
 
-The caveat for using this is that in our experience it requires using a .groovy formatted configuration file to support the extended configuration properties.
-
-See [Groovy config format](/administration/configuration/config-file-reference.md#groovy-config-format).
+:::tip
+For the extended configuration properties, it needs to be appended to the property prefix `grails.mail.props.<key_props>`. For example, to enable `startttl`, the property should be `grails.mail.props.mail.smtp.starttls.enable=true`
+:::
 
 ## Notification email settings
 


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/2002

Updating documentation which guides the user to setup the advanced configuration of the smtp server in .properties format and not in .groovy format