### PR TITLE
Clarity on prerequisites for Batch Key processing

### DIFF
--- a/docs/manual/webhooks/advanced-run-job.md
+++ b/docs/manual/webhooks/advanced-run-job.md
@@ -30,6 +30,8 @@ the event and run each item through the action processing.
 The batch key `$.messages` could be used to process each item
 individually.
 
+**Note:** Enabling Batch Key executes all items concurrently. Therefore, the job associated with the Webhook must have [Multiple Executions](https://docs.rundeck.com/docs/manual/creating-jobs.html#multiple-executions) enabled and a value large enough to support the number of items extracted from the list.
+
 :::tip
 The batch key supports JsonPath deep scanning. A key
 such as `$.messages[*].alerts` could be used to extract nested lists


### PR DESCRIPTION
In order for a Batch Key to work in the Advanced Run Job webhook, the associated job must have Multiple Executions enabled.