### PR TITLE
RUN-595: documenting Log output limit optional property

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -653,7 +653,7 @@ First Load Asynch: true/false
 
 ### Limit displayed Job execution Log Output
  
-Limit the amount of lines displayed in Log Output after a configurable limit has been reached.
+Limit the amount of lines displayed in Log Output when following the execution of a Job that is running (not finished yet) after a configurable limit has been reached.
 If the value is not defined, default behavior is to display all the generated output
 
 Trim Output: Max size of visible Log Output (not present by default).

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -651,9 +651,9 @@ Enabled: true/false (default true).
 First Load Asynch: true/false
 : `rundeck.nodeService.nodeCache.firstLoadAsynch=false` The default for whether the first load of a project's nodes should be performed synchronously or not. If set to `true`, and the [Project Nodes > Synchronous First Load](/administration/projects/project-create.md#project-nodes) value is unset, then the initial load of a Project's nodes when the cache is empty will be done in the background asynchronously. Otherwise the initial load is done synchronously, possibly causing a delay at Rundeck startup or Job execution startup. A Project level configuration value will override this default.
 
-### Reduce displayed Job execution Log Output
+### Limit displayed Job execution Log Output
  
-Reduce the amount of lines displayed in Log Output after a configurable limit has been reached.
+Limit the amount of lines displayed in Log Output after a configurable limit has been reached.
 If the value is not defined, default behavior is to display all the generated output
 
 Trim Output: Max size of visible Log Output (not present by default).

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -651,6 +651,16 @@ Enabled: true/false (default true).
 First Load Asynch: true/false
 : `rundeck.nodeService.nodeCache.firstLoadAsynch=false` The default for whether the first load of a project's nodes should be performed synchronously or not. If set to `true`, and the [Project Nodes > Synchronous First Load](/administration/projects/project-create.md#project-nodes) value is unset, then the initial load of a Project's nodes when the cache is empty will be done in the background asynchronously. Otherwise the initial load is done synchronously, possibly causing a delay at Rundeck startup or Job execution startup. A Project level configuration value will override this default.
 
+### Reduce displayed Job execution Log Output
+ 
+Reduce the amount of lines displayed in Log Output after a configurable limit has been reached.
+If the value is not defined, default behavior is to display all the generated output
+
+Trim Output: Max size of visible Log Output (not present by default).
+
+: `rundeck.logviewer.trimOutput=250kb` Remove the oldest lines in Log Output after displaying 250kb of logs 
+
+
 ### Groovy config format
 
 If you would prefer to use Groovy for the config file, you can use rundeck-config.groovy instead of rundeck-config.properties. Or, you can use a combination of the two (i.e. some settings configured in the properties file and some in the Groovy file).


### PR DESCRIPTION
Issue:
https://github.com/rundeckpro/rundeckpro/issues/1850

Description:
Documenting new optional property to limit the amount of logs being displayed