### PR TITLE
Added warning to database configuration section

### DIFF
--- a/docs/administration/install/installing-rundeck.md
+++ b/docs/administration/install/installing-rundeck.md
@@ -181,6 +181,10 @@ dataSource.properties.validationQuery = SELECT 1 FROM DUAL
 
 ::::
 
+:::warning
+If using passwords with **special characters**, make sure the corresponding property at least has **no spaces** between the equals and the value: `dataSource.password=<rundeckpassword>`
+:::
+
 ## Rundeck Configuration
 
 ### Server URL


### PR DESCRIPTION
It seems like many customers have been through this issue.
They waste time trying to find out why their rundeck instances don't work when setting a password with special characters.

The warning:
Don't use spaces when setting the `dataSource.password` property.