### PR TITLE
Added MySQL create user step

### DIFF
--- a/docs/administration/configuration/database/mysql.md
+++ b/docs/administration/configuration/database/mysql.md
@@ -5,7 +5,7 @@ MySQL 5.6 is now End of Life.  Rundeck will offer limited support on that versio
 
 ## Install MySQL
 
-Install MySQL using their installation guides [here](https://dev.mysql.com/doc/refman/8.0/en/installing.html)
+Install MySQL using the installation guides [here](https://dev.mysql.com/doc/refman/8.0/en/installing.html)
 
 ## Configure MySQL
 
@@ -25,7 +25,7 @@ MySQL 5.7 is in extended support but does not have the `utf8mb4` as a default ch
 
 ### MySQL 5.6
 
-MySQL 5.6 is End-of-Life and no longer fully supported as a backend.  If you are currently using this it's strongly recommended to upgrade those instances.
+MySQL 5.6 is End-of-Life and no longer fully supported as a backend.  Rundeck strongly recommends upgrading in-use instances of MySQL 5.6.
 
 ## Setup Rundeck Database
 
@@ -45,7 +45,7 @@ Next, create the MySQL user for the rundeck database:
     mysql> create user 'rundeckuser'@'localhost' identified by 'rundeckpassword';
     Query OK, 1 row affected (0.00 sec)
 
-Then "grant" access for your new user, and specify the hostname the Rundeck server will connect from. if it is the same server, use "localhost".
+Then "grant" access to the new user, and specify the hostname the Rundeck server will connect from. if it is the same server, use "localhost".
 
     mysql> grant ALL on rundeck.* to 'rundeckuser'@'localhost';
     Query OK, 1 row affected (0.00 sec)

--- a/docs/administration/configuration/database/mysql.md
+++ b/docs/administration/configuration/database/mysql.md
@@ -40,9 +40,14 @@ Enter the root password to connect. At the *mysql>* prompt, enter the following 
     mysql> create database rundeck;
     Query OK, 1 row affected (0.00 sec)
 
-Then "grant" access for a new user/password, and specify the hostname the Rundeck server will connect from. if it is the same server, use "localhost".
+Next, create the MySQL user for the rundeck database:
 
-    mysql> grant ALL on rundeck.* to 'rundeckuser'@'localhost' identified by 'rundeckpassword';
+    mysql> create user 'rundeckuser'@'localhost' identified by 'rundeckpassword';
+    Query OK, 1 row affected (0.00 sec)
+
+Then "grant" access for your new user, and specify the hostname the Rundeck server will connect from. if it is the same server, use "localhost".
+
+    mysql> grant ALL on rundeck.* to 'rundeckuser'@'localhost';
     Query OK, 1 row affected (0.00 sec)
 
 Exit the mysql prompt.


### PR DESCRIPTION
MySQL 8.x has deprecated the shortcut that allows you to create a new database user with a grant statement. In order to minimize confusion for newbies who are using MySQL, I've patched the detailed mysql doc to break out the create user step into a separate statement. This should work for all MySQL installs, regardless of version, so it should be more generically useful for everyone.