### PR TITLE
Solutions Navbar Quick Fix

### DIFF
--- a/docs/.vuepress/navbar-menus/learning.js
+++ b/docs/.vuepress/navbar-menus/learning.js
@@ -12,6 +12,6 @@ module.exports = [{
   },
   {
       text: 'Solutions',
-      link: '/learning/solutions/auto-incident-kubernetes-logs'
+      link: '/learning/solutions/automated-diagnostics/solution-overview'
   }
 ]


### PR DESCRIPTION
Need the **Solutions** to direct to the new Automated Diagnostics Solution Guide - rather than to the "old" Kubernetes Solution page.