### PR TITLE
Example value modified on porperty rundeck.gui.paginatejobs.max.per.page

### DIFF
--- a/docs/administration/configuration/gui-customization.md
+++ b/docs/administration/configuration/gui-customization.md
@@ -107,7 +107,7 @@ Paginate job list when listing project jobs
 
 
 ### rundeck.gui.paginatejobs.max.per.page
-- Example: ```TRUE```
+- Example: ```10```
 - min version: 2.x
 
 Number of jobs per page to display when job pagination is enabled

--- a/docs/learning/howto/pagerduty-notification.md
+++ b/docs/learning/howto/pagerduty-notification.md
@@ -5,7 +5,7 @@ Rundeck integrates with PagerDuty’s incident management platform, which provid
 In this guide we will show you how to trigger an event in PagerDuty after executing a job in Rundeck. This functionality is available in both Rundeck Community and Enterprise.   
 
 :::tip
-Note, there are many more [PagerDuty plugins](https://docs.rundeck.com/docs/manual/webhooks/pagerduty-run-job.html.) available for Rundeck Enterprise users
+Note, there are many more [PagerDuty plugins](https://docs.rundeck.com/docs/manual/webhooks/pagerduty-run-job.html) available for Rundeck Enterprise users
 :::
 
 Rundeck Notifications are actions triggered based on the result of a Job that was executed.  There are five conditions that can trigger Rundeck notifications, those conditions are:


### PR DESCRIPTION
Ticket: RUN-313

Problem: property rundeck.gui.paginatejobs.max.per.page had a boolean as example value.

Fix: property rundeck.gui.paginatejobs.max.per.page is now setted as integer.
