### PR TITLE
"Optional" label added on L449 for Primary Server ID:

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -446,7 +446,7 @@ If you are deploying the Rundeck war file to Tomcat, you can manage the session 
     <session-config> <session-timeout>30</session-timeout> </session-config>
 ```
 
-### Primary Server Id
+### Primary Server Id (optional)
 
 If you are running Rundeck in a cluster set up you'll want to set one of the servers as the primary server.
 Once set as primary, that server will be the one that applies any data updates that might need to be run on bootstrap.


### PR DESCRIPTION
Fixes: https://github.com/rundeck/docs/issues/999

"Optional" label added on L449 for Primary Server ID:
from @sjrd218 "primaryServerId was added before we had liquibase to try to mark one server as the one in charge of db updates. With liquibase it's probably not needed anymore."