### PR TITLE
Add RD_INSECURE_SSL_NO_WARN env var suggestion

### DIFF
--- a/docs/rd-cli/configuration.md
+++ b/docs/rd-cli/configuration.md
@@ -135,7 +135,7 @@ See [SSL Configuration](./ssl.md)
 
 To disable *all* SSL certificate checks, and hostname verifications:
 
-    `export RD_INSECURE_SSL=true`
+    `export RD_INSECURE_SSL=true RD_INSECURE_SSL_NO_WARN=true`
 
 When enabled, a value of `RD_DEBUG=2` will also report SSL certificate
 information.
@@ -145,7 +145,7 @@ information.
 To retain SSL certificate verification, but allow *any* hostname to be
 allowed for the certificate:
 
-    `export RD_INSECURE_SSL_HOSTNAME=true RD_INSECURE_SSL_NO_WARN=true`
+    `export RD_INSECURE_SSL_HOSTNAME=true`
 
 ## Alternate SSL Hostname Verification
 

--- a/docs/rd-cli/configuration.md
+++ b/docs/rd-cli/configuration.md
@@ -145,7 +145,7 @@ information.
 To retain SSL certificate verification, but allow *any* hostname to be
 allowed for the certificate:
 
-    `RD_INSECURE_SSL_HOSTNAME=true`
+    `export RD_INSECURE_SSL_HOSTNAME=true RD_INSECURE_SSL_NO_WARN=true`
 
 ## Alternate SSL Hostname Verification
 
@@ -154,4 +154,4 @@ allows you to retain SSL certificate verification, but set an
 alternate hostname to accept from the remote server certificate, if
 it does not match the hostname you are using in your request:
 
-    `RD_ALT_SSL_HOSTNAME=hostname`
+    `export RD_ALT_SSL_HOSTNAME=hostname`


### PR DESCRIPTION
Version 2.0.0 of the `rundeck-cli` will fail with an NPE if `RD_INSECURE_SSL=true` is set. https://github.com/rundeck/rundeck-cli/issues/453 suggests also setting `RD_INSECURE_SSL_NO_WARN=true` to address the issue (which it does), so adding this to the docs so that others don't have trouble in the future.