### PR TITLE
Fix missing example how to include whk include auth tokens

### DIFF
--- a/docs/api/rundeck-api.md
+++ b/docs/api/rundeck-api.md
@@ -5844,6 +5844,14 @@ In APIv34 or later:
 * `exportWebhooks` true/false, include project webhooks in the archive
 * `whkIncludeAuthTokens` true/false, include the auth token information when exporting webhooks, if not included the auth tokens will be regenerated upon import
 
+:::tip
+By default `exportAll` does not include the webhooks auth tokens, `whkIncludeAuthTokens` must be set to true in order to export the auth tokens. 
+
+Example:
+```
+GET /api/34/project/[PROJECT]/export?exportAll=true&whkIncludeAuthTokens=true
+```
+:::
 
 GET Examples:
 


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2509

Problem
Missing example showing how to include whkIncludeAuthTokens when exporting the project via API and using the export all flag. 

Solution
Example added. 