### PR TITLE
Run-1040: logstorage checkpoints minimum

### DIFF
--- a/docs/administration/cluster/logstore/azure.md
+++ b/docs/administration/cluster/logstore/azure.md
@@ -46,7 +46,7 @@ This will work only if the generated paths follow the [naming conventions for Az
 :::
 
 #### (Enterprise Version only):
-The Azure Storage Enterprise Version includes the [checkpoint property](/administration/configuration/plugins/configuring.md#logging) which enables an incremental update to the execution log across the members of the cluster. To use the pro version of this plugin (3.4.4+), please use the following on the rundeck-config.properties:
+The Azure Storage Enterprise Version includes the [checkpoint property](/administration/configuration/plugins/configuring.md#logging-checkpoints) which enables an incremental update to the execution log across the members of the cluster. To use the pro version of this plugin (3.4.4+), please use the following on the rundeck-config.properties:
 
 ```properties
 rundeck.execution.logs.fileStoragePlugin=rundeckpro.azure-storage

--- a/docs/administration/configuration/plugins/configuring.md
+++ b/docs/administration/configuration/plugins/configuring.md
@@ -282,6 +282,9 @@ that can be used to tune the behavior of the plugins:
   - threadpool size for log storage retry scheduling (retries)
   - default: 5
 
+
+#### Logging Checkpoints
+
 For plugins that support Partial/Checkpoint log storage these additional configuration properties can be set:
 
 - `rundeck.execution.logs.fileStorage.checkpoint.time.interval` default: `30s` (30 seconds)

--- a/docs/administration/configuration/plugins/configuring.md
+++ b/docs/administration/configuration/plugins/configuring.md
@@ -290,7 +290,12 @@ For plugins that support Partial/Checkpoint log storage these additional configu
 - `rundeck.execution.logs.fileStorage.checkpoint.time.interval` default: `30s` (30 seconds)
   - This is the time interval between submitting a new partial log storage request. _Network delays might affect the time until changes are reflected in the storage_
 - `rundeck.execution.logs.fileStorage.checkpoint.time.minimum` default: `30s` (30 seconds)
-  - This is the minimum time to wait until the execution starts comparing the current time with the `interval`. Eg: If `minimum = 10` and `interval = 5`, once the minimum is reached, the execution will see that the current time is greater than the interval, then it will submit the first storage request. After that, one storage request will be submitted every `interval` (in this case 5) seconds
+  - This is the minimum time to wait until the execution starts comparing the current time with the `interval`.
+
+:::tip
+Eg: If `minimum = 10` and `interval = 5`, once the minimum is reached, the execution will see that the current time is greater than the interval, then it will submit the first storage request. After that, one storage request will be submitted every `interval` (in this case 5) seconds
+:::
+
 - `rundeck.execution.logs.fileStorage.checkpoint.fileSize.minimum` default: `0` (no minimum)
   - This is the minimum file size before the first partial log storage request
 - `rundeck.execution.logs.fileStorage.checkpoint.fileSize.increment` default: `0` (no minimum increment)

--- a/docs/administration/configuration/plugins/configuring.md
+++ b/docs/administration/configuration/plugins/configuring.md
@@ -282,12 +282,12 @@ that can be used to tune the behavior of the plugins:
   - threadpool size for log storage retry scheduling (retries)
   - default: 5
 
-For plugins that support Partial/Checkpoint log storage, these additional configuration properties can be set:
+For plugins that support Partial/Checkpoint log storage these additional configuration properties can be set:
 
 - `rundeck.execution.logs.fileStorage.checkpoint.time.interval` default: `30s` (30 seconds)
-  - This is the time interval between submitting a new partial log storage request
+  - This is the time interval between submitting a new partial log storage request. _Network delays might affect the time until changes are reflected in the storage_
 - `rundeck.execution.logs.fileStorage.checkpoint.time.minimum` default: `30s` (30 seconds)
-  - This is the minimum time to wait until the first partial log storage request
+  - This is the minimum time to wait until the execution starts comparing the current time with the `interval`. Eg: If `minimum = 10` and `interval = 5`, once the minimum is reached, the execution will see that the current time is greater than the interval, then it will submit the first storage request. After that, one storage request will be submitted every `interval` (in this case 5) seconds
 - `rundeck.execution.logs.fileStorage.checkpoint.fileSize.minimum` default: `0` (no minimum)
   - This is the minimum file size before the first partial log storage request
 - `rundeck.execution.logs.fileStorage.checkpoint.fileSize.increment` default: `0` (no minimum increment)


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2591

The documentation seemed to not reflect the implemented feature's behavior.
The `checkpoint.time.minimum` doesn't necessarily represent the instant the first storage request is submitted. It actually represents the moment in which the Log Store File Checker starts comparing the _"last update time"_ (since the job started, or the last checkpoint) against the `checkpoint.time.interval`.

Screenshot:
![image](https://user-images.githubusercontent.com/49494423/178767056-017eea8f-16e8-4509-a9b0-a6a3d8a5ebce.png)
