### PR TITLE
any to Any value on autotakeover config

### DIFF
--- a/docs/administration/cluster/autotakeover/index.md
+++ b/docs/administration/cluster/autotakeover/index.md
@@ -35,7 +35,7 @@ Then configure Autotakeover by adding the following settings in `rundeck-config.
 rundeck.clusterMode.autotakeover.enabled=true
 
 # policy indicates which nodes to take over. "Any": all dead nodes. "Static": only allowed uuids
-rundeck.clusterMode.autotakeover.policy=any
+rundeck.clusterMode.autotakeover.policy=Any
 
 # delay in seconds to wait after sending autotakeover proposal
 rundeck.clusterMode.autotakeover.delay = 60


### PR DESCRIPTION
fix #1033 

Customers and support copy that configuration, and it fails, since the right value is case-sensitive.

rundeck.clusterMode.autotakeover.policy=any 🚫 
rundeck.clusterMode.autotakeover.policy=Any ✅ 