### PR TITLE
RUN-1099: added warning about permission for ssm

### DIFF
--- a/docs/manual/projects/node-execution/aws-ssm.md
+++ b/docs/manual/projects/node-execution/aws-ssm.md
@@ -26,6 +26,10 @@ Before configuring these plugins, be sure that you have completed the prerequisi
    <br><br>![aws-ssm-test-run](@assets/img/aws-ssm-test-run-command.png)<br>
    <br>![aws-ssm-test-script](@assets/img/aws-ssm-test-run-script.png)<br>
 
+:::warning
+Make sure you read the mentioned aws documentation and gave the correct permissions to the **ec2 machine** and the user that consumes the aws ssm api. Eg: the allowed actions that may be required for the ssm user are `ssm:SendCommand` and `ssm:ListCommandInvocations`, and in the case of the ec2 machine: `s3:GetObject`.
+:::
+
 ### Node Executor
 In order for SSM Node Executor to send commands to remote nodes, the following properties must be set on the nodes in Rundeck:
 1. `instanceId` - This is the EC2 instance-id from AWS.  If using the [AWS EC2 Node Source](/administration/projects/resource-model-sources/aws.html#amazon-ec2-node-source), then this property will be automatically applied.<br><br>

--- a/docs/manual/projects/node-execution/aws-ssm.md
+++ b/docs/manual/projects/node-execution/aws-ssm.md
@@ -27,7 +27,7 @@ Before configuring these plugins, be sure that you have completed the prerequisi
    <br>![aws-ssm-test-script](@assets/img/aws-ssm-test-run-script.png)<br>
 
 :::warning
-Make sure you read the mentioned aws documentation and gave the correct permissions to the **ec2 machine** and the user that consumes the aws ssm api. Eg: the allowed actions that may be required for the ssm user are `ssm:SendCommand` and `ssm:ListCommandInvocations`, and in the case of the ec2 machine: `s3:GetObject`.
+Please read the mentioned AWS documentation and configure the correct permissions to the **EC2 machine** and the user that consumes the AWS SSM API. e.g.: The allowed actions that may be required for the SSM user are `ssm:SendCommand` and `ssm:ListCommandInvocations`, and in the case of the EC2 machine: `s3:GetObject`.
 :::
 
 ### Node Executor


### PR DESCRIPTION
This could be solved reading the documentation

Fix: https://github.com/rundeckpro/rundeckpro/issues/2641
Fix: https://pagerduty.atlassian.net/browse/RUN-1099

I added warning about the required permissions and encouraging to read the mentioned aws docs

![image](https://user-images.githubusercontent.com/49494423/184154387-7f1f1e0f-6f95-4d95-9434-d03f9676ccd4.png)
