### PR TITLE
remove unused property rundeck.gui.login.footerMessageHtml

### DIFF
--- a/docs/administration/configuration/gui-customization.md
+++ b/docs/administration/configuration/gui-customization.md
@@ -135,13 +135,6 @@ Text displayed in the login page.
 HTML displayed on the login page. The HTML will be sanitized before display.
 
 
-### rundeck.gui.login.footerMessageHtml
-- Example: ```(Default: blank)```
-- min version: 2.x
-
-HTML displayed on the login page below the login form. The HTML will be sanitized before display.
-
-
 ### rundeck.gui.errorpage.hidestacktrace
 - Example: ```(Default: false)```
 - min version: 2.x


### PR DESCRIPTION
Partialy fix: https://github.com/rundeckpro/rundeckpro/issues/1868

An unused property was missing to be deprecated from docs

More info on: https://docs.google.com/spreadsheets/d/1qm-sMfMUflm3uV64NZsxBZ_j8_nXQDkB2Fpz-XZgn64/edit#gid=0