### PR TITLE
url remote options modify retry property as is on the code

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -617,7 +617,7 @@ rundeck.jobs.options.remoteUrlConnectionTimeout=[seconds]
 
 If the request is sent, but the server disconnects without a response (e.g. server is overloaded), retry the request this many times.
 
-Default value: 3
+Default value: 5
 
 Change this by setting:
 


### PR DESCRIPTION
Problem: The  docs about Job Remote Option URL connection retry parameter had a diffeference with the code. Before was 3 and should be 5.

Solution: Modify the docs and set the default property to 5. 

