### PR TITLE
add tip to loop script plugin over json

### DIFF
--- a/docs/manual/node-steps/loop-plugins.md
+++ b/docs/manual/node-steps/loop-plugins.md
@@ -23,7 +23,9 @@ In order to capture the JSON array in previous steps (data context), you can use
 * **_Stop Iteration on failure_**: Stop execution if the iteration failed
 
 The input JSON array must be a simple key/value JSON array:
-
+:::tip
+The JSON provided cannot have spaces in the attribute name, this is allowed just for the values
+:::
 ````
 [ 
   {"id":"1","name":"test 1"},


### PR DESCRIPTION
fix https://pagerduty.atlassian.net/browse/RSE-46

This adds a tip for the current behavior of the loop script from a JSON array to specify that the attributes cant have spaces in the name. This is due to a restriction when doing string replacements.