### PR TITLE
Add fixed gui properties 

### DIFF
--- a/docs/administration/configuration/gui-customization.md
+++ b/docs/administration/configuration/gui-customization.md
@@ -113,12 +113,18 @@ Displaying a real tree in the Jobs overview instead of collapsing empty groups.
 Change the default page shown after choosing a project. Values: 'adhoc', 'configure', 'createJob', 'events', 'home', 'jobs', 'nodes', 'projectHome' or 'uploadJob'.
 
 
-
 ### rundeck.gui.enableJobHoverInfo
 - Example: ```(Default: true)```
 - min version: 2.x
 
 Shows job information when the user hovers over a job name in various pages.
+
+
+### rundeck.gui.login.disclaimer
+- Example: ```(Default: blank)```
+- min version: 3.0.8
+
+HTML displayed on the login page below the login form element but seperate from the login form element. The HTML will be sanitized before display.
 
 
 ### rundeck.gui.login.welcome
@@ -133,6 +139,13 @@ Text displayed in the login page.
 - min version: 2.x
 
 HTML displayed on the login page. The HTML will be sanitized before display.
+
+
+### rundeck.gui.login.footerMessageHtml
+- Example: ```(Default: blank)```
+- min version: 2.x
+
+HTML displayed on the login page below the login form. The HTML will be sanitized before display.
 
 
 ### rundeck.gui.errorpage.hidestacktrace


### PR DESCRIPTION
Problem: 
In previous Rundeck versions, these two GUI properties **rundeck.gui.login.disclaimer** and **rundeck.gui.login.footerMessageHtml** were not working and were deprecated. This PR https://github.com/rundeck/rundeck/pull/7846 added the missing code to make  **rundeck.gui.login.disclaimer** and **rundeck.gui.login.footerMessageHtml** works as expected again.

Solution:
Add to the documentation the functional properties 

<img width="1376" alt="imagen" src="https://user-images.githubusercontent.com/87494173/187279902-81f0a08f-11b0-44c5-b37b-fa21725dbad5.png">

