### PR TITLE
RSE-85 Header X-XSS Protect disabled permanently

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -326,7 +326,7 @@ Some of the properties that work with live reloading:
 ### Security HTTP Headers
 
 :::warning
-The HTTP header 'XSS-Protection' has been deprecated by mordern browsers and it use can introduce additional security issues on the client side of the application. So Rundeck will not support this header no more since version 4.3.0 .
+The HTTP header 'XSS-Protection' has been deprecated by mordern browsers and it use can introduce additional security issues on the client side of the application. So Rundeck will no longer support this header as of version 4.3.0 .
 :::
 
 Rundeck adds some HTTP headers for XSS prevention and other security reasons, as described below.

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -326,7 +326,7 @@ Some of the properties that work with live reloading:
 ### Security HTTP Headers
 
 :::warning
-The HTTP header 'XSS-Protection' has been deprecated by mordern browsers and it use can introduce additional security issues on the client side of the application. So Rundeck will no longer support this header as of version 4.3.0 .
+The HTTP header 'XSS-Protection' has been deprecated by mordern browsers and it use can introduce additional security issues on the client side of the application. Rundeck has deprecated this setting as of version 4.3.0.
 :::
 
 Rundeck adds some HTTP headers for XSS prevention and other security reasons, as described below.

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -341,7 +341,7 @@ rundeck.security.httpHeaders.enabled=true
 
 #########
 # enable x-content-type-options: nosniff  (default: true)
-rundeck.security.httpHeaders.provider.xcto.enabled=trues
+rundeck.security.httpHeaders.provider.xcto.enabled=true
 
 # enable x-frame-options: deny  (default: true)
 

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -325,6 +325,10 @@ Some of the properties that work with live reloading:
 
 ### Security HTTP Headers
 
+:::warning
+The HTTP header 'XSS-Protection' has been deprecated by mordern browsers and it use can introduce additional security issues on the client side of the application. So Rundeck will not support this header no more since version 4.3.0 .
+:::
+
 Rundeck adds some HTTP headers for XSS prevention and other security reasons, as described below.
 
 By default, these headers are enabled, but they can be individually disabled, or reconfigured.
@@ -337,26 +341,8 @@ rundeck.security.httpHeaders.enabled=true
 
 #########
 # enable x-content-type-options: nosniff  (default: true)
-rundeck.security.httpHeaders.provider.xcto.enabled=true
+rundeck.security.httpHeaders.provider.xcto.enabled=trues
 
-#########
-# enable x-xss-protection: 1  (default: true)
-
-rundeck.security.httpHeaders.provider.xxssp.enabled=true
-
-# Alternates for x-xss-protection:
-#
-# use x-xss-protection: 1; mode=block
-#
-
-# rundeck.security.httpHeaders.provider.xxssp.config.block=true
-
-#
-# use x-xss-protection: 1; report=https://some-uri
-
-# rundeck.security.httpHeaders.provider.xxssp.config.report=https://some-uri
-
-########
 # enable x-frame-options: deny  (default: true)
 
 rundeck.security.httpHeaders.provider.xfo.enabled=true


### PR DESCRIPTION
# X-XSS removal from the docs
As seen here: https://owasp.org/www-project-secure-headers/#x-xss-protection, and by this PR: https://github.com/rundeck/rundeck/pull/7696 , Rundeck is no longer supporting the header since it's deprecated.

## In this PR
1. We removed the property that sets the header from the docs
2. Added a warning to any users who want to set the header.