### PR TITLE
RSE-88: Added reference for notification context in job workflows page

### DIFF
--- a/docs/developer/05-notification-plugins.md
+++ b/docs/developer/05-notification-plugins.md
@@ -59,6 +59,8 @@ the value.
 The execution data is included as a Map called `execution`
 containing the following keys and values:
 
+> Note: The context variables that will be available for users to use on inputs on the gui will depend on the specific notification plugin.
+
 `execution.id`: ID of the execution
 
 `execution.href`: URL to the execution output view

--- a/docs/manual/job-workflows.md
+++ b/docs/manual/job-workflows.md
@@ -288,7 +288,7 @@ When a Job step is executed, it has a set of "context" variables that can be acc
 
 The execution data is included as a Map called execution containing the following keys and values:
 
-> Note: The `execution` variables are only available in the Notification context.  They are not available while a job is running or as part of Job Steps.
+> Note: The `execution` variables are only available in the [Notification context](/developer/05-notification-plugins.md#execution-data). They are not available while a job is running or as part of Job Steps.
 
 - `execution.id`: ID of the execution
 - `execution.href`: URL to the execution output view


### PR DESCRIPTION
Just added a reference to notification plugins main page and a note to remind that not all notification plugins have the same context variables.