### PR TITLE
enhance docs UX by expanding content-width

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -63,6 +63,7 @@ a.home-link{
 }
 
 .theme-default-content:not(.custom) {
+  max-width: 65%
   padding: 6rem 2.5rem 2rem;
 }
 


### PR DESCRIPTION
Today the width of the content on our docs site is (very) narrow when compared with other docs sites.  This noticeably effects images, especially those that are necessarily full-webapp screenshots.

This commit expands the width of the content on every page.