### PR TITLE
PAM instructions updated

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -631,24 +631,6 @@ On Debian based systems you need to install libpam4j :
 apt install libpam4j-java
 ```
 
-On modern Debian linux distributions, add the following line on the `/etc/apt/sources.list` file:
-
-```
-deb http://ftp.us.debian.org/debian stretch main contrib non-free
-```
-
-Save the file and update all repositories with:
-
-```
-apt update
-```
-
-And then, install libpam4j-java library:
-
-```bash
-apt install libpam4j-java
-```
-
 This module can work with existing properties-file based authorization roles by enabling shared credentials between the modules, and introducing a Property file module that can be used only for authorization.
 
 Modules:


### PR DESCRIPTION
"Modern Linux distributions" info retired to avoid the "mixed repos" problem.

This "workaround" works:

1. Install this dependency (included on Debian 11 by default): `apt install libjna-java`
2. download the libpam4j library from Debian 9 repo: `wget http://ftp.us.debian.org/debian/pool/main/libp/libpam4j/libpam4j-java_1.4-2+deb9u1_all.deb`
3. install the libpamj4 package: `dpkg -i libpam4j-java_1.4-2+deb9u1_all.deb`

But the real problem is that libpm4j is outdated and not included on any modern Linux distro, so, installing that library is always a “tricky workaround”.