### PR TITLE
RSE-160: Fix: Missing file option basePath on docs

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -643,6 +643,11 @@ _For 1GB ~ 2GB files, is recommended to set:_
 java -Xms4g -Xmx8g -jar rundeck.war
 ```
 
+:::tip
+It is also possible to reconfigure the default path for files according to [this page](/developer/14-file-upload-plugins.html#about) using the property in this form:
+
+`framework.plugin.FileUpload.filesystem-temp.basePath=/desired/path`
+:::
 
 ### Job YAML format
 


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-160
Fix: https://github.com/rundeck/docs/issues/1095

Added tip referencing a more general page that explains about File Upload plugins:

![image](https://user-images.githubusercontent.com/49494423/192642046-d8724d21-1300-4ce1-8565-6acd01bcc3c4.png)
