### PR TITLE
add default image borders

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -22,6 +22,10 @@ figcaption
   font-style: italic
   text-align: center
 
+img {
+  border: 1px solid blue;
+}
+
 dl
   line-height: 1.7
 

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -23,7 +23,7 @@ figcaption
   text-align: center
 
 img {
-  border: 1px solid blue;
+  border: 1px solid #C0C0C0;
 }
 
 dl


### PR DESCRIPTION
This PR adds a default border to all images on the docs site.  

Currently, the vast majority of images in our docs appear to be "floating":

![Screen Shot 2022-09-30 at 5 28 51 PM](https://user-images.githubusercontent.com/11511251/193375733-1203f1da-aef7-402b-8e34-d33a7be96e91.png)

This PR provides a slim, light-gray border around all images so users can easily discern where the screenshots start and end:

![Screen Shot 2022-09-30 at 5 29 44 PM](https://user-images.githubusercontent.com/11511251/193375777-b4da47a0-cc94-41c7-a0e9-f54d38a9619d.png)

Can be compared to [Tableau doc](https://help.tableau.com/current/pro/desktop/en-us/getstarted_buildmanual_ex1basic.htm) and [Terraform Cloud doc](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started#create-an-account)