### PR TITLE
Note on support for Progress badge Status Symbols

### DIFF
--- a/docs/manual/log-filters/progress-badge.md
+++ b/docs/manual/log-filters/progress-badge.md
@@ -6,14 +6,14 @@ This log filter changes the log output of the steps in a job’s activity logs b
 
 One of the most common use-cases for the Progress Badge is to simplify the verbose output of diagnostics - such as application logs - into content that is consumable by first-responders of incidents.
 
-<img style='border:1px solid #327af6' src="@assets/img/progress-badge-output.png" />
+![PG Output](@assets/img/progress-badge-output.png)<br>
 
 ## Usage
 
 To add the Progress Badge to a job step:
 
 1. Click the **gear** icon in the upper-right of the job step:
-   <img style='border:1px solid #327af6' src="@assets/img/add-log-filter.png" />
+   ![Select Log Filter](@assets/img/add-log-filter.png)
 2. Click on **Progress Badge** and fill in the fields outlined below:
 
 **Regex**: Optional regex to search the log returns for. If this field is set, the badge will only appear if the regex finds a match.
@@ -21,6 +21,18 @@ To add the Progress Badge to a job step:
 **Text**: The text to be placed in the log-output.
 
 **Status Symbol**: Optional emoticon to append to the text in the log-output.
+
+::: warning Status Symbol Support
+For users that are self-hosting Process Automation, in order for Job definitions to support the Status Symbols, the database must support 4-Byte characters.
+As noted [here](/administration/configuration/database/mysql), MySQL 5.7 does not enable 4-Byte character support by default. <br>
+This can be enabled by adding the following to `my.cnf` (Linux) or `my.ini` (Windows):
+```
+[mysqld]
+character_set_server = utf8mb4
+```
+Without 4-Byte character support, an error will appear when attempting to save the Job definition that has a Status Symbol selected:<br>
+`Hibernate operation: could not execute statement; SQL [n/a]; (conn=74878) Incorrect string value: '\xE2\x9C\x85"`
+:::
 
 **Context Variable**: The name of a context-variable that can be referenced in subsequent steps.  For example, if `http_status` placed here, then the text plus emoticon will be referencable as `${data.http_status}` in subsequent job steps.
 
@@ -63,7 +75,7 @@ The Progress Badge is used to simplify the output of the HTTP diagnostics.
 6. Select the green check-mark emoticon for the **Status Symbol**.
 7. Insert the following into the **Context Variable** field  **`simplified-response`**:
 <p align="center">
-<img style='border:1px solid #327af6' width="500" src="@assets/img/completed-progress-badge.png" />
+<img width="500" src="@assets/img/completed-progress-badge.png" />
 </p>
 8. Add _another_ **Progress Badge** Log Filter to the same step.
 9. Insert the following into the **Regex** field: **`HTTP/.*(400|404|500|504|301).*`**
@@ -71,15 +83,15 @@ The Progress Badge is used to simplify the output of the HTTP diagnostics.
 11. Select the red **X** emoticon for the **Status Symbol**.
 12. Insert the following into the **Context Variable** field: **`simplified-response`**.
 <p align="center">
-<img style='border:1px solid #327af6' width="500" src="@assets/img/progress-badge-unhealthy.png" />
+<img width="500" src="@assets/img/progress-badge-unhealthy.png" />
 </p>
 
 Now, when a URL returns a **`200`**, the simplified message will be displayed alongside the verbose HTTP response:
-<img style='border:1px solid #327af6' src="@assets/img/progress-badge-output.png" />
+![PG Output](@assets/img/progress-badge-output.png)
 
 This simplified output can then be sent to other tools, such as PagerDuty Incident Response.
 First, add the **PagerDuty / Incident / Note** job step:
-<img style='border:1px solid #327af6' src="@assets/img/progress-badge-pd-step.png" />
+![PagerDuty Step](@assets/img/progress-badge-pd-step.png)
 <br><br>
 Then, when the job is invoked, the **Text** plus **Status Symbol** will appear on the Incident Timeline:
-<img style='border:1px solid #327af6' src="@assets/img/progress-badge-pd-timeline.png" />
+![PD Timeline](@assets/img/progress-badge-pd-timeline.png)


### PR DESCRIPTION
Added this note to the Progress Badge page so that if users are running older versions of MySQL, they know how to enable utf8mb4:

![Screen Shot 2022-10-07 at 9 51 47 AM](https://user-images.githubusercontent.com/11511251/194607458-d82ba18d-194c-4b8a-b43e-82ee75185094.png)
