### PR TITLE
RSE-209: Use tabs to follow steps easier on ssl config between OSs

### DIFF
--- a/docs/administration/security/ssl.md
+++ b/docs/administration/security/ssl.md
@@ -215,7 +215,7 @@ vi /etc/rundeck/rundeck-config.properties
 ::::
 
 
-Change the following properties to include the appropriate https protocol, hostname and port. _(The port value can also be extractedf rom `-Dserver.https.port` runtime configuration property)_
+Change the following properties to include the appropriate https protocol, hostname and port. _(The port value can also be extracted from `-Dserver.https.port` runtime configuration property)_
 ```properties
 grails.serverURL=https://localhost:4443
 ```

--- a/docs/administration/security/ssl.md
+++ b/docs/administration/security/ssl.md
@@ -8,7 +8,12 @@ A better practice is having this layer at a proxy/load balancer service.
 
 This document describes how to configure Rundeck for SSL/HTTPS support, and assumes it is running from the `rundeck-launcher` standalone launcher. 
 
-(1) Before beginning, do a first-run of the launcher, as it will create the base directory for Rundeck and generate configuration files. (This is not necessary for RPM/DEB installations)
+(1) Before beginning:
+
+:::: tabs
+::: tab WAR
+
+Do a first-run of the launcher, as it will create the base directory for Rundeck and generate configuration files. _(This is not necessary for RPM/DEB installations)_
 
 ```properties
 cd $RDECK_BASE;  java -jar {{{rundeckVersion}}}.war
@@ -20,15 +25,59 @@ This will start the server and generate necessary config files. Press Ctrl-C to 
 Grails application running at http://localhost:4440 in environment: production
 ```
 
+:::
+
+::: tab DEB
+
+Just have rundeck installed: 
+
+[Rundeck Installation Guide](/administration/install/installing-rundeck.html#installation)
+
+Stop the service if running:
+```bash
+systemctl stop rundeckd
+```
+
+:::
+
+::: tab RPM
+
+Just have rundeck installed: 
+
+[Installing on CentOS or Red Hat Linux distributions](/administration/install/linux-rpm.html#installing-rundeck)
+
+Stop the service if running:
+```bash
+service rundeckd stop
+```
+
+:::
+::::
+
+
 (2) Using the [keytool] command, generate a keystore for use as the server cert and client truststore. Specify passwords for key and keystore:
 
 [keytool]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/keytool.html
 
 Make sure to use the correct `$HOSTNAME` value both here and in response to the prompts below.
 
+:::: tabs
+::: tab WAR
+
 ```shell
-keytool -keystore etc/keystore -ext san=dns:$HOSTNAME -alias rundeck -genkey -keyalg RSA -keypass adminadmin -storepass adminadmin
+keytool -keystore $RDECK_BASE/etc/keystore -ext san=dns:$HOSTNAME -alias rundeck -genkey -keyalg RSA -keypass adminadmin -storepass adminadmin
 ```
+
+:::
+
+::: tab RPM/DEB
+
+```shell
+keytool -keystore /etc/rundeck/ssl/keystore -ext san=dns:$HOSTNAME -alias rundeck -genkey -keyalg RSA -keypass adminadmin -storepass adminadmin
+```
+
+:::
+::::
 
 :::tip 
 Modern SSL clients no longer use the "CN" value of a certificate to validate the hostname, and require that the hostname be included in the SubjectAlternativeName field. The flag `-ext san=dns:$HOSTNAME` includes a "SubjectAlternativeName" when generating the certificate. Newer clients may fail with an error about validating the hostname if this is empty or does not contain a matching value. The flag value can include multiple entries such as `-ext san=dns:x.tld,dns:y.tld`.
@@ -62,15 +111,47 @@ For RPM/DEB installations, see the configuration layout for better understanding
 (3) CLI tools that communicate to the Rundeck server need to trust the SSL certificate provided by the server. They are preconfigured to look for a truststore at the location:
 `$RDECK_BASE/etc/truststore`. Copy the keystore as the truststore for CLI tools:
 
+:::: tabs
+::: tab WAR
+
 ```shell
-cp etc/keystore etc/truststore
+cp $RDECK_BASE/etc/keystore $RDECK_BASE/etc/truststore
 ```
+
+:::
+
+::: tab RPM/DEB
+
+```shell
+cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
+```
+
+:::
+::::
+
+
+
 
 (4) Modify the ssl.properties file to specify the full path location of the keystore and the appropriate passwords:
 
+:::: tabs
+::: tab WAR
+
 ```shell
-vi server/config/ssl.properties
+vi $RDECK_BASE/server/config/ssl.properties
 ```
+
+:::
+
+::: tab RPM/DEB
+
+```shell
+vi /etc/rundeck/ssl/ssl.properties
+```
+
+:::
+::::
+
 
 An example ssl.properties file (from the RPM and DEB packages).
 
@@ -84,32 +165,95 @@ truststore.password=adminadmin
 
 The ssl.properties default keystore and truststore location path for war installation is \$RDECK_BASE/etc/
 
-(5) Configure client properties. Modify the file
-`$RDECK_BASE/etc/framework.properties` and change these properties:
+(5) Configure client properties. Modify the file:
 
-* framework.server.url
-* framework.rundeck.url
-* framework.server.port
+:::: tabs
+::: tab WAR
 
-
-Set them to the appropriate https protocol, and change the port to 4443, or to the value from `-Dserver.https.port` runtime configuration property.
-
-(6) Configure server URL so that Rundeck knows its external address. Modify the file `$RDECK_BASE/server/config/rundeck-config.properties` and change the `grails.serverURL`:
-
-```properties
-grails.serverURL=https://myhostname:4443
+```shell
+vi $RDECK_BASE/etc/framework.properties
 ```
 
-Set the URL to include the appropriate https protocol, and change the port to 4443, or to the value from `-Dserver.https.port` runtime configuration property.
+:::
 
-(7) For Debian installation, create/edit `/etc/default/rundeckd`, for RPM installation, create/edit `/etc/sysconfig/rundeckd`:
+::: tab RPM/DEB
+
+```shell
+vi /etc/rundeck/ssl/framework.properties
+```
+
+:::
+::::
+
+
+Set them to the appropriate https protocol, ip,and change the port to 4443, or to the value from `-Dserver.https.port` runtime configuration property.
+```properties
+framework.server.url=https://localhost:4443
+framework.server.port=4443
+```
+
+
+(6) Configure server URL so that Rundeck knows its external address. 
+
+:::: tabs
+::: tab WAR
+Modify the file 
+```shell
+vi $RDECK_BASE/server/config/rundeck-config.properties
+```
+
+:::
+
+::: tab RPM/DEB
+
+Modify the file 
+```shell
+vi /etc/rundeck/rundeck-config.properties
+```
+
+:::
+::::
+
+
+Change the following properties to include the appropriate https protocol, hostname and port. _(The port value can also be extractedf rom `-Dserver.https.port` runtime configuration property)_
+```properties
+grails.serverURL=https://localhost:4443
+```
+
+
+(7) For WAR installations skip this step
+
+:::: tabs
+::: tab WAR
+
+Create/edit `/etc/default/rundeckd`:
 
 ```properties
 RUNDECK_WITH_SSL=true
 RDECK_HTTPS_PORT=1234
 ```
 
-(8) Start the server. For the rundeck launcher, tell it where to read the ssl.properties
+:::
+
+::: tab RPM/DEB
+
+Create/edit `/etc/sysconfig/rundeckd`:
+
+```properties
+RUNDECK_WITH_SSL=true
+RDECK_HTTPS_PORT=1234
+```
+
+:::
+::::
+
+
+(8) Start the server.
+
+:::: tabs
+::: tab WAR
+
+Tell the launcher where to read the ssl.properties
 
 ```shell
 java -Drundeck.ssl.config=$RDECK_BASE/server/config/ssl.properties -jar rundeck-{{{rundeckVersionFull}}}.war
@@ -126,6 +270,22 @@ If successful, there will be a line indicating the SSl connector has started:
 ```log
 Grails application running at https://localhost:1234 in environment: production
 ```
+
+:::
+
+::: tab RPM/DEB
+
+```shell
+service rundeckd start
+```
+
+:::
+::::
+
+:::warning
+Make sure the entering packets to the used port are not being filtered by any kind of firewall rule.
+:::
+
 
 ## Import Existing PFX Key to Keystore
 Use the following commands to extract the Certificate, key and the CA from the PFX, and convert everything to the Keystore format.  (Note: OpenSSL will need to be installed prior to starting)

--- a/docs/administration/security/ssl.md
+++ b/docs/administration/security/ssl.md
@@ -8,7 +8,7 @@ A better practice is having this layer at a proxy/load balancer service.
 
 This document describes how to configure Rundeck for SSL/HTTPS support, and assumes it is running from the `rundeck-launcher` standalone launcher. 
 
-(1) Before beginning:
+**1.** Before beginning:
 
 :::: tabs
 ::: tab WAR
@@ -55,7 +55,7 @@ service rundeckd stop
 ::::
 
 
-(2) Using the [keytool] command, generate a keystore for use as the server cert and client truststore. Specify passwords for key and keystore:
+**2.** Using the [keytool] command, generate a keystore for use as the server cert and client truststore. Specify passwords for key and keystore:
 
 [keytool]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/keytool.html
 
@@ -108,7 +108,7 @@ For RPM/DEB installations, see the configuration layout for better understanding
 [Rundeck Configuration - Configuration File Reference - Configuration Layout](/administration/configuration/config-file-reference.md#configuration-layout)
 :::
 
-(3) CLI tools that communicate to the Rundeck server need to trust the SSL certificate provided by the server. They are preconfigured to look for a truststore at the location:
+**3.** CLI tools that communicate to the Rundeck server need to trust the SSL certificate provided by the server. They are preconfigured to look for a truststore at the location:
 `$RDECK_BASE/etc/truststore`. Copy the keystore as the truststore for CLI tools:
 
 :::: tabs
@@ -132,7 +132,7 @@ cp /etc/rundeck/ssl/keystore /etc/rundeck/ssl/truststore
 
 
 
-(4) Modify the ssl.properties file to specify the full path location of the keystore and the appropriate passwords:
+**4.** Modify the ssl.properties file to specify the full path location of the keystore and the appropriate passwords:
 
 :::: tabs
 ::: tab WAR
@@ -165,7 +165,7 @@ truststore.password=adminadmin
 
 The ssl.properties default keystore and truststore location path for war installation is \$RDECK_BASE/etc/
 
-(5) Configure client properties. Modify the file:
+**5.** Configure client properties. Modify the file:
 
 :::: tabs
 ::: tab WAR
@@ -193,7 +193,7 @@ framework.server.port=4443
 ```
 
 
-(6) Configure server URL so that Rundeck knows its external address. 
+**6.** Configure server URL so that Rundeck knows its external address. 
 
 :::: tabs
 ::: tab WAR
@@ -221,34 +221,34 @@ grails.serverURL=https://localhost:4443
 ```
 
 
-(7) For WAR installations skip this step
+**7.** _For WAR installations skip this step_
 
 :::: tabs
-::: tab WAR
+::: tab DEB
 
 Create/edit `/etc/default/rundeckd`:
 
 ```properties
-RUNDECK_WITH_SSL=true
-RDECK_HTTPS_PORT=1234
+export RUNDECK_WITH_SSL=true
+export RDECK_HTTPS_PORT=1234
 ```
 
 :::
 
-::: tab RPM/DEB
+::: tab RPM
 
 Create/edit `/etc/sysconfig/rundeckd`:
 
 ```properties
-RUNDECK_WITH_SSL=true
-RDECK_HTTPS_PORT=1234
+export RUNDECK_WITH_SSL=true
+export RDECK_HTTPS_PORT=1234
 ```
 
 :::
 ::::
 
 
-(8) Start the server.
+**8.** Start the server.
 
 :::: tabs
 ::: tab WAR
@@ -353,11 +353,11 @@ Some common error messages and causes:
 ```log
 java.io.IOException: Keystore was tampered with, or password was incorrect
 ```
-
 : A password specified in the file was incorrect.
 
+```log
 2010-12-02 10:07:29.958::WARN: failed SslSocketConnector@0.0.0.0:4443: java.io.FileNotFoundException: /Users/greg/rundeck/etc/keystore (No such file or directory)
-
+```
 : The keystore/truststore file specified in ssl.properties doesn't exist
 
 ### Optional PEM export


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-209
(Extended changes in: https://github.com/rundeck/docs/pull/1106)

Used tabs to follow guide easier along different OSs:
 ![image](https://user-images.githubusercontent.com/49494423/198150666-81807d47-6ecb-409b-96d5-8e1c7678da86.png)
