### PR TITLE
Add tip ilegal characters on URL 

### DIFF
--- a/docs/manual/node-steps/builtin.md
+++ b/docs/manual/node-steps/builtin.md
@@ -150,6 +150,10 @@ Performs an HTTP Request with or without authentication (per node)
 Remote URL
 : The URL to which to make the request.
 
+:::tip
+All unsafe characters must always be encoded within a URL. For more information on unsafe characters see [IETF | Internet Engineering Task Force](https://www.ietf.org/rfc/rfc1738.txt)
+:::
+
 HTTP Method
 : The method that you want to be performed on the URL
 

--- a/docs/manual/node-steps/builtin.md
+++ b/docs/manual/node-steps/builtin.md
@@ -151,6 +151,7 @@ Remote URL
 : The URL to which to make the request.
 
 :::tip
+This plugin doesn't support unsafe characters. If you get this error message: `Illegal character in scheme name at index` means that you're using an unsafe character.
 All unsafe characters must always be encoded within a URL. For more information on unsafe characters see [IETF | Internet Engineering Task Force](https://www.ietf.org/rfc/rfc1738.txt)
 :::
 


### PR DESCRIPTION
Problem: As seen on https://pagerduty.atlassian.net/browse/RSE-189,  a client could try to make an HTTP request with illegal characters, this action will throw an exception that rundeck control. 

Solution: Clarify that the URL can not have illegal characters.

How will look:

<img width="1108" alt="imagen" src="https://user-images.githubusercontent.com/87494173/201934011-f85e34b8-ce9b-418e-a346-870a841b48ff.png">
