### PR TITLE
Fix: broken link to password authentication on page upgrading-to-4.8

### DIFF
--- a/docs/upgrading/upgrading-to-4.8.md
+++ b/docs/upgrading/upgrading-to-4.8.md
@@ -4,7 +4,7 @@ To enhance the Security of Rundeck and Process Automation in version 4.8 we adde
 
 ## Usage Scenario
 
-Using Password Authentication against the API as described [in the documentation here](/docs/api/rundeck-api.html#password-authentication).
+Using Password Authentication against the API as described [in the documentation here](/api/rundeck-api.html#password-authentication).
 
 ## Changes required
 


### PR DESCRIPTION
Problem: Broken URL to redirect to API password authentication.

Solution: Fix URL to go to /api/rundeck-api.html#password-authentication 

