### PR TITLE
RSE-275 Fix: Missing AWS page on docs

### DIFF
--- a/docs/.vuepress/sidebar-menus/administration.js
+++ b/docs/.vuepress/sidebar-menus/administration.js
@@ -19,6 +19,7 @@ module.exports = [{
                   '/administration/install/linux-deb',
                   '/administration/install/linux-rpm',
                   '/administration/install/tomcat',
+                  '/administration/install/aws',
                   '/administration/install/windows',
                   '/administration/install/source',
                   '/administration/install/docker'

--- a/docs/administration/install/aws.md
+++ b/docs/administration/install/aws.md
@@ -1,4 +1,4 @@
-# AWS
+# Installing on AWS
 
 <!---
 


### PR DESCRIPTION
Problem: This page https://docs.rundeck.com/docs/administration/install/aws.html was unreachable from the sidebar on docs and also on the searcher.

Solution: Add the page to the sidebar module to make it reachable in both cases. 

How will look after fix:

**Sidebar** 

<img width="340" alt="imagen" src="https://user-images.githubusercontent.com/87494173/207439367-e6144958-2052-4a33-b23f-794857e82808.png">

**Searcher**  

<img width="381" alt="imagen" src="https://user-images.githubusercontent.com/87494173/207440189-af8cce4a-1f4b-4b7f-aa13-360f014fd1ba.png">



