### PR TITLE
RSE-255 Fix: Problems with LDAP integration with a huge number of groups

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -429,6 +429,10 @@ The [PAM](#pam) section is a useful comparison as it uses the same method to com
 
 ### Active Directory
 
+:::tip
+The maximum quantity of results that Rundeck is able to retrieve from Active Directory is limited to the value specified for the MaxPageSize parameter within the Active Directory configuration.
+:::
+
 Here is an example configuration for Active Directory. The string _sAMAccountName_ refers to the short user name and is valid in a default Active Directory installation, but may vary in some environments.
 
 ```c .numberLines


### PR DESCRIPTION
Problem: So far Rundeck does not support pagination on Active Directory-LDAP authentication and the maximum amount of results that Rundeck is able to get from AD is specified on the Active Directory side on MaxPageSize. 

Solution: Add a tip on documentation to prevent clients from exceeding the maximum results specified on their Active Directory 

More info: https://pagerduty.atlassian.net/browse/RSE-255

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/87494173/214292560-9e862544-8de5-4f22-93ad-0db581513204.png">
