### PR TITLE
Improve documentation about remote options and remote cascade options

### DIFF
--- a/docs/manual/job-options.md
+++ b/docs/manual/job-options.md
@@ -476,7 +476,7 @@ Option model providers are configured on a per-Option basis (where a Job may hav
    - OR, an array of Maps, each with two entries, `name` and `value`.
 4. By default, the HTTP(S) response must include the `application/json` content type in the header.
    In case this cannot be controlled, the attribute `project.jobs.disableRemoteOptionJsonCheck` can be set to `true` in the project settings.
-5. On HTTP(S) unsafe characters should be avoided within a URL, they may cause errors since characters will be inconsistent after being encoded.   
+5. On HTTP(S) unsafe characters as `blank/empty space, ", <, >, %, {, }, |, \, ^, ´` should be avoided or encoded within a URL, keep in mind that if encoded the name on the server side should be the same. For more information on unsafe characters see [IETF | Internet Engineering Task Force](https://www.ietf.org/rfc/rfc1738.txt)    
 
 ### Configuration
 
@@ -590,9 +590,9 @@ remote values URL. The property reference is of the form
 like "http://server/options?option2=${option.option2.value}", then that option
 will depend on the value of the "option2" option.
 
-If the `“option2”` value have a unsafe character as `“My value”` the unsafe character 
+If the `“option2”` value has an unsafe character as `“My value”` the unsafe character 
 will be encoded to `"My%20value"` and the URL will be "http://server/options?My%20value",
-the po JSON must be stored as `“My%20value”` on the server side or the request will return a 404 error.
+the pointed JSON must be stored as `“My%20value”` on the server side or the request will return a 404 error.
 
 In the GUI, when the options are loaded, option2 will be shown first, and the
 remote values for option1 will only be loaded once a value has been selected for

--- a/docs/manual/job-options.md
+++ b/docs/manual/job-options.md
@@ -476,6 +476,7 @@ Option model providers are configured on a per-Option basis (where a Job may hav
    - OR, an array of Maps, each with two entries, `name` and `value`.
 4. By default, the HTTP(S) response must include the `application/json` content type in the header.
    In case this cannot be controlled, the attribute `project.jobs.disableRemoteOptionJsonCheck` can be set to `true` in the project settings.
+5. On HTTP(S) unsafe characters should be avoided within a URL, they may cause errors since characters will be inconsistent after being encoded.   
 
 ### Configuration
 
@@ -588,6 +589,10 @@ remote values URL. The property reference is of the form
 `${option.[name].value}`. If you declare an option with a remote values URL
 like "http://server/options?option2=${option.option2.value}", then that option
 will depend on the value of the "option2" option.
+
+If the `“option2”` value have a unsafe character as `“My value”` the unsafe character 
+will be encoded to `"My%20value"` and the URL will be "http://server/options?My%20value",
+the po JSON must be stored as `“My%20value”` on the server side or the request will return a 404 error.
 
 In the GUI, when the options are loaded, option2 will be shown first, and the
 remote values for option1 will only be loaded once a value has been selected for


### PR DESCRIPTION
Related to: https://pagerduty.atlassian.net/browse/RSE-293

Problem: Documentation about remote options and remote cascade options was missing important information about unsafe characters on URLs, this misinformation could cause an error since unsafe characters will be encoded and if the name is not the same on the server side including the encoded, will throw an error.

Solution: Add the missing information on the options requirements and also an example within the remote cascade options.

How will look:

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/87494173/216459886-5ecdf941-e73b-4245-b721-84d06530e184.png">

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/87494173/216459842-07ee6df8-f10c-4561-b51d-3451eb14b7a7.png">
