### PR TITLE
Warning to avoid erratic behavior

### DIFF
--- a/docs/manual/projects/scm/git.md
+++ b/docs/manual/projects/scm/git.md
@@ -39,6 +39,10 @@ Many SCM systems provide a "clone" url for http[s] in the form: `http[s]://host.
 Many SCM systems provide a "clone" url for ssh in the form: `git@host.xz:path/to/repo.git`, to make use of this in the default git plugin it is necessary to prepend `ssh://` and replace the `:` with a `/` in the url: `ssh://git@host.xz/path/to/repo.git`
 :::
 
+:::warning
+The plugin will try to resolve the origin based on the URL that is provided to it. So if the user provides an invalid URL, it can cause Rundeck to behave erratically (same behavior as in a server command shell). Please make sure to supply a URL that plausibly resolves to the *.git file.
+:::
+
 **Fetch automatically** automatize the fetch command to be called in background.
 
 ### Job Source Files Configuration


### PR DESCRIPTION
Related to this: https://pagerduty.atlassian.net/browse/RSE-294

The client was pointing to an invalid URL, this cause the Java Thread to hangs up, Rundeck it's not possible to perform basic activities then without awaiting for the timeout to show up.