### PR TITLE
cleanup v42 feature API docs

### DIFF
--- a/docs/api/api-index-links.md
+++ b/docs/api/api-index-links.md
@@ -45,6 +45,9 @@
 
 [/api/V/executions/metrics]:/api/rundeck-api.html#execution-query-metrics
 
+[/api/V/feature/]:/api/rundeck-api.html#get-all-system-feature-status
+[/api/V/feature/\[FEATURE\]]:/api/rundeck-api.html#get-a-system-feature-status
+
 [/api/V/job/\[ID\]]:/api/rundeck-api.html#getting-a-job-definition
 [DELETE /api/V/job/\[ID\]]:/api/rundeck-api.html#deleting-a-job-definition
 

--- a/docs/api/rundeck-api-versions.md
+++ b/docs/api/rundeck-api-versions.md
@@ -37,7 +37,8 @@ Changes introduced by API Version number:
 **Version 42**:
 
 * Endpoints promoted out of incubating status. These endpoints no longer contain `incubating/` in the endpoint URL, and now require API version 42 minimum.
-    * [`GET /api/42/feature/[featureName]`][/api/42/feature/\[featureName\]] - Query system feature status. 
+    * [`GET /api/42/feature/[FEATURE]`][/api/V/feature/\[FEATURE\]] - Query system feature status for a feature. 
+    * [`GET /api/42/feature/`][/api/V/feature/] - Get all system feature statuses. 
   
 
 **Version 41**:

--- a/docs/api/rundeck-api.md
+++ b/docs/api/rundeck-api.md
@@ -7869,9 +7869,9 @@ Return the information whether a specific system feature is enabled or not.
 
 **Request:**
 
-    GET /api/42/feature/[featureName]
+    GET /api/42/feature/[FEATURE]
 
-The `featureName` parameter should be the feature's configuration name without `rundeck.feature.` prefix and `.enabled` suffix. E.g. For configuration name `rundeck.feature.runner.enabled`, the value of `[featureName]` should be `runner`  
+The `FEATURE` parameter should be the feature's configuration name without `rundeck.feature.` prefix and `.enabled` suffix. E.g. For configuration name `rundeck.feature.runner.enabled`, the value of `[FEATURE]` should be `runner`  
 
 **Response:**
 
@@ -7975,8 +7975,12 @@ Content-Type: `application/json`
 
 * `GET` [Execution Query Metrics](#execution-query-metrics)
 
-[/api/V/feature/\[featureName\]][]
-* `GET` [System feature on/off status](#system-feature) 
+[/api/V/feature/\[FEATURE\]][]
+* `GET` [System feature on/off status][/api/V/feature/\[FEATURE\]]
+
+[/api/V/feature/][]
+* `GET` [All System feature on/off statuses][/api/V/feature/]
+
 
 [/api/V/job/\[ID\]][]
 


### PR DESCRIPTION
* use conventional uppercase for url parameters `[FEATURE]`
* add missing index links and link definitions
* add missing history link to all system features endpoint