### PR TITLE
RSE-377 Fix: Documentation for execution cleaning

### DIFF
--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -34,6 +34,11 @@ After the job runs a couple of times it is possible to see that the executions w
 Although the remote execution policy is reevaluated on every execution, it is **also** possible to make cluster members **reevaluate** the remote execution policy **only once** when the job is scheduled. This is possible by setting to **false** the following property:
 `rundeck.clusterMode.remoteScheduledExecutionPolicy.enabled`
 :::
+
+#### Execution Cleaning
+
+When a 
+
 #### Policy
 
 ```

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -37,7 +37,9 @@ Although the remote execution policy is reevaluated on every execution, it is **
 
 #### Execution Cleaning
 
-When a 
+For reasons external to the cluster, members may go offline or be interrupted; It is for this reason that the Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
+
+- **Stale Executions**: when a cluster member starts running a job, the job enters in 'Running' state, if during the execution, the cluster member goes offline and there are no cluster members that can perform the "Autotakeover" action, the Job execution will be cleaned up when the cluster scales back into replicas, leaving the job with the "Incomplete" status by default.
 
 #### Policy
 

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -37,7 +37,7 @@ Although the remote execution policy is reevaluated on every execution, it is **
 
 #### Execution Cleaning
 
-For reasons external to the cluster, members may go offline or be interrupted; For this reason the Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
+For reasons external to the cluster, members may go offline or be interrupted; For this reason Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
 
 - **Stale Executions**: when a cluster member starts running a job, the job enters in 'Running' state, if during the execution, the cluster member goes offline and there are no cluster members that can perform the "Autotakeover" action, the Job execution will be cleaned up when the cluster scales back into replicas, leaving the job with the "Incomplete" status by default.
 

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -37,7 +37,7 @@ Although the remote execution policy is reevaluated on every execution, it is **
 
 #### Execution Cleaning
 
-For reasons external to the cluster, members may go offline or be interrupted; It is for this reason that the Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
+For reasons external to the cluster, members may go offline or be interrupted; For this reason that the Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
 
 - **Stale Executions**: when a cluster member starts running a job, the job enters in 'Running' state, if during the execution, the cluster member goes offline and there are no cluster members that can perform the "Autotakeover" action, the Job execution will be cleaned up when the cluster scales back into replicas, leaving the job with the "Incomplete" status by default.
 

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -41,6 +41,8 @@ For reasons external to the cluster, members may go offline or be interrupted; I
 
 - **Stale Executions**: when a cluster member starts running a job, the job enters in 'Running' state, if during the execution, the cluster member goes offline and there are no cluster members that can perform the "Autotakeover" action, the Job execution will be cleaned up when the cluster scales back into replicas, leaving the job with the "Incomplete" status by default.
 
+- **Missed Executions**: When a node has scheduled job runs and gho offline before executing them, the rundeck cluster will create a "missed" run to warn that some of the jobs were not executed after the instance restart.
+
 #### Policy
 
 ```

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -37,7 +37,7 @@ Although the remote execution policy is reevaluated on every execution, it is **
 
 #### Execution Cleaning
 
-For reasons external to the cluster, members may go offline or be interrupted; For this reason that the Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
+For reasons external to the cluster, members may go offline or be interrupted; For this reason the Rundeck Cluster can automatically clean up the executions on certain occasions that we will describe below:
 
 - **Stale Executions**: when a cluster member starts running a job, the job enters in 'Running' state, if during the execution, the cluster member goes offline and there are no cluster members that can perform the "Autotakeover" action, the Job execution will be cleaned up when the cluster scales back into replicas, leaving the job with the "Incomplete" status by default.
 


### PR DESCRIPTION
# Documentation about the Cluster Execution's Cleaning
Currently searching info inside the code about other 'cleaning' milestones.