### PR TITLE
Fix minor typos under `docs/administration/` and `docs/learning/`

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -168,7 +168,7 @@ generated at project setup time. Each project has a directory within the Rundeck
 | --- | --- |
 | `project.name`                           | Declare the project name. |
 | `project.ssh-authentication`             | SSH authentication type (eg, privateKey). |
-| `project.ssh-keypath`                    | Loal SSH identify file. (Note: this is not a keystorage path but a local file system path.)|
+| `project.ssh-keypath`                    | Load SSH identify file. (Note: this is not a keystorage path but a local file system path.)|
 | `service.FileCopier.default.provider`    | Default script file copier plugin. |
 | `service.NodeExecutor.default.provider`  | Default node executor plugin. |
 | `resources.source.N...`                  | Defines a Resource model source see [Resource Model Sources](/manual/projects/resource-model-sources/). |
@@ -326,7 +326,7 @@ Some of the properties that work with live reloading:
 ### Security HTTP Headers
 
 :::warning
-The HTTP header 'XSS-Protection' has been deprecated by mordern browsers and it use can introduce additional security issues on the client side of the application. Rundeck has deprecated this setting as of version 4.3.0.
+The HTTP header 'XSS-Protection' has been deprecated by modern browsers and it use can introduce additional security issues on the client side of the application. Rundeck has deprecated this setting as of version 4.3.0.
 :::
 
 Rundeck adds some HTTP headers for XSS prevention and other security reasons, as described below.

--- a/docs/administration/configuration/database/secure_mssql.md
+++ b/docs/administration/configuration/database/secure_mssql.md
@@ -36,7 +36,7 @@ com.microsoft.sqlserver.jdbc.SQLServerException: Login failed. The login is from
 
 One solution is to use "localhost" in the jdbc connection
 
-3.- Different arquitecture error
+3.- Different architecture error
 
 ```log
 Configuring Spring Security Core ...

--- a/docs/administration/configuration/email-settings.md
+++ b/docs/administration/configuration/email-settings.md
@@ -88,7 +88,7 @@ In addition these properties are defined:
 
 #### Custom Attached Log Output file
 
-When the log output is attached as a file, the file's extension can be defined by adding new settings on rudeck-config.properties.
+When the log output is attached as a file, the file's extension can be defined by adding new settings on rundeck-config.properties.
 For example:
 
 ```properties

--- a/docs/administration/configuration/gui-customization.md
+++ b/docs/administration/configuration/gui-customization.md
@@ -100,7 +100,7 @@ To customize the link's name of the "Get help" button in Rundeck's GUI Support f
 ![Figure: The "Get Help link name changed for a custom value named in the property"](~@assets/img/gui-custom-helpLink-name.png)
 
 ### rundeck.gui.workflowGraph
-- Examble: ```false```
+- Example: ```false```
 - min version: 4.10
 
 Prevents the ruleset graph renderization.
@@ -141,7 +141,7 @@ Shows job information when the user hovers over a job name in various pages.
 - Example: ```(Default: blank)```
 - min version: 3.0.8
 
-HTML displayed on the login page below the login form element but seperate from the login form element. The HTML will be sanitized before display.
+HTML displayed on the login page below the login form element but separate from the login form element. The HTML will be sanitized before display.
 
 
 ### rundeck.gui.login.welcome

--- a/docs/administration/configuration/plugins/configuring.md
+++ b/docs/administration/configuration/plugins/configuring.md
@@ -372,7 +372,7 @@ The `db` implementation has no configuration properties.
 
 You can combine multiple Storage Plugins to operate over different branches of the Storage Tree, by defining multiple configurations and using the `path` to locate them within the tree. You could use this, for example, to store some Keys in the database, some on the local filesystem, and some in some other backend provider, such as Vault.
 
-You would defin multiple configurations using sequential index numbers, and apply them to specific `path` locations.
+You would define multiple configurations using sequential index numbers, and apply them to specific `path` locations.
 
 Example:
 

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -41,7 +41,7 @@ For reasons external to the cluster, members may go offline or be interrupted; F
 
 - **Stale Executions**: when a cluster member starts running a job, the job enters in 'Running' state, if during the execution, the cluster member goes offline and there are no cluster members that can perform the "Autotakeover" action, the Job execution will be cleaned up when the cluster scales back into replicas, leaving the job with the "Incomplete" status by default.
 
-- **Missed Executions**: When a node has scheduled job runs and gho offline before executing them, the rundeck cluster will create a "missed" run to warn that some of the jobs were not executed after the instance restart.
+- **Missed Executions**: When a node has scheduled job runs and go offline before executing them, the rundeck cluster will create a "missed" run to warn that some of the jobs were not executed after the instance restart.
 
 #### Policy
 
@@ -172,7 +172,7 @@ ratio and the percentage of CPU.
 rundeck.clusterMode.remoteExecution.config.criteria = threadRatio,load
 ```
 
-> **Note:** These are the only criterias available so far.
+> **Note:** These are the only criteria available so far.
 
 Each criteria can be weighted using a relative value:
 

--- a/docs/administration/configuration/repository.md
+++ b/docs/administration/configuration/repository.md
@@ -41,7 +41,7 @@ When you enable the Rundeck Repository the following default files and directori
 
 * `RDECK_BASE/server/config/artifact-repositories.yaml` - Repositories are configured in this file.
 * `RDECK_BASE/repository/artifacts` - The directory into which your private plugins will be copied when you use the `upload` command to build your private plugin repository.
-* `RDECK_BASE/repository/installedPlugins` - The directory into which plugins will be copied when you use install them either from the offical Rundeck repository or your private repository.
+* `RDECK_BASE/repository/installedPlugins` - The directory into which plugins will be copied when you use install them either from the official Rundeck repository or your private repository.
 
 Both the `artifacts` and `installedPlugins` locations are configurable using the storage tree mechanism.  
 

--- a/docs/administration/configuration/storage-facility.md
+++ b/docs/administration/configuration/storage-facility.md
@@ -62,7 +62,7 @@ It is highly recommended that you configure Rundeck to use a relational database
 
 For information on configuring Rundeck to use specific Databases, see:
 
-- [Administor Guide > Rundeck Configuration > Database](/administration/configuration/database/index.md)
+- [Administration Guide > Rundeck Configuration > Database](/administration/configuration/database/index.md)
 
 To develop your own storage plugin, see:
 

--- a/docs/administration/configuration/system-properties.md
+++ b/docs/administration/configuration/system-properties.md
@@ -48,7 +48,7 @@ You should _not_ modify the `/etc/rundeck/profile` file directly, as it may be o
 or any changes from the upgrade might not be applied.
 
 Instead, For RPM or DEB installations, you can use environment variables set in a "defaults" file to add
-additional Java Sytem Properties.
+additional Java System Properties.
 
 - RPM install: `/etc/sysconfig/rundeckd`
 - DEB install: `/etc/default/rundeckd`

--- a/docs/administration/install/system-requirements.md
+++ b/docs/administration/install/system-requirements.md
@@ -107,7 +107,7 @@ There are various ways for installing SSH on Windows; we recommend
 ### Database
 
 When you install the vanilla standalone rundeck configuration, it will use H2, an embedded database.
-It is convenient to have an embedded database when you are just trying Rundeck or using it for a non-critical purpose. Be aware though that using the H2 database is not considered safe for production because it not reslilient if Rundeck is not shutdown gracefully. When shutdown gracefully, Rundeck can write the data (kept in memory) to disk. If Rundeck is forcefully shutdown, the data can not be guaranteed to be written to file on disk and cause truncation and corruption.
+It is convenient to have an embedded database when you are just trying Rundeck or using it for a non-critical purpose. Be aware though that using the H2 database is not considered safe for production because it not resilient if Rundeck is not shutdown gracefully. When shutdown gracefully, Rundeck can write the data (kept in memory) to disk. If Rundeck is forcefully shutdown, the data can not be guaranteed to be written to file on disk and cause truncation and corruption.
 
 Don't use the H2 embedded database for anything except testing and non-production.
 

--- a/docs/administration/security/authorization.md
+++ b/docs/administration/security/authorization.md
@@ -296,11 +296,11 @@ Table: Application scope generic type actions
 | "             | "                  | `read`             | Read files and list directories in the storage facility |
 | "             | "                  | `delete`           | Delete files in the storage facility                    |
 | `apitoken`    | "username","roles" | `create`           | Create an API Token with specified roles or username    |
-| `runner`      | "username","roles" | `read`             | Read Runner setup/configuration deatils                 |
+| `runner`      | "username","roles" | `read`             | Read Runner setup/configuration details                 |
 | "             | "                  | `create`           | Create new Runner entries                               |
 | "             | "                  | `update`           | Update existing Runner entries                          |
 | "             | "                  | `delete`           | Delete Runner entries                                   |
-| "             | "                  | `ping`             | Execute the ping command to check Runner statu          |
+| "             | "                  | `ping`             | Execute the ping command to check Runner status         |
 | "             | "                  | `regenerate_credentials`| Regenerate a new credential package for a Runner   |
 
 

--- a/docs/administration/security/ratelimiting.md
+++ b/docs/administration/security/ratelimiting.md
@@ -28,7 +28,7 @@ rundeck.authRateLimiting.refillWindowInSeconds=60
 > Note: There is currently no way to clear a failed attempt lockout besides waiting for refill window to expire without any further failed attempts.
 
 
-## API Endpionts Rate Limiting (Enterprise)
+## API Endpoints Rate Limiting (Enterprise)
 
 :::enterprise
 :::

--- a/docs/administration/security/ssl.md
+++ b/docs/administration/security/ssl.md
@@ -265,7 +265,7 @@ You can change port by adding `-Dserver.https.port`:
 java -Drundeck.ssl.config=$RDECK_BASE/server/config/ssl.properties -Dserver.https.port=1234 -jar rundeck-{{{rundeckVersionFull}}}.war
 ```
 
-If successful, there will be a line indicating the SSl connector has started:
+If successful, there will be a line indicating the SSL connector has started:
 
 ```log
 Grails application running at https://localhost:1234 in environment: production
@@ -420,7 +420,7 @@ Use -Dserver.ssl.ciphers to enable the Ciphers
 ```
 
 #### For .RPM and .DEB Systems
-Edit /etc/sysconfig/rundeckd (for .RMP) or /etc/default/rundeckd (for .DEB) and add the flags
+Edit /etc/sysconfig/rundeckd (for .RPM) or /etc/default/rundeckd (for .DEB) and add the flags
 
 ```properties
 RDECK_JVM_OPTS="-Dserver.ssl.enabledProtocols=YourProtocols -Dserver.ssl.ciphers=YourCiphers`
@@ -492,7 +492,7 @@ E.g.:
 grails.serverURL=https://192.168.0.27:8443/rundeckpro
 ```
 
-#### Configure framework.propeties file with port and https protocol
+#### Configure framework.properties file with port and https protocol
 E.g.:
 ```properties
 framework.server.port = 8443

--- a/docs/administration/security/sso/azure-sso.md
+++ b/docs/administration/security/sso/azure-sso.md
@@ -51,7 +51,7 @@ Next, add the required permissions in Azure.
 
 ### Azure - Create the Application Secret
 
-Next, create an application secret (ID & passsword) that will be used in the Rundeck configuration.  Note, if you lose the secret value/password, you can delete the existing secret and create a new one.
+Next, create an application secret (ID & password) that will be used in the Rundeck configuration.  Note, if you lose the secret value/password, you can delete the existing secret and create a new one.
 
 ![](~@assets/img/sso-azure-05-secret1.jpg)
 

--- a/docs/administration/security/sso/okta.md
+++ b/docs/administration/security/sso/okta.md
@@ -3,7 +3,7 @@
 :::enterprise
 :::
 
-Process Automation can be configured to work with the Okta security platfom.
+Process Automation can be configured to work with the Okta security platform.
 
 To configure the Okta SSO plugin for Rundeck add a new application to your Okta Applications and then configure Rundeck to authenticate using Okta.
 

--- a/docs/learning/getting-started/jobs/creating-a-job.md
+++ b/docs/learning/getting-started/jobs/creating-a-job.md
@@ -100,4 +100,4 @@ Notifications are messages, such as an email or HTTP service push. This is a com
 }
 ```
 ### The Welcome Project
-A good place to learn and practice Rundeck concepts is the Welcome Project, you can check it outout many related concepts [here](https://docs.rundeck.com/docs/learning/howto/welcome-project-starter.html).<br>
+A good place to learn and practice Rundeck concepts is the Welcome Project, you can check it out many related concepts [here](https://docs.rundeck.com/docs/learning/howto/welcome-project-starter.html).<br>

--- a/docs/learning/getting-started/jobs/pieces-of-a-job.md
+++ b/docs/learning/getting-started/jobs/pieces-of-a-job.md
@@ -115,7 +115,7 @@ The Limit Multiple Executions is the maximum number of multiple executions. Use 
 #### Job timeout
 Indicates the maximum runtime allowed for a job. After this time expires, the job will be aborted.<br>
 
-#### Jon Retry
+#### Job Retry
 Count indicates the maximum number of times to retry the job if it fails or times out. You can also set a delay between retries.<br>
 
 #### Retry Delay

--- a/docs/learning/howto/how2kube.md
+++ b/docs/learning/howto/how2kube.md
@@ -26,7 +26,7 @@ Rundeck uses the [Kubernetes workflow step plugin](https://github.com/rundeck-pl
 1. Kubectl to interact with minikube<br>
  Kubectl is a command-line tool for interacting with minikube. Click [here](https://kubernetes.io/docs/tasks/tools/#kubectl) to learn how to install Kubectl<br>
 1. K9s for cluster monitoring (optional)<br>
- K9s is a tool focused on monitoring and interacting with the cluster.  Click [here](https://k9scli.io/topics/install/) to learn how to installk9.<br>
+ K9s is a tool focused on monitoring and interacting with the cluster. Click [here](https://k9scli.io/topics/install/) to learn how to install K9s<br>
 1. Rundeck<br>
 
 ## Kubernetes Rundeck Plugin Prerequisites

--- a/docs/learning/howto/log4shell.md
+++ b/docs/learning/howto/log4shell.md
@@ -108,7 +108,7 @@ To add the job definitions to a project of your own follow these steps:
 
 ## Setting up a Health Check
 
-Health Checks (availble in Process Automation) will run commands periodically to determine the health of a system.  We can apply this to the Log4Shell situation and add a Health Check to see if a machine needs to be patched.
+Health Checks (available in Process Automation) will run commands periodically to determine the health of a system.  We can apply this to the Log4Shell situation and add a Health Check to see if a machine needs to be patched.
 
 ### Setup Steps
 

--- a/docs/learning/solutions/auto-incident-kubernetes-logs.md
+++ b/docs/learning/solutions/auto-incident-kubernetes-logs.md
@@ -80,7 +80,7 @@ Optionally use the PagerDuty API Token generated earlier for the Rundeck Job, or
 6. In PagerDuty, navigate to **Automation -> Rundeck Actions -> Add Action**:
 <br><br>![Add Action](@assets/img/solutions-pd-diag-k8s-add-action.png)<br><br>
 7. Fill in the Automation Action details with the desired Name and Description. Select **rundeck** as the type of action and **Diagnostic** as the category.  
-Paste the jod ID into the **Job ID** field and insert `-pd_incident_id ${pagerduty.incidentId}` into the **Rundeck arguments** field:
+Paste the job ID into the **Job ID** field and insert `-pd_incident_id ${pagerduty.incidentId}` into the **Rundeck arguments** field:
 <br><br>![Action Details](@assets/img/solutions-pd-diag-k8s-pd-action.png)<br><br>
 8. Select the Runner that you installed from **Step 3** and then select the same Kubernetes service associated with the Kubernetes Selector from **Step 6** of configuring the Rundeck Job.  
 :::


### PR DESCRIPTION
This pull request fixes some minor typos under `docs/administration/` and `docs/learning/` directories using `aspell`.

Please don't hesitate to ask for changes if there is any convention to follow or if you have any questions, and feel free to ignore this PR if it isn't relevant.

Thanks for you time,