### PR TITLE
Notes.js and Template changes for Runner Info

### DIFF
--- a/docs/.vuepress/notes.js
+++ b/docs/.vuepress/notes.js
@@ -22,7 +22,8 @@ async function main() {
     context.enterprise = await getRepoData({repo: 'rundeckpro', owner: 'rundeckpro'}, ['release-notes/include'])
     context.docs = await getRepoData({repo: 'docs', owner: 'rundeck'}, [])
     context.ansible = await getRepoData({repo: 'ansible-plugin', owner: 'rundeck-plugins'}, [])
-    context.contributors = {...context.core.contributors, ...context.enterprise.contributors, ...context.docs.contributors, ...context.ansible.contributors}
+    context.runner = await getRepoData({repo: 'sidecar', owner: 'rundeckpro'}, ['release-notes/include'])
+    context.contributors = {...context.core.contributors, ...context.docs.contributors, ...context.ansible.contributors}
     //context.reporters = {...context.core.reporters, ...context.enterprise.reporters}
 
     // FS.writeFileSync('notes.json', JSON.stringify(context))
@@ -96,11 +97,24 @@ async function getRepoData(repo, includeLabels, excludeTags) {
         reporters[user.data.login] = user.data
     }
 
+    const releasesResponse = await gh.repos.listReleases({
+        ...repo
+      });
+  
+      const releases = releasesResponse.data;
+    // console.log(`Total releases: ${releases.length}`);
+    // console.log("Release List:");
+  
+    //   releases.forEach((release) => {
+    //     console.log(`- ${release.tag_name}`);
+    //   })
+
     return {
         contributors,
         reporters,
         pulls,
-        issues
+        issues,
+        releases
     }
   }
 }

--- a/docs/.vuepress/notes.js
+++ b/docs/.vuepress/notes.js
@@ -1,5 +1,6 @@
 const FS = require('fs')
 const Path = require('path')
+const { Buffer } = require("buffer")
 
 const nunjucks = require('nunjucks')
 
@@ -23,6 +24,7 @@ async function main() {
     context.docs = await getRepoData({repo: 'docs', owner: 'rundeck'}, [])
     context.ansible = await getRepoData({repo: 'ansible-plugin', owner: 'rundeck-plugins'}, [])
     context.runner = await getRepoData({repo: 'sidecar', owner: 'rundeckpro'}, ['release-notes/include'])
+    context.sidecarVersion = await getSideCarVersion({repo: 'rundeckpro', owner: 'rundeckpro'})
     context.contributors = {...context.core.contributors, ...context.docs.contributors, ...context.ansible.contributors}
     //context.reporters = {...context.core.reporters, ...context.enterprise.reporters}
 
@@ -48,6 +50,45 @@ async function main() {
     }
 
     FS.writeFileSync(path, notes)
+}
+
+async function getSideCarVersion(repo) {
+    const gh = new Octokit({auth: argv.token || process.env.GH_API_TOKEN})
+
+    const milestones = await gh.issues.listMilestones({...repo})
+
+    const milestone = milestones.data.filter(m => m.title == argv.milestone)[0]
+
+    if (!milestone) {
+        console.error(`GitHub milestone ${argv.milestone} not found!`)
+        //process.exit(1)
+    } else {
+        try {
+            const proRunnerVersion = await gh.repos.getContent({
+                ...repo,
+                path: "gradle.properties",
+                ref: `v${milestone}`
+            })
+            const runnerVersion = proRunnerVersion.data;
+            //console.log(runnerVersion);
+            const content = Buffer.from(runnerVersion.content, "base64").toString();
+            //console.log(`Content:\n${content}\n`);
+            const sidecarVersionLine = content.match(/^sidecarVersion=(.*)/m);
+            if (sidecarVersionLine) {
+                version = sidecarVersionLine[1].trim();
+                console.log(`Sidecar Version: ${version}`);
+            }
+            return {
+                version
+            }
+        } catch (error) {
+            console.error("Sidecar Version Not Found")
+            version = "Version Not Found check for release tag"
+            return {
+                version
+            }
+        }
+    }
 }
 
 async function getRepoData(repo, includeLabels, excludeTags) {
@@ -97,24 +138,11 @@ async function getRepoData(repo, includeLabels, excludeTags) {
         reporters[user.data.login] = user.data
     }
 
-    const releasesResponse = await gh.repos.listReleases({
-        ...repo
-      });
-  
-      const releases = releasesResponse.data;
-    // console.log(`Total releases: ${releases.length}`);
-    // console.log("Release List:");
-  
-    //   releases.forEach((release) => {
-    //     console.log(`- ${release.tag_name}`);
-    //   })
-
     return {
         contributors,
         reporters,
         pulls,
-        issues,
-        releases
+        issues
     }
   }
 }

--- a/docs/.vuepress/notes.md.nj
+++ b/docs/.vuepress/notes.md.nj
@@ -54,7 +54,7 @@ Check out the new features and enhancements for PagerDuty Process Automation (fo
 
 ## Enterprise Runner Updates
 
-**Latest Runner Version:** {{runner.releases[0].name}}
+**Bundled Runner Version:** {{sidecarVersion.version}}
 
 {% for pull in runner.pulls -%}
 * {{ pull.title | replace(r/RUN-[0-9]*:?\s?/g, "") | replace(r/RSE-[0-9]*:?\s?/g, "") | replace(r/RCLOUD-[0-9]*:?\s?/g, "") }}

--- a/docs/.vuepress/notes.md.nj
+++ b/docs/.vuepress/notes.md.nj
@@ -51,6 +51,15 @@ Check out the new features and enhancements for PagerDuty Process Automation (fo
 * [{{ pull.title | replace(r/RUN-[0-9]*:?\s?/g, "") | replace(r/RSE-[0-9]*:?\s?/g, "") | replace(r/RCLOUD-[0-9]*:?\s?/g, "") }}]({{pull.html_url}})
 {% endfor %}
 
+
+## Enterprise Runner Updates
+
+**Latest Runner Version:** {{runner.releases[0].name}}
+
+{% for pull in runner.pulls -%}
+* {{ pull.title | replace(r/RUN-[0-9]*:?\s?/g, "") | replace(r/RSE-[0-9]*:?\s?/g, "") | replace(r/RCLOUD-[0-9]*:?\s?/g, "") }}
+{% endfor %}
+
 ## Community Contributors
 
 Submit your own Pull Requests to get recognition here!


### PR DESCRIPTION
This will add functionality to check the rundeckpro/sidecar repo for new PRs related to the official version release of the product.

To add a PR to the Release Notes add the `release-notes/include` tag (same as on `rundeckpro/rundeckpro`)

The Latest GitHub release name will also be put in the release notes for reference.

To see the output as a test use the following command from this branch on docs:
`npm run notes -- --milestone=4.15.0 --draft`  and check the draft.md file.  (don't commit the output file to docs though)