### PR TITLE
Update resource-yaml-v13.md to remove sshport documented attribute.

### DIFF
--- a/docs/manual/document-format-reference/resource-yaml-v13.md
+++ b/docs/manual/document-format-reference/resource-yaml-v13.md
@@ -88,10 +88,6 @@ Optional Entries:
 
 : URL to an external resource model editor service.
 
-`sshport`
-
-: The connection port to use, 22 by default
-
 `ssh-keypath`
 
 : The path to the SSH key in the Rundeck Key store. For example: keys/ec2/west.pem


### PR DESCRIPTION
Updates the documentation for the YAML resource definition to remove `sshport` as a known optional entry, as it does not actually have an effect. It appears that one has to provide the port by appending `:<port>` to the `hostname` value, as noted for the `hostname` attribute. 

I noticed that `sshport` is not documented within the XML or JSON definition for a node resource either, making me think the fact that `sshport` having no effect was not simply just a bug.