### PR TITLE
Update resource YAML documentation to rename ssh-keypath attribute to ssh-key-storage-path

### DIFF
--- a/docs/manual/document-format-reference/resource-yaml-v13.md
+++ b/docs/manual/document-format-reference/resource-yaml-v13.md
@@ -92,7 +92,7 @@ Optional Entries:
 
 : The connection port to use, 22 by default
 
-`ssh-keypath`
+`ssh-key-storage-path`
 
 : The path to the SSH key in the Rundeck Key store. For example: keys/ec2/west.pem
 


### PR DESCRIPTION
Updates the YAML node resource documentation to change the `ssh-keypath` attribute name to `ssh-key-storage-path`. 

When testing, I found that `ssh-keypath` did not work. However I found `ssh-key-storage-path` documented in the[ JSON documentation examples](https://docs.rundeck.com/docs/manual/document-format-reference/resource-json-v10.html#examples). When I tried this different name in my node YAML definition, it worked.