### PR TITLE
VMware and Github plugins now in RBA

### DIFF
--- a/docs/about/cloud/index.md
+++ b/docs/about/cloud/index.md
@@ -49,8 +49,6 @@ The following plugins are not available in Runbook Automation at the moment. The
       - rundeck-localexec
       - rundeck-script-plugin
       - rundeckpro-cyberark
-      - github-script-plugin
-      - rundeckpro-vmware-plugin
     providerNameEntries:
       FileCopier:
         - script-copy


### PR DESCRIPTION
The VMware and Github plugins are listed as plugins _not_ available in RBA, but they are now available in RBA (by using the Runner).
