### PR TITLE
RSE-724: Adding the new flag "allGroups"

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -388,6 +388,9 @@ The `JettyCachingLdapLoginModule` has these configuration properties:
 `nestedGroups`
 : "true/false" - Default: false. If true, will resolve all nested groups for authenticated users. For the first user to login after a fresh start it will take a couple of seconds longer, this is when the cache of all nested groups is built. This will happen as often as the cache is refreshed. Uses the cacheDurationMillis for cache timeout. The groups recognized as nested will depend on the `roleBaseDn`, any other role outside of this will not be taken.
 
+`allGroups`
+: "true/false" - Default: false. If true, will resolve all nested groups, although you have more than 1000 nested groups, regardless of `SizeLimit Exceeded Error`.
+
 The `JettyCombinedLdapLoginModule` is extends the previous module, so is configured in almost exactly the same way, but adds these additional configuration options:
 
 ```c .numberLines

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -389,7 +389,7 @@ The `JettyCachingLdapLoginModule` has these configuration properties:
 : "true/false" - Default: false. If true, will resolve all nested groups for authenticated users. For the first user to login after a fresh start it will take a couple of seconds longer, this is when the cache of all nested groups is built. This will happen as often as the cache is refreshed. Uses the cacheDurationMillis for cache timeout. The groups recognized as nested will depend on the `roleBaseDn`, any other role outside of this will not be taken.
 
 `allGroups`
-: "true/false" - Default: false. If true, will resolve all nested groups, although you have more than 1000 nested groups, regardless of `SizeLimit Exceeded Error`.
+: "true/false" - Default: `true`. If true, will resolve all nested groups, although you have more than 1000 nested groups, regardless of `SizeLimit Exceeded Error`.
 
 The `JettyCombinedLdapLoginModule` is extends the previous module, so is configured in almost exactly the same way, but adds these additional configuration options:
 


### PR DESCRIPTION
### Bug: 
LDAP: error code 4 - Sizelimit Exceeded when you activated the nestedGroups option and you had a large number of groups.
### Doc
New parameter is documented: allGroups flag to enable/disable if getting all groups or default in **LDAP**. Flag is false by default.

It's related to https://github.com/rundeck/rundeck/pull/8436