### PR TITLE
RSE-704: unrecognized node type warnings with aurora postgres below 4.15

### DIFF
--- a/docs/administration/configuration/database/postgres.md
+++ b/docs/administration/configuration/database/postgres.md
@@ -46,3 +46,9 @@ dataSource.password = rundeckpassword
 With recent Rundeck versions, PostgreSQL connector is bundled.
 
 Now, you can start Rundeck.
+
+## Amazon Aurora PostgreSQL
+:::warning
+Aurora PostgreSQL databases on versions below 15.3.0, display warnings `unrecognized node type: 378` when processing queries, this is harmless since the queries are executed as expected but can be anoying for some users.
+See: [Aurora PostgreSQL 15.3.0 updates page](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html#AuroraPostgreSQL.Updates.20180305.1530) 
+:::


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-704

#### Problem
Messages like:
```
[2023-07-11T22:00:41,523] WARN  spi.SqlExceptionHelper - SQL Warning Code: 0, SQLState: 01000
[2023-07-11T22:00:41,523] WARN  spi.SqlExceptionHelper - unrecognized node type: 378
```
are constantly displayed on the logs when running the server with postgres 14.6 in AWS aurora.

#### Added Doc
A notice was added so that users are aware of this.
![image](https://github.com/rundeck/docs/assets/49494423/7349e054-211b-46fa-8439-96b1a40075e6)

