### PR TITLE
RSE-783: doc: Added sql server configuration to avoid deadlocks

### DIFF
--- a/docs/administration/configuration/database/mssql.md
+++ b/docs/administration/configuration/database/mssql.md
@@ -14,3 +14,32 @@ dataSource.url = jdbc:sqlserver://mssql.rundeck.local;DatabaseName=rundeck
 dataSource.username = rundeckuser
 dataSource.password = rundeckpassword
 ```
+### Sql Server Configuration
+
+In certain instances, the default configuration of Sql Server has presented challenges in ensuring the seamless operation of Rundeck oss and Process Automation. These challenges include encountering deadlocks within numerous transactions, primarily attributed to Sql Server's distinct approach to managing concurrent data access at the row level, which differs from other database systems. Fortunately, these issues can be addressed through reconfiguration to enhance performance and facilitate smoother operations in such scenarios.
+
+In Microsoft SQL Server (MSSQL), there exists a flag that allows you to modify the behavior of transactions when using the READ_COMMITTED isolation level. This flag is named 'is_read_committed_snapshot_on.' To determine its current status, you can execute the following query on your database:
+
+```conf1
+SELECT is_read_committed_snapshot_on, snapshot_isolation_state_desc,snapshot_isolation_state
+FROM sys.databases
+WHERE name = 'RundeckDBName'
+```
+
+Output:
+```output
+|is_read_committed_snapshot_on|snapshot_isolation_state_desc|snapshot_isolation_state|
+|-----------------------------|-----------------------------|------------------------|
+|0                            |OFF                          |0                       |
+```
+
+This flag can be a valuable tool for mitigating deadlocks by enabling transactions to access the last committed value of a row without waiting for other transactions to release their locks. To enable this feature:
+
+```conf2
+ALTER DATABASE RundeckDBName  
+SET ALLOW_SNAPSHOT_ISOLATION ON  
+  
+ALTER DATABASE RundeckDBName  
+SET READ_COMMITTED_SNAPSHOT ON  
+```
+


### PR DESCRIPTION
### Problem
Because SQL Server locks rows when multiple transactions attempt to access them simultaneously, Rundeck may begin to report deadlock errors in its logs. This behavior can adversely affect the application's performance and functionality.

### Fix
By activating the flags **_ALLOW_SNAPSHOT_ISOLATION_** and **_READ_COMMITTED_SNAPSHOT_**, SQL Server can alter its behavior in handling concurrent transactions, effectively mitigating deadlock issues within Rundeck

```note
This documentation is NOT related to any related to any PR or release. 
It is just for user deciding to use Microsoft Sql Server (mssql) as database.
```