### PR TITLE
RSE-784 Fix: Pywinrm does not work on rehl 7

### DIFF
--- a/docs/learning/howto/configuring-windows-nodes.md
+++ b/docs/learning/howto/configuring-windows-nodes.md
@@ -29,7 +29,7 @@ The [pywinrm plugin](https://github.com/rundeck-plugins/py-winrm-plugin) uses th
 
 * Python 3.3-3.5 or PyPy2 installed on Rundeck server. _(Python 3 strongly recommended)_
 * Pywinrm library (It can be installed with the following command: `pip install pywinrm`)
-* OpenSSL version 1.1.1 or higher. (To check the openssl version: `openssl version - "OpenSSL 1.1.1k"`)
+* OpenSSL version 1.1.1 or higher. (openssl version can be checked with the following command: `openssl version - "OpenSSL 1.1.1k"`)
     * `requests-kerberos` and `requests-credssp` are optional.
   
 Note: Due to networking complexity issues this exercise will not work with the Welcome Projects.  These steps assume you have Rundeck installed [using these instructions](/administration/install/installing-rundeck.md).  For more information see the [Additional Information](#additional-information) section.

--- a/docs/learning/howto/configuring-windows-nodes.md
+++ b/docs/learning/howto/configuring-windows-nodes.md
@@ -29,8 +29,8 @@ The [pywinrm plugin](https://github.com/rundeck-plugins/py-winrm-plugin) uses th
 
 * Python 3.3-3.5 or PyPy2 installed on Rundeck server. _(Python 3 strongly recommended)_
 * Pywinrm library (It can be installed with the following command: `pip install pywinrm`)
+* OpenSSL version must be 1.1.1 or higher. (To check the openssl version: `openssl version - "OpenSSL 1.1.1k"`)
     * `requests-kerberos` and `requests-credssp` are optional.
-
 Note: Due to networking complexity issues this exercise will not work with the Welcome Projects.  These steps assume you have Rundeck installed [using these instructions](/administration/install/installing-rundeck.md).  For more information see the [Additional Information](#additional-information) section.
 
 ## Basic Windows Requirements

--- a/docs/learning/howto/configuring-windows-nodes.md
+++ b/docs/learning/howto/configuring-windows-nodes.md
@@ -29,8 +29,9 @@ The [pywinrm plugin](https://github.com/rundeck-plugins/py-winrm-plugin) uses th
 
 * Python 3.3-3.5 or PyPy2 installed on Rundeck server. _(Python 3 strongly recommended)_
 * Pywinrm library (It can be installed with the following command: `pip install pywinrm`)
-* OpenSSL version must be 1.1.1 or higher. (To check the openssl version: `openssl version - "OpenSSL 1.1.1k"`)
+* OpenSSL version 1.1.1 or higher. (To check the openssl version: `openssl version - "OpenSSL 1.1.1k"`)
     * `requests-kerberos` and `requests-credssp` are optional.
+  
 Note: Due to networking complexity issues this exercise will not work with the Welcome Projects.  These steps assume you have Rundeck installed [using these instructions](/administration/install/installing-rundeck.md).  For more information see the [Additional Information](#additional-information) section.
 
 ## Basic Windows Requirements


### PR DESCRIPTION
Problem: pyWinrm does not work on RHEL7 (Red Hat Enterprise Linux 7). An error occurs indicating that urllib3 2.x requires OpenSSL 1.1.1  but the last version that REHL 7 provides is OpenSSL 1.0.4.

Solution: Add openssl version 1.1.1 or higher as a requirement for pyWinrm to function.