### PR TITLE
RSE-812: Doc: not importing logs from s3logstore

### DIFF
--- a/docs/developer/06-logging-plugins.md
+++ b/docs/developer/06-logging-plugins.md
@@ -135,6 +135,44 @@ Note that the Map keys will not start with `job.`, simply use the variable name,
 
 In addition, for ExecutionFileStorage plugins, another map entry named `filetype` will be specified, which indicates which type of file is being stored. You need to use this filetype as part of the identifier for storing or retrieving the file.
 
+### Importing executions
+When importing executions they not always come along with their log files since they can be present in a remote log storage, resulting on execution logs that might not follow the expected path, eg:
+```
+# The server has the following path configured for the ExecutionFileStorage
+path = path/to/logs/${job.project}/${job.execid}.log
+
+# Given a project "P-example" and an execution with id "5" we would expect the log to be present in the path
+log-path = path/to/logs/P-example/5.log
+
+# But if the execution was imported from another server, the log file path could be
+log-path = other/path/to/logs/Other-Project/999.log
+```
+The Logging plugins must be aware of this and can make use of `outputfilepath`,`isRemoteFilePath` and `execIdForLogStore` variables which are present on the execution context (`v > 4.17.0`) to solve these cases. The mark used to spot these cases is `isRemoteFilePath`, eg:
+```
+# For both Cases, the path configured for the ExecutionFileStorage is
+path = path/to/logs/${job.project}/${job.execid}.log
+
+## Case 1 (Execution was created in the current server)
+### Given an execution with the following context
+execid == '5'
+project == 'my-project'
+outputfilepath == '/local/path/to/cached/file/5.rdlog'
+isRemoteFilePath == 'false'
+execIdForLogStore == '5'
+### To access this log file, the log plugin must use the configured path and expand it using the context variables of the given execution to find the log in:
+log-path = 'path/to/logs/my-project/5.log'
+
+## Case 2 (imported execution)
+## Given an execution with the following context
+execid == '6'
+project == 'my-project'
+outputfilepath == 'other/path/to/logs/Other-Project/999.log'
+isRemoteFilePath == 'true'
+execIdForLogStore == '999'
+### To access this log file, the log plugin can skip the configured path and use the outputfilepath directly (and the "execIdForLogStore" variable if it uses it in remote file metadata):
+log-path = 'other/path/to/logs/Other-Project/999.log' # If the log file is present in the same storage configured in the server and the server has access to the path, the log will be retrieved corretly
+```
+
 ## StreamingLogWriter
 
 The `StreamingLogWriter` ([javadoc]({{{javaDocBase}}}/com/dtolabs/rundeck/core/logging/StreamingLogWriter.html)) system receives log events from an execution and writes them somewhere.

--- a/docs/developer/06-logging-plugins.md
+++ b/docs/developer/06-logging-plugins.md
@@ -136,7 +136,8 @@ Note that the Map keys will not start with `job.`, simply use the variable name,
 In addition, for ExecutionFileStorage plugins, another map entry named `filetype` will be specified, which indicates which type of file is being stored. You need to use this filetype as part of the identifier for storing or retrieving the file.
 
 ### Importing executions
-When importing executions they not always come along with their log files since they can be present in a remote log storage, resulting on execution logs that might not follow the expected path, eg:
+When importing executions they not always come along with their log files since they can be present in a remote log storage, resulting on execution logs that might not follow the expected path, eg:  
+
 ```
 # The server has the following path configured for the ExecutionFileStorage
 path = path/to/logs/${job.project}/${job.execid}.log
@@ -146,8 +147,10 @@ log-path = path/to/logs/P-example/5.log
 
 # But if the execution was imported from another server, the log file path could be
 log-path = other/path/to/logs/Other-Project/999.log
-```
-The Logging plugins must be aware of this and can make use of `outputfilepath`,`isRemoteFilePath` and `execIdForLogStore` variables which are present on the execution context (`v > 4.17.0`) to solve these cases. The mark used to spot these cases is `isRemoteFilePath`, eg:
+```  
+
+The Logging plugins must be aware of this and can make use of `outputfilepath`,`isRemoteFilePath` and `execIdForLogStore` variables which are present on the execution context (`v > 4.17.0`) to solve these cases. The mark used to spot these cases is `isRemoteFilePath`, eg:  
+
 ```
 # For both Cases, the path configured for the ExecutionFileStorage is
 path = path/to/logs/${job.project}/${job.execid}.log
@@ -171,7 +174,7 @@ isRemoteFilePath == 'true'
 execIdForLogStore == '999'
 ### To access this log file, the log plugin can skip the configured path and use the outputfilepath directly (and the "execIdForLogStore" variable if it uses it in remote file metadata):
 log-path = 'other/path/to/logs/Other-Project/999.log' # If the log file is present in the same storage configured in the server and the server has access to the path, the log will be retrieved corretly
-```
+```  
 
 ## StreamingLogWriter
 

--- a/docs/manual/job-workflows.md
+++ b/docs/manual/job-workflows.md
@@ -241,6 +241,9 @@ When a Job step is executed, it has a set of "context" variables that can be acc
 - `job.id`: ID of the Job
 - `job.url`: URL to the Job/execution data.
 - `job.execid`: ID of the current Execution
+- `job.outputfilepath`: Contains the path to the log file for the current execution which can be local or remote.
+- `job.isRemoteFilePath`: This is a flag (`"true"`, `"false"`) to identify if the path in `outputfilepath` corresponds to the server file system or a remote file.
+- `job.execIdForLogStore`: The execution id of the log file which isn't necessarily the same as the `execid` (eg: if the execution was imported from another project).
 - `job.executionType` : Execution type, can be `user`, `scheduled` or `user-scheduled` for `Run Job Later` executions
 - `job.username`: Username of the user executing the Job
 - `job.project`: Project name

--- a/docs/manual/projects/project-archive.md
+++ b/docs/manual/projects/project-archive.md
@@ -36,6 +36,9 @@ When importing a project with Rundeck, there are some things to consider:
 
 - **Executions**
 : This allows you to choose whether or not you existing executions and their history to be imported. If "import all" is selected, it will create new executions and history reports from the archive.
+::: warning
+When importing executions that have **logs in a remote storage** they are not imported **until they are accessed later**. In order to access these log files, they **must be present in the remote storage configured** and the server **must have the neccessary permissions** to access the log file path (from the remote storage provider side) 
+:::
 
 - **Configuration**
 : This allows you to specify whether you want to import the configuration properties of the project. If "import project configuration" is chosen, the project configuration will be overwritten with the properties stored in the archive. If not, the configurations will not be used.

--- a/docs/manual/projects/project-archive.md
+++ b/docs/manual/projects/project-archive.md
@@ -37,7 +37,7 @@ When importing a project with Rundeck, there are some things to consider:
 - **Executions**
 : This allows you to choose whether or not you existing executions and their history to be imported. If "import all" is selected, it will create new executions and history reports from the archive.
 ::: warning
-When importing executions that have **logs in a remote storage** they are not imported **until they are accessed later**. In order to access these log files, they **must be present in the remote storage configured** and the server **must have the neccessary permissions** to access the log file path (from the remote storage provider side) 
+If any of the imported executions include **logs in a remote storage**, those log files are not imported **until they are accessed later**. In order to view the remotely stored log files, they **must still be present in the remote storage** and the receiving server **must have the necessary permissions** (from the remote storage provider side) to access the log file path.  
 :::
 
 - **Configuration**


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-740
Depends on: https://github.com/rundeck/rundeck/pull/8583

Documentation for the usage of `outputfilepath`, `isRemoteFilePath` and `execIdForLogStore` execution context variables for retrieving log files for imported executions in Log Storage Plugins.