### PR TITLE
Update linux-deb.md

### DIFF
--- a/docs/administration/install/linux-deb.md
+++ b/docs/administration/install/linux-deb.md
@@ -102,6 +102,7 @@ sudo dpkg -i rundeck_{{$rundeckVersionFull}}-1_all.deb
 To start Rundeck:
 
 ```bash
+sudo systemctl daemon-reload
 sudo service rundeckd start
 ```
 


### PR DESCRIPTION
Without the daemon-reload, systemctl reports the service cannot be found.

>➜  matt ~ sudo service rundeckd start
Failed to start rundeckd.service: Unit rundeckd.service not found.