### PR TITLE
Fix: api index links should use .md

### DIFF
--- a/docs/api/api-index-links.md
+++ b/docs/api/api-index-links.md
@@ -1,237 +1,237 @@
 
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugins]:/api/rundeck-api.html#list-scm-plugins
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/input]:/api/rundeck-api.html#get-scm-plugin-input-fields
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/setup]:/api/rundeck-api.html#setup-scm-plugin-for-a-project
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/enable]:/api/rundeck-api.html#enable-scm-plugin-for-a-project
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/disable]:/api/rundeck-api.html#disable-scm-plugin-for-a-project
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/status]:/api/rundeck-api.html#get-project-scm-status
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/config]:/api/rundeck-api.html#get-project-scm-config
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]]:/api/rundeck-api.html#perform-project-scm-action
-[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]/input]:/api/rundeck-api.html#get-project-scm-action-input-fields
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugins]:/api/rundeck-api.md#list-scm-plugins
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/input]:/api/rundeck-api.md#get-scm-plugin-input-fields
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/setup]:/api/rundeck-api.md#setup-scm-plugin-for-a-project
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/enable]:/api/rundeck-api.md#enable-scm-plugin-for-a-project
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/plugin/\[TYPE\]/disable]:/api/rundeck-api.md#disable-scm-plugin-for-a-project
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/status]:/api/rundeck-api.md#get-project-scm-status
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/config]:/api/rundeck-api.md#get-project-scm-config
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]]:/api/rundeck-api.md#perform-project-scm-action
+[/api/V/project/\[PROJECT\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]/input]:/api/rundeck-api.md#get-project-scm-action-input-fields
 
-[/api/V/project/\[PROJECT\]/sources]:/api/rundeck-api.html#list-resource-model-sources-for-a-project
-[/api/V/project/\[PROJECT\]/source/\[INDEX\]]:/api/rundeck-api.html#get-a-resource-model-source-for-a-project
-[/api/V/project/\[PROJECT\]/source/\[INDEX\]/resources]:/api/rundeck-api.html#list-resources-of-a-resource-model-source
-[GET /api/V/project/\[PROJECT\]/source/\[INDEX\]/resources]:/api/rundeck-api.html#list-resources-of-a-resource-model-source
-[POST /api/V/project/\[PROJECT\]/source/\[INDEX\]/resources]:/api/rundeck-api.html#update-resources-of-a-resource-model-source
+[/api/V/project/\[PROJECT\]/sources]:/api/rundeck-api.md#list-resource-model-sources-for-a-project
+[/api/V/project/\[PROJECT\]/source/\[INDEX\]]:/api/rundeck-api.md#get-a-resource-model-source-for-a-project
+[/api/V/project/\[PROJECT\]/source/\[INDEX\]/resources]:/api/rundeck-api.md#list-resources-of-a-resource-model-source
+[GET /api/V/project/\[PROJECT\]/source/\[INDEX\]/resources]:/api/rundeck-api.md#list-resources-of-a-resource-model-source
+[POST /api/V/project/\[PROJECT\]/source/\[INDEX\]/resources]:/api/rundeck-api.md#update-resources-of-a-resource-model-source
 
-[/api/V/job/\[ID\]/scm/\[INTEGRATION\]/status]:/api/rundeck-api.html#get-job-scm-status
-[/api/V/job/\[ID\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]]:/api/rundeck-api.html#perform-job-scm-action
-[/api/V/job/\[ID\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]/input]:/api/rundeck-api.html#get-job-scm-action-input-fields
+[/api/V/job/\[ID\]/scm/\[INTEGRATION\]/status]:/api/rundeck-api.md#get-job-scm-status
+[/api/V/job/\[ID\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]]:/api/rundeck-api.md#perform-job-scm-action
+[/api/V/job/\[ID\]/scm/\[INTEGRATION\]/action/\[ACTION_ID\]/input]:/api/rundeck-api.md#get-job-scm-action-input-fields
 
 
-[/api/V/config/refresh]:/api/rundeck-api.html#config-refresh
+[/api/V/config/refresh]:/api/rundeck-api.md#config-refresh
 
-[/api/V/execution/\[ID\]]:/api/rundeck-api.html#execution-info
+[/api/V/execution/\[ID\]]:/api/rundeck-api.md#execution-info
 
-[/api/V/execution/\[ID\]/abort]:/api/rundeck-api.html#aborting-executions
+[/api/V/execution/\[ID\]/abort]:/api/rundeck-api.md#aborting-executions
 
-[/api/V/execution/\[ID\]/input/files]:/api/rundeck-api.html#list-input-files-for-an-execution
+[/api/V/execution/\[ID\]/input/files]:/api/rundeck-api.md#list-input-files-for-an-execution
 
-[/api/V/execution/\[ID\]/output/state]:/api/rundeck-api.html#execution-output-with-state
+[/api/V/execution/\[ID\]/output/state]:/api/rundeck-api.md#execution-output-with-state
 
-[/api/V/execution/\[ID\]/output/step/\[STEPCTX\]]:/api/rundeck-api.html#execution-output
+[/api/V/execution/\[ID\]/output/step/\[STEPCTX\]]:/api/rundeck-api.md#execution-output
 
-[/api/V/execution/\[ID\]/output/node/\[NODE\]/step/\[STEPCTX\]]:/api/rundeck-api.html#execution-output
+[/api/V/execution/\[ID\]/output/node/\[NODE\]/step/\[STEPCTX\]]:/api/rundeck-api.md#execution-output
 
-[/api/V/execution/\[ID\]/output/node/\[NODE\]]:/api/rundeck-api.html#execution-output
+[/api/V/execution/\[ID\]/output/node/\[NODE\]]:/api/rundeck-api.md#execution-output
 
-[/api/V/execution/\[ID\]/output]:/api/rundeck-api.html#execution-output
+[/api/V/execution/\[ID\]/output]:/api/rundeck-api.md#execution-output
 
-[/api/V/execution/\[ID\]/state]:/api/rundeck-api.html#execution-state
+[/api/V/execution/\[ID\]/state]:/api/rundeck-api.md#execution-state
 
-[/api/V/executions/delete]:/api/rundeck-api.html#bulk-delete-executions
+[/api/V/executions/delete]:/api/rundeck-api.md#bulk-delete-executions
 
 
-[/api/V/executions/metrics]:/api/rundeck-api.html#execution-query-metrics
+[/api/V/executions/metrics]:/api/rundeck-api.md#execution-query-metrics
 
-[/api/V/feature/]:/api/rundeck-api.html#get-all-system-feature-status
-[/api/V/feature/\[FEATURE\]]:/api/rundeck-api.html#get-a-system-feature-status
+[/api/V/feature/]:/api/rundeck-api.md#get-all-system-feature-status
+[/api/V/feature/\[FEATURE\]]:/api/rundeck-api.md#get-a-system-feature-status
 
-[/api/V/job/\[ID\]]:/api/rundeck-api.html#getting-a-job-definition
-[DELETE /api/V/job/\[ID\]]:/api/rundeck-api.html#deleting-a-job-definition
+[/api/V/job/\[ID\]]:/api/rundeck-api.md#getting-a-job-definition
+[DELETE /api/V/job/\[ID\]]:/api/rundeck-api.md#deleting-a-job-definition
 
-[/api/V/job/\[ID\]/executions]:/api/rundeck-api.html#getting-executions-for-a-job
+[/api/V/job/\[ID\]/executions]:/api/rundeck-api.md#getting-executions-for-a-job
 
-[/api/V/job/\[ID\]/execution/enable]:/api/rundeck-api.html#enable-executions-for-a-job
+[/api/V/job/\[ID\]/execution/enable]:/api/rundeck-api.md#enable-executions-for-a-job
 
-[/api/V/job/\[ID\]/execution/disable]:/api/rundeck-api.html#disable-executions-for-a-job
+[/api/V/job/\[ID\]/execution/disable]:/api/rundeck-api.md#disable-executions-for-a-job
 
-[POST /api/V/job/\[ID\]/executions]:/api/rundeck-api.html#running-a-job
-[DELETE /api/V/job/\[ID\]/executions]:/api/rundeck-api.html#delete-all-executions-for-a-job
+[POST /api/V/job/\[ID\]/executions]:/api/rundeck-api.md#running-a-job
+[DELETE /api/V/job/\[ID\]/executions]:/api/rundeck-api.md#delete-all-executions-for-a-job
 
-[/api/V/job/\[ID\]/retry/\[EXECID\]]:/api/rundeck-api.html#retry-a-job-based-on-execution
-[POST /api/V/job/\[ID\]/retry/\[EXECID\]]:/api/rundeck-api.html#retry-a-job-based-on-execution
+[/api/V/job/\[ID\]/retry/\[EXECID\]]:/api/rundeck-api.md#retry-a-job-based-on-execution
+[POST /api/V/job/\[ID\]/retry/\[EXECID\]]:/api/rundeck-api.md#retry-a-job-based-on-execution
 
-[/api/V/job/\[ID\]/info]:/api/rundeck-api.html#get-job-metadata
-[GET /api/V/job/\[ID\]/info]:/api/rundeck-api.html#get-job-metadata
-[/api/V/job/\[ID\]/input/file]:/api/rundeck-api.html#upload-a-file-for-a-job-option
-[POST /api/V/job/\[ID\]/input/file]:/api/rundeck-api.html#upload-a-file-for-a-job-option
-[/api/V/job/\[ID\]/input/files]:/api/rundeck-api.html#list-files-uploaded-for-a-job
+[/api/V/job/\[ID\]/info]:/api/rundeck-api.md#get-job-metadata
+[GET /api/V/job/\[ID\]/info]:/api/rundeck-api.md#get-job-metadata
+[/api/V/job/\[ID\]/input/file]:/api/rundeck-api.md#upload-a-file-for-a-job-option
+[POST /api/V/job/\[ID\]/input/file]:/api/rundeck-api.md#upload-a-file-for-a-job-option
+[/api/V/job/\[ID\]/input/files]:/api/rundeck-api.md#list-files-uploaded-for-a-job
 
-[/api/V/job/\[ID\]/forecast]:/api/rundeck-api.html#get-job-forecast
-[GET /api/V/job/\[ID\]/forecast]:/api/rundeck-api.html#get-job-forecast
+[/api/V/job/\[ID\]/forecast]:/api/rundeck-api.md#get-job-forecast
+[GET /api/V/job/\[ID\]/forecast]:/api/rundeck-api.md#get-job-forecast
 
-[/api/V/job/\[ID\]/schedule/enable]:/api/rundeck-api.html#enable-scheduling-for-a-job
+[/api/V/job/\[ID\]/schedule/enable]:/api/rundeck-api.md#enable-scheduling-for-a-job
 
-[/api/V/job/\[ID\]/schedule/disable]:/api/rundeck-api.html#disable-scheduling-for-a-job
+[/api/V/job/\[ID\]/schedule/disable]:/api/rundeck-api.md#disable-scheduling-for-a-job
 
-[/api/V/job/\[ID\]/run]:/api/rundeck-api.html#running-a-job
-[/api/V/job/\[ID\]/workflow]:/api/rundeck-api.html#get-job-workflow
+[/api/V/job/\[ID\]/run]:/api/rundeck-api.md#running-a-job
+[/api/V/job/\[ID\]/workflow]:/api/rundeck-api.md#get-job-workflow
 
-[/api/V/jobs/delete]:/api/rundeck-api.html#bulk-job-delete
-[/api/V/jobs/execution/enable]:/api/rundeck-api.html#bulk-toggle-job-execution
-[/api/V/jobs/execution/disable]:/api/rundeck-api.html#bulk-toggle-job-execution
-[/api/V/jobs/file/\[ID\]]:/api/rundeck-api.html#get-info-about-an-uploaded-file
-[/api/V/jobs/schedule/enable]:/api/rundeck-api.html#bulk-toggle-job-schedules
-[/api/V/jobs/schedule/disable]:/api/rundeck-api.html#bulk-toggle-job-schedules
+[/api/V/jobs/delete]:/api/rundeck-api.md#bulk-job-delete
+[/api/V/jobs/execution/enable]:/api/rundeck-api.md#bulk-toggle-job-execution
+[/api/V/jobs/execution/disable]:/api/rundeck-api.md#bulk-toggle-job-execution
+[/api/V/jobs/file/\[ID\]]:/api/rundeck-api.md#get-info-about-an-uploaded-file
+[/api/V/jobs/schedule/enable]:/api/rundeck-api.md#bulk-toggle-job-schedules
+[/api/V/jobs/schedule/disable]:/api/rundeck-api.md#bulk-toggle-job-schedules
 
 
-[/api/V/metrics]:/api/rundeck-api.html#list-metrics
+[/api/V/metrics]:/api/rundeck-api.md#list-metrics
 
-[/api/V/metrics/healthcheck]:/api/rundeck-api.html#metrics-healthcheck
+[/api/V/metrics/healthcheck]:/api/rundeck-api.md#metrics-healthcheck
 
-[/api/V/metrics/metrics]:/api/rundeck-api.html#metrics-data
+[/api/V/metrics/metrics]:/api/rundeck-api.md#metrics-data
 
-[/api/V/metrics/ping]:/api/rundeck-api.html#metrics-ping
+[/api/V/metrics/ping]:/api/rundeck-api.md#metrics-ping
 
-[/api/V/metrics/threads]:/api/rundeck-api.html#metrics-threads
+[/api/V/metrics/threads]:/api/rundeck-api.md#metrics-threads
 
-[/api/V/project/\[PROJECT\]]:/api/rundeck-api.html#getting-project-info
-[DELETE /api/V/project/\[PROJECT\]]:/api/rundeck-api.html#project-deletion
+[/api/V/project/\[PROJECT\]]:/api/rundeck-api.md#getting-project-info
+[DELETE /api/V/project/\[PROJECT\]]:/api/rundeck-api.md#project-deletion
 
-[/api/V/project/\[PROJECT\]/acl/*]:/api/rundeck-api.html#project-acls
+[/api/V/project/\[PROJECT\]/acl/*]:/api/rundeck-api.md#project-acls
 
-[/api/V/project/\[PROJECT\]/config]:/api/rundeck-api.html#get-project-configuration
-[PUT /api/V/project/\[PROJECT\]/config]:/api/rundeck-api.html#put-project-configuration
+[/api/V/project/\[PROJECT\]/config]:/api/rundeck-api.md#get-project-configuration
+[PUT /api/V/project/\[PROJECT\]/config]:/api/rundeck-api.md#put-project-configuration
 
 
-[/api/V/project/\[PROJECT\]/config/\[KEY\]]:/api/rundeck-api.html#get-project-configuration-key
-[PUT /api/V/project/\[PROJECT\]/config/\[KEY\]]:/api/rundeck-api.html#put-project-configuration-key
-[DELETE /api/V/project/\[PROJECT\]/config/\[KEY\]]:/api/rundeck-api.html#delete-project-configuration-key
+[/api/V/project/\[PROJECT\]/config/\[KEY\]]:/api/rundeck-api.md#get-project-configuration-key
+[PUT /api/V/project/\[PROJECT\]/config/\[KEY\]]:/api/rundeck-api.md#put-project-configuration-key
+[DELETE /api/V/project/\[PROJECT\]/config/\[KEY\]]:/api/rundeck-api.md#delete-project-configuration-key
 
 
-[/api/V/project/\[PROJECT\]/executions]:/api/rundeck-api.html#execution-query
+[/api/V/project/\[PROJECT\]/executions]:/api/rundeck-api.md#execution-query
 
 
-[/api/V/project/\[PROJECT\]/executions/metrics]:/api/rundeck-api.html#execution-query-metrics
+[/api/V/project/\[PROJECT\]/executions/metrics]:/api/rundeck-api.md#execution-query-metrics
 
-[/api/V/project/\[PROJECT\]/executions/running]:/api/rundeck-api.html#listing-running-executions
+[/api/V/project/\[PROJECT\]/executions/running]:/api/rundeck-api.md#listing-running-executions
 
 
-[/api/V/project/\[PROJECT\]/export]:/api/rundeck-api.html#project-archive-export
-[/api/V/project/\[PROJECT\]/export/async]:/api/rundeck-api.html#project-archive-export-async
-[/api/V/project/\[PROJECT\]/export/status/\[TOKEN\]]:/api/rundeck-api.html#project-archive-export-async-status
-[/api/V/project/\[PROJECT\]/export/download/\[TOKEN\]]:/api/rundeck-api.html#project-archive-export-async-download
+[/api/V/project/\[PROJECT\]/export]:/api/rundeck-api.md#project-archive-export
+[/api/V/project/\[PROJECT\]/export/async]:/api/rundeck-api.md#project-archive-export-async
+[/api/V/project/\[PROJECT\]/export/status/\[TOKEN\]]:/api/rundeck-api.md#project-archive-export-async-status
+[/api/V/project/\[PROJECT\]/export/download/\[TOKEN\]]:/api/rundeck-api.md#project-archive-export-async-download
 
 
-[/api/V/project/\[PROJECT\]/\[FILE.md\]]:/api/rundeck-api.html#get-readme-file
-[PUT /api/V/project/\[PROJECT\]/\[FILE.md\]]:/api/rundeck-api.html#put-readme-file
-[DELETE /api/V/project/\[PROJECT\]/\[FILE.md\]]:/api/rundeck-api.html#delete-readme-file
+[/api/V/project/\[PROJECT\]/\[FILE.md\]]:/api/rundeck-api.md#get-readme-file
+[PUT /api/V/project/\[PROJECT\]/\[FILE.md\]]:/api/rundeck-api.md#put-readme-file
+[DELETE /api/V/project/\[PROJECT\]/\[FILE.md\]]:/api/rundeck-api.md#delete-readme-file
 
-[/api/V/project/\[PROJECT\]/history]:/api/rundeck-api.html#listing-history
+[/api/V/project/\[PROJECT\]/history]:/api/rundeck-api.md#listing-history
 
-[/api/V/project/\[PROJECT\]/import]:/api/rundeck-api.html#project-archive-import
+[/api/V/project/\[PROJECT\]/import]:/api/rundeck-api.md#project-archive-import
 
-[/api/V/project/\[PROJECT\]/jobs]:/api/rundeck-api.html#listing-jobs
+[/api/V/project/\[PROJECT\]/jobs]:/api/rundeck-api.md#listing-jobs
 
-[/api/V/project/\[PROJECT\]/jobs/export]:/api/rundeck-api.html#exporting-jobs
+[/api/V/project/\[PROJECT\]/jobs/export]:/api/rundeck-api.md#exporting-jobs
 
-[/api/V/project/\[PROJECT\]/jobs/import]:/api/rundeck-api.html#importing-jobs
+[/api/V/project/\[PROJECT\]/jobs/import]:/api/rundeck-api.md#importing-jobs
 
-[/api/V/project/\[PROJECT\]/resources]:/api/rundeck-api.html#listing-resources
+[/api/V/project/\[PROJECT\]/resources]:/api/rundeck-api.md#listing-resources
 
-[/api/V/project/\[PROJECT\]/resource/\[NAME\]]:/api/rundeck-api.html#getting-resource-info
+[/api/V/project/\[PROJECT\]/resource/\[NAME\]]:/api/rundeck-api.md#getting-resource-info
 
-[/api/V/projects]:/api/rundeck-api.html#listing-projects
+[/api/V/projects]:/api/rundeck-api.md#listing-projects
 
-[POST /api/V/projects]:/api/rundeck-api.html#project-creation
+[POST /api/V/projects]:/api/rundeck-api.md#project-creation
 
-[/api/V/project/\[PROJECT\]/run/command]:/api/rundeck-api.html#running-adhoc-commands
+[/api/V/project/\[PROJECT\]/run/command]:/api/rundeck-api.md#running-adhoc-commands
 
-[/api/V/project/\[PROJECT\]/run/script]:/api/rundeck-api.html#running-adhoc-scripts
+[/api/V/project/\[PROJECT\]/run/script]:/api/rundeck-api.md#running-adhoc-scripts
 
-[/api/V/project/\[PROJECT\]/run/url]:/api/rundeck-api.html#running-adhoc-script-urls
+[/api/V/project/\[PROJECT\]/run/url]:/api/rundeck-api.md#running-adhoc-script-urls
 
-[/api/V/scheduler/takeover]:/api/rundeck-api.html#takeover-schedule-in-cluster-mode
+[/api/V/scheduler/takeover]:/api/rundeck-api.md#takeover-schedule-in-cluster-mode
 
-[/api/V/scheduler/jobs]:/api/rundeck-api.html#list-scheduled-jobs-for-this-cluster-server
+[/api/V/scheduler/jobs]:/api/rundeck-api.md#list-scheduled-jobs-for-this-cluster-server
 
-[/api/V/scheduler/server/\[UUID\]/jobs]:/api/rundeck-api.html#list-scheduled-jobs-for-a-cluster-server
+[/api/V/scheduler/server/\[UUID\]/jobs]:/api/rundeck-api.md#list-scheduled-jobs-for-a-cluster-server
 
-[/api/V/storage/keys/\[PATH\]/\[FILE\]]:/api/rundeck-api.html#list-keys
-[PUT /api/V/storage/keys/\[PATH\]/\[FILE\]]:/api/rundeck-api.html#upload-keys
-[DELETE /api/V/storage/keys/\[PATH\]/\[FILE\]]:/api/rundeck-api.html#delete-keys
+[/api/V/storage/keys/\[PATH\]/\[FILE\]]:/api/rundeck-api.md#list-keys
+[PUT /api/V/storage/keys/\[PATH\]/\[FILE\]]:/api/rundeck-api.md#upload-keys
+[DELETE /api/V/storage/keys/\[PATH\]/\[FILE\]]:/api/rundeck-api.md#delete-keys
 
 
-[/api/V/system/acl/*]:/api/rundeck-api.html#acls
-[/api/V/system/info]:/api/rundeck-api.html#system-info
-[/api/V/system/executions/enable]:/api/rundeck-api.html#set-active-mode
-[POST /api/V/system/executions/enable]:/api/rundeck-api.html#set-active-mode
-[/api/V/system/executions/disable]:/api/rundeck-api.html#set-passive-mode
-[POST /api/V/system/executions/disable]:/api/rundeck-api.html#set-passive-mode
-[/api/V/system/executions/status]:/api/rundeck-api.html#get-current-execution-mode
+[/api/V/system/acl/*]:/api/rundeck-api.md#acls
+[/api/V/system/info]:/api/rundeck-api.md#system-info
+[/api/V/system/executions/enable]:/api/rundeck-api.md#set-active-mode
+[POST /api/V/system/executions/enable]:/api/rundeck-api.md#set-active-mode
+[/api/V/system/executions/disable]:/api/rundeck-api.md#set-passive-mode
+[POST /api/V/system/executions/disable]:/api/rundeck-api.md#set-passive-mode
+[/api/V/system/executions/status]:/api/rundeck-api.md#get-current-execution-mode
 
-[/api/V/system/logstorage]:/api/rundeck-api.html#log-storage-info
-[/api/V/system/logstorage/incomplete]:/api/rundeck-api.html#list-executions-with-incomplete-log-storage
-[/api/V/system/logstorage/incomplete/resume]:/api/rundeck-api.html#resume-incomplete-log-storage
-[POST /api/V/system/logstorage/incomplete/resume]:/api/rundeck-api.html#resume-incomplete-log-storage
+[/api/V/system/logstorage]:/api/rundeck-api.md#log-storage-info
+[/api/V/system/logstorage/incomplete]:/api/rundeck-api.md#list-executions-with-incomplete-log-storage
+[/api/V/system/logstorage/incomplete/resume]:/api/rundeck-api.md#resume-incomplete-log-storage
+[POST /api/V/system/logstorage/incomplete/resume]:/api/rundeck-api.md#resume-incomplete-log-storage
 
-[/api/V/tokens]:/api/rundeck-api.html#list-tokens
-[/api/V/tokens/\[USER\]]:/api/rundeck-api.html#list-tokens
-[POST /api/V/tokens/\[USER\]]:/api/rundeck-api.html#create-a-token
-[/api/V/token/\[ID\]]:/api/rundeck-api.html#get-a-token
-[DELETE /api/V/token/\[ID\]]:/api/rundeck-api.html#delete-a-token
+[/api/V/tokens]:/api/rundeck-api.md#list-tokens
+[/api/V/tokens/\[USER\]]:/api/rundeck-api.md#list-tokens
+[POST /api/V/tokens/\[USER\]]:/api/rundeck-api.md#create-a-token
+[/api/V/token/\[ID\]]:/api/rundeck-api.md#get-a-token
+[DELETE /api/V/token/\[ID\]]:/api/rundeck-api.md#delete-a-token
 
 
-[/api/V/user/list]:/api/rundeck-api.html#list-users
-[/api/V/user/info]:/api/rundeck-api.html#get-user-profile
-[POST /api/V/user/info]:/api/rundeck-api.html#modify-user-profile
-[/api/V/user/info/\[USER\]]:/api/rundeck-api.html#get-another-user-profile
-[POST /api/V/user/info/\[USER\]]:/api/rundeck-api.html#modify-another-user-profile
-[/api/V/user/roles]:/api/rundeck-api.html#list-roles
+[/api/V/user/list]:/api/rundeck-api.md#list-users
+[/api/V/user/info]:/api/rundeck-api.md#get-user-profile
+[POST /api/V/user/info]:/api/rundeck-api.md#modify-user-profile
+[/api/V/user/info/\[USER\]]:/api/rundeck-api.md#get-another-user-profile
+[POST /api/V/user/info/\[USER\]]:/api/rundeck-api.md#modify-another-user-profile
+[/api/V/user/roles]:/api/rundeck-api.md#list-roles
 
-[/api/V/project/\[PROJECT\]/webhooks]:/api/rundeck-api.html#list-project-webhooks
-[/api/V/plugin/list]:/api/rundeck-api.html#list-installed-plugins
-[GET /api/V/plugin/list]:/api/rundeck-api.html#list-installed-plugins
+[/api/V/project/\[PROJECT\]/webhooks]:/api/rundeck-api.md#list-project-webhooks
+[/api/V/plugin/list]:/api/rundeck-api.md#list-installed-plugins
+[GET /api/V/plugin/list]:/api/rundeck-api.md#list-installed-plugins
 
-[/api/V/webhook/\[AUTH_TOKEN\]]:/api/rundeck-api.html#send-webhook-event
+[/api/V/webhook/\[AUTH_TOKEN\]]:/api/rundeck-api.md#send-webhook-event
 
-[/api/V/project/\[PROJECT\]/webhook/]:/api/rundeck-api.html#add-a-webhook
-[/api/V/project/\[PROJECT\]/webhook/\[ID\]]:/api/rundeck-api.html#get-a-webhook
+[/api/V/project/\[PROJECT\]/webhook/]:/api/rundeck-api.md#add-a-webhook
+[/api/V/project/\[PROJECT\]/webhook/\[ID\]]:/api/rundeck-api.md#get-a-webhook
 
-[POST /api/V/enterprise/cluster/executions/enable]:/api/rundeck-api.html#set-active-mode-for-a-cluster-member-enterprise
-[POST /api/V/enterprise/cluster/executions/disable]:/api/rundeck-api.html#set-passive-mode-for-a-cluster-member-enterprise
+[POST /api/V/enterprise/cluster/executions/enable]:/api/rundeck-api.md#set-active-mode-for-a-cluster-member-enterprise
+[POST /api/V/enterprise/cluster/executions/disable]:/api/rundeck-api.md#set-passive-mode-for-a-cluster-member-enterprise
 
 
-[/api/V/enterprise/license]:/api/rundeck-api.html#view-license
-[GET /api/V/enterprise/license]:/api/rundeck-api.html#view-license
-[POST /api/V/enterprise/license]:/api/rundeck-api.html#set-license-key
+[/api/V/enterprise/license]:/api/rundeck-api.md#view-license
+[GET /api/V/enterprise/license]:/api/rundeck-api.md#view-license
+[POST /api/V/enterprise/license]:/api/rundeck-api.md#set-license-key
 
 
 
-[/api/V/project/\[PROJECT\]/calendars]:/api/rundeck-api.html#list-project-calendars
-[GET /api/V/project/\[PROJECT\]/calendars]:/api/rundeck-api.html#list-project-calendars
-[POST /api/V/project/\[PROJECT\]/calendars]:/api/rundeck-api.html#create-update-project-calendar
-[DELETE /api/V/project/\[PROJECT\]/calendars/\[ID\]]:/api/rundeck-api.html#delete-project-calendar
+[/api/V/project/\[PROJECT\]/calendars]:/api/rundeck-api.md#list-project-calendars
+[GET /api/V/project/\[PROJECT\]/calendars]:/api/rundeck-api.md#list-project-calendars
+[POST /api/V/project/\[PROJECT\]/calendars]:/api/rundeck-api.md#create-update-project-calendar
+[DELETE /api/V/project/\[PROJECT\]/calendars/\[ID\]]:/api/rundeck-api.md#delete-project-calendar
 
-[/api/V/system/calendars]:/api/rundeck-api.html#list-system-calendars
-[GET /api/V/system/calendars]:/api/rundeck-api.html#list-system-calendars
-[POST /api/V/system/calendars]:/api/rundeck-api.html#create-update-system-calendar
-[DELETE /api/V/system/calendars/\[ID\]]:/api/rundeck-api.html#delete-system-calendar
+[/api/V/system/calendars]:/api/rundeck-api.md#list-system-calendars
+[GET /api/V/system/calendars]:/api/rundeck-api.md#list-system-calendars
+[POST /api/V/system/calendars]:/api/rundeck-api.md#create-update-system-calendar
+[DELETE /api/V/system/calendars/\[ID\]]:/api/rundeck-api.md#delete-system-calendar
 
-[GET /api/V/feature/\[featureName\]]:/api/rundeck-api.html#system-feature
+[GET /api/V/feature/\[featureName\]]:/api/rundeck-api.md#system-feature
 
-[GET /api/V/runnerManagement/checkPing/\[TOKEN\]]:/api/rundeck-api.html#check-a-ping-response
-[GET /api/V/runnerManagement/download/\[TOKEN\]]:/api/rundeck-api.html#download-runner-jar
-[POST /api/V/runnerManagement/runner/\[ID\]/ping]:/api/rundeck-api.html#ping-the-runner
-[POST /api/V/runnerManagement/runner/\[ID\]/regenerateCreds]:/api/rundeck-api.html#regenerate-credentials-for-the-runner
-[GET /api/V/runnerManagement/runner/\[ID\]/tags]:/api/rundeck-api.html#list-tags-for-the-runner
-[GET /api/V/runnerManagement/runner/\[RUNNERID\]]:/api/rundeck-api.html#get-runner-information
-[POST /api/V/runnerManagement/runner/\[RUNNERID\]]:/api/rundeck-api.html#update-the-runner
-[DELETE /api/V/runnerManagement/runner/\[RUNNERID\]]:/api/rundeck-api.html#delete-the-specified-runner
-[GET /api/V/runnerManagement/runners]:/api/rundeck-api.html#list-available-runners
-[POST /api/V/runnerManagement/runners]:/api/rundeck-api.html#create-a-new-runner
-[GET /api/V/runnerManagement/tags]:/api/rundeck-api.html#list-all-known-tags
-[GET /api/V/runnerManagement/ui]:/api/rundeck-api.html#get-ui-info-for-runner-management
-[GET /api/V/runnerTag/searchTags]:/api/rundeck-api.html#list-tags-for-the-runner
+[GET /api/V/runnerManagement/checkPing/\[TOKEN\]]:/api/rundeck-api.md#check-a-ping-response
+[GET /api/V/runnerManagement/download/\[TOKEN\]]:/api/rundeck-api.md#download-runner-jar
+[POST /api/V/runnerManagement/runner/\[ID\]/ping]:/api/rundeck-api.md#ping-the-runner
+[POST /api/V/runnerManagement/runner/\[ID\]/regenerateCreds]:/api/rundeck-api.md#regenerate-credentials-for-the-runner
+[GET /api/V/runnerManagement/runner/\[ID\]/tags]:/api/rundeck-api.md#list-tags-for-the-runner
+[GET /api/V/runnerManagement/runner/\[RUNNERID\]]:/api/rundeck-api.md#get-runner-information
+[POST /api/V/runnerManagement/runner/\[RUNNERID\]]:/api/rundeck-api.md#update-the-runner
+[DELETE /api/V/runnerManagement/runner/\[RUNNERID\]]:/api/rundeck-api.md#delete-the-specified-runner
+[GET /api/V/runnerManagement/runners]:/api/rundeck-api.md#list-available-runners
+[POST /api/V/runnerManagement/runners]:/api/rundeck-api.md#create-a-new-runner
+[GET /api/V/runnerManagement/tags]:/api/rundeck-api.md#list-all-known-tags
+[GET /api/V/runnerManagement/ui]:/api/rundeck-api.md#get-ui-info-for-runner-management
+[GET /api/V/runnerTag/searchTags]:/api/rundeck-api.md#list-tags-for-the-runner


### PR DESCRIPTION
using link to `.html` path causes it to be treated as absolute url, but using `.md` resolves to the correct result.