### PR TITLE
H2 defaults

### DIFF
--- a/docs/administration/configuration/database/index.md
+++ b/docs/administration/configuration/database/index.md
@@ -30,7 +30,7 @@ You specify the `dataSource.` configuration properties.
 Here is the default, set up for the default embedded H2 database:
 
 ```properties
-dataSource.url = jdbc:h2:file:/var/lib/rundeck/data/grailsdb;MVCC=true
+dataSource.url = jdbc:h2:file:/var/lib/rundeck/data/rundeckdb;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=MONTH,HOUR,MINUTE,YEAR,SECONDS
 ```
 
 `dataSource.dbCreate` specifies how the behavior that Hibernate should take when it

--- a/docs/administration/configuration/docker.md
+++ b/docs/administration/configuration/docker.md
@@ -137,7 +137,7 @@ the container.
 
 `RUNDECK_DATABASE_URL`
 
-Defaults to `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. The default configuration utilizes an h2 file for data storage.
+Defaults to `jdbc:h2:file:/home/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE`. The default configuration utilizes an h2 file for data storage.
 
 `RUNDECK_DATABASE_MIGRATE_ONSTART`
 


### PR DESCRIPTION
Update h2 defaults with relevant values (MVCC has been removed from H2 long time ago and this option will cause failures to start)
I copied the new defaults from the current rundeck release.