### PR TITLE
add script-command-plugin to list

### DIFF
--- a/docs/administration/runner/runner-remoteplugins.md
+++ b/docs/administration/runner/runner-remoteplugins.md
@@ -87,6 +87,7 @@ The following plugins are available in the next generation Runners:
 - Kubernetes-InlineScript-Step
 - SQLRunnerNodeStepPlugin
 - vmware-vm-powerops
+- script-file-command
 - filetransfer
 
 @tab Workflow Steps


### PR DESCRIPTION
Added support for `script-command-plugin` to the Enterprise Runner:

![Screenshot 2023-12-19 at 3 35 16 PM](https://github.com/rundeck/docs/assets/11511251/f8621062-a0ed-479c-a1d5-a0bea20e954f)
