### PR TITLE
renaming thycotic to delinea

### DIFF
--- a/docs/manual/key-storage/storage-plugins/thycotic-storage.md
+++ b/docs/manual/key-storage/storage-plugins/thycotic-storage.md
@@ -1,18 +1,18 @@
-# Thycotic Storage Plugin (Enterprise)
+# Delinea Storage Plugin (Enterprise)
 
 :::enterprise
 :::
 
-Delinea (formerly Thycotic) is a leader in Privileged Access Management solutions providing cloud ready, easy to use security solutions across the complete privileged access surface.  A centralized password management system provides visibility and control to protect privileges from attack.  Thycotic's solution is built for the Enterprise to enforce strong password business policies and prevent data breaches.  [Read more about their solution here](https://thycotic.com/solutions/enterprise-password-management/).
+Delinea (formerly Thycotic) is a leader in Privileged Access Management solutions providing cloud ready, easy to use security solutions across the complete privileged access surface.  A centralized password management system provides visibility and control to protect privileges from attack.  Delinea's solution is built for the Enterprise to enforce strong password business policies and prevent data breaches.  [Read more about their solution here](https://delinea.com/products/secret-server).
 
-Process Automation users have access to the Thycotic Storage Plugin which can be used to access password/key data stored in a Thycotic Secret Server.
+Process Automation users have access to the Delinea Storage Plugin which can be used to access password/key data stored in a Delinea Secret Server.
 
 ## Configuration
 
 ::: tabs
 @tab GUI Config
 
-Use the following steps to configure the Thycotic plugin for key storage:
+Use the following steps to configure the Delinea plugin for key storage:
 
 1. Navigate to the System Menu (gear icon in the upper right).
 2. Click on **Key Storage**:
@@ -23,24 +23,24 @@ Use the following steps to configure the Thycotic plugin for key storage:
 
 Fill in the fields for the integration as necessary:
 
-* **Key Storage Path**: The path in the Runbook Automation storage tree to apply the plugin. If `keys` is specified, then all keys and directories added to Key Storage will also be added to Thycotic.
+* **Key Storage Path**: The path in the Runbook Automation storage tree to apply the plugin. If `keys` is specified, then all keys and directories added to Key Storage will also be added to Delinea.
 * **Remove Path Prefix**: By default, the storage plugin will be invoked using the full path that is requested. If set to true, the path used when invoking the storage plugin would not include the prefix. It is **recommended to set this to true**. If set to false, keys will not be displayed unless an existing directory is specified in Runbook Automation.
-* **Username** (Required): Username for an account in Thycotic with access to the secrets that will be used into Runbook Automation.
-* **Password** (Required): The password for the account in Thycotic with access to the secrets that will be used into Runbook Automation.
-* **Address** (Required): The base URL for the secret server account where the secrets should be saved. For example, `https://example.secretservercloud.com`. If using Thycotic on-premises, the address must be appended with `/SecretServer`, so your full URL will be `https://example.yourdomain.com/SecretServer`. 
-* **Allow Self Signed Certificate**: Set to true if a self-signed certificate will be used to access the Thycotic server. 
-* **Maximum resources allowed to retrieve** This value allows the user to customize the number of resources to retrieve from thycotic.
-* **Domain**: Fully qualified domain name is using an Active Directory account for integrating with Thycotic.
+* **Username** (Required): Username for an account in Delinea with access to the secrets that will be used into Runbook Automation.
+* **Password** (Required): The password for the account in Delinea with access to the secrets that will be used into Runbook Automation.
+* **Address** (Required): The base URL for the secret server account where the secrets should be saved. For example, `https://example.secretservercloud.com`. If using Delinea on-premises, the address must be appended with `/SecretServer`, so your full URL will be `https://example.yourdomain.com/SecretServer`. 
+* **Allow Self Signed Certificate**: Set to true if a self-signed certificate will be used to access the Delinea server. 
+* **Maximum resources allowed to retrieve** This value allows the user to customize the number of resources to retrieve from Delinea.
+* **Domain**: Fully qualified domain name is using an Active Directory account for integrating with Delinea.
 
 Below is an example configuration, which can be configured using the *System Configuration* module. Add each setting as a configuration entry.
 
-![Thycotic Configuration](/assets/img/keystorage-thycotic-config.png)<br>
+![Delinea Configuration](/assets/img/keystorage-thycotic-config.png)<br>
 
 Once the configuration is set, click on **Save** to add it to the list of configured storage integrations.
 
 Click on **Save** to commit the configuration.
 
-In the **Keys** tab, the directory defined in the **Path Prefix** should now be visible. Click into this directory to begin navigating the secrets from Thycotic.
+In the **Keys** tab, the directory defined in the **Path Prefix** should now be visible. Click into this directory to begin navigating the secrets from Delinea.
 
 @tab rundeck-config.properties
 
@@ -60,9 +60,9 @@ rundeck.storage.provider.[index].config.allowSelfSignedCert=true
 
 :::
 
-## Thycotic through Enterprise Runner
+## Delinea through Enterprise Runner
 
-The [Enterprise Runner](/administration/runner/runner-intro.html) can be used to integrate with Thycotic Secret Server. This is useful when Thycotic is hosted in an environment that is not directly accessible from Runbook Automation.
+The [Enterprise Runner](/administration/runner/runner-intro.html) can be used to integrate with Delinea Secret Server. This is useful when Delinea is hosted in an environment that is not directly accessible from Runbook Automation.
 
 The following provides examples of how to configure the Enterprise Runner to connect to Secret Server:
 


### PR DESCRIPTION
Thycotic became Delinea in 2022 so our documentation (and plugin) should be renamed accordingly.