### PR TITLE
Update aws.md

### DIFF
--- a/docs/manual/projects/resource-model-sources/aws.md
+++ b/docs/manual/projects/resource-model-sources/aws.md
@@ -105,7 +105,7 @@ A few of the most common Node Executors are [SSH](/manual/projects/node-executio
 With EC2's, there is also the option to use [AWS's Systems Manager (SSM)](/manual/projects/node-execution/aws-ssm.html#description).
 
 In order to specify a Node Executor for _all_ EC2's, add the associated Node Executor properties to the **Mapping Params** field.  For example, to use SSH:<br>
-`ssh-keypath.default=keys/us-west-1-privKey;username.default=ubuntu`
+`ssh-key-storage-path.default=keys/us-west-1-privKey;username.default=ubuntu`
 
 Or, to use SSM:<br>
 `ssm-accessKeyId.default=MY_AWS_ACCESS_KEY;ssm-secretKey.default=keys/aws_access_key`


### PR DESCRIPTION
From a value standpoint, highlighting a property such as "ssh-key-storage-path.default" that relies on our built-in keystorage plugin feels like a more common use case than the previous one which relies on a key located in the filesystem.