### PR TITLE
RUN-2752: Added notes about malformed json response

### DIFF
--- a/docs/manual/projects/resource-model-sources/servicenow.md
+++ b/docs/manual/projects/resource-model-sources/servicenow.md
@@ -104,8 +104,9 @@ osFamily.default=unix
 ```
 
 ## Notes
-The API sometimes returns incomplete or malformed JSON data due to timeouts caused by processing large amounts of information. This can be indicated by an error message within the JSON response. To fix this, you can adjust a setting in ServiceNow to increase the timeout duration.
-By default is 60 seconds.
+The ServiceNow API sometimes returns incomplete or malformed JSON data due to timeouts caused by processing large amounts of information. This can be indicated by an error message within the JSON response. To fix this, you can adjust a setting in ServiceNow to increase the timeout duration.
+
+The ServiceNow default is 60 seconds.  Increasing the value may help address this timeout issue.
 
 ```
 System Definition > Transaction Quota Rules > REST Table API request timeout

--- a/docs/manual/projects/resource-model-sources/servicenow.md
+++ b/docs/manual/projects/resource-model-sources/servicenow.md
@@ -102,3 +102,11 @@ In the case only the default value exists, this fixed value are going to be set.
 ```
 osFamily.default=unix
 ```
+
+## Notes
+The API sometimes returns incomplete or malformed JSON data due to timeouts caused by processing large amounts of information. This can be indicated by an error message within the JSON response. To fix this, you can adjust a setting in ServiceNow to increase the timeout duration.
+By default is 60 seconds.
+
+```
+System Definition > Transaction Quota Rules > REST Table API request timeout
+```


### PR DESCRIPTION
## ⛔️ Ticket
https://pagerduty.atlassian.net/browse/RUN-2752

## ✅ Description
When ServiceNow sends a malformed json response it can be fixed adjusting this config:

System Definition > Transaction Quota Rules > REST Table API request timeout