### PR TITLE
RUN-2836: Runner - Added runner override tmp directory - Docs

### DIFF
--- a/docs/administration/runner/runner-config.md
+++ b/docs/administration/runner/runner-config.md
@@ -33,4 +33,15 @@ java -Dmicronaut.http.client.proxy-type=http -Dmicronaut.http.client.proxy-addre
 
 [Runner APIs](/api#runner-management) are available to create, edit, download, and delete Runners.
 
+## Override temporary directory
 
+To override the temporary directory used by the Runner, add these parameters when starting it.
+
+`runner.rundeck.overrideTempDir:` 'true' to override the temporary directory, or 'false' to retain the default directory '/temp'.
+
+`runner.dirs.tmp:` the new temporary directory.
+
+Example:
+```
+java -Drunner.rundeck.overrideTempDir=true -Drunner.dirs.tmp=/your/custom/dir -jar runner.jar
+```


### PR DESCRIPTION
## Ticket
https://pagerduty.atlassian.net/browse/RUN-2836

## Description
To override the temporary directory used by the Runner, these parameters must be added when starting it.

runner.rundeck.overrideTempDir: 'true' to override the temporary directory, or 'false' to retain the default directory '/temp'.

runner.dirs.tmp: the new temporary directory.

Example:

`java -Drunner.rundeck.overrideTempDir=true -Drunner.dirs.tmp=/your/custom/dir -jar pd-runner.jar`