### PR TITLE
Update configuring.md

### DIFF
--- a/docs/administration/configuration/plugins/configuring.md
+++ b/docs/administration/configuration/plugins/configuring.md
@@ -378,14 +378,14 @@ Example:
 
 ```properties
 rundeck.storage.provider.1.type=db
-rundeck.storage.provider.1.path=/keys
+rundeck.storage.provider.1.path=keys
 
 rundeck.storage.provider.2.type=file
-rundeck.storage.provider.2.path=/keys/local
+rundeck.storage.provider.2.path=keys/local
 rundeck.storage.provider.2.config.baseDir=/var/local/rundeck
 
-rundeck.storage.provider.3.type=vault-plugin
-rundeck.storage.provider.3.path=/keys/vault
+rundeck.storage.provider.3.type=vault-storage
+rundeck.storage.provider.3.path=keys/vault
 rundeck.storage.provider.3.removePathPrefix=true
 ```
 


### PR DESCRIPTION
Updates in the example code block for _Using Multiple Storage Plugins_, one because based on newly installed RD server, the forward slash `/` is no longer present, and two because the `type=vault-plugin` does not work and should be set to `vault-storage` instead.