### PR TITLE
RUN-3515: Create CVE-2023-0833.md

### DIFF
--- a/docs/history/cves/CVE-2023-0833.md
+++ b/docs/history/cves/CVE-2023-0833.md
@@ -1,0 +1,16 @@
+---
+order: 51
+---
+
+# CVE-2023-0833
+
+## Issue in okhttp:3.14.9
+
+::: danger FALSE POSITIVE
+ Rundeck and Runbook Automation are not vulnerable to this CVE.
+:::
+
+[CVE-2023-0833](https://nvd.nist.gov/vuln/detail/CVE-2023-0833)
+
+This vulnerability allows an authenticated attacker to potentially access information outside their regular permissions through an exception triggered by a header containing an illegal value. While the vulnerable OkHttp library was bundled in the agent.jar through transitive dependencies from Retrofit in the core project, neither runner-agent nor rundeckpro-runner use it, making this vulnerability unexploitable in our context. The vulnerability warning disappeared after upgrading to Retrofit 3.0.0, which includes OkHttp 4.x.
+


### PR DESCRIPTION
This CVE is a false positive: OkHttp was bundled in agent.jar because runner-agent's build.gradle uses the shadow plugin to create a fat JAR that includes all transitive dependencies, including the OkHttp library that comes via the Retrofit dependency from core. Neither runner-agent nor rundeckpro-runner plugin were using it, so the vulnerability wasn’t applicable in our case. Furthermore, the CVE disappeared when retrofit was updated.