### PR TITLE
RUN-3601: Create false positive notice for CVE-2025-48924

### DIFF
--- a/docs/history/cves/CVE-2025-48924.md
+++ b/docs/history/cves/CVE-2025-48924.md
@@ -1,0 +1,15 @@
+---
+order: 51
+---
+
+# CVE-2025-48924
+
+## Issue in Apache Commons Lang
+
+::: danger FALSE POSITIVE
+ Rundeck and Runbook Automation are not vulnerable to this CVE.
+:::
+
+[CVE-2025-48924](https://nvd.nist.gov/vuln/detail/CVE-2025-48924) describes an Uncontrolled Recursion vulnerability in Apache Commons Lang. This issue affects commons-lang:commons-lang versions 2.0 to 2.6, and org.apache.commons:commons-lang3 versions 3.0 before 3.18.0. The vulnerability is present in the `ClassUtils.getClass(...)` method, which can throw a `StackOverflowError` on very long inputs. Since errors of this type are typically not handled, this could cause an application to stop unexpectedly. The recommended mitigation is to upgrade to version 3.18.0 or later.
+
+After review, we have confirmed that neither Rundeck nor Runbook Automation use the affected `ClassUtils.getClass(...)` method, so this vulnerability does not impact our products.


### PR DESCRIPTION
Neither rundeck nor rundeckpro use the method mentioned by CVE-2025-48924