### PR TITLE
Fixed key storage path - group-project-full.md

### DIFF
--- a/docs/learning/howto/acls/group-project-full.md
+++ b/docs/learning/howto/acls/group-project-full.md
@@ -72,9 +72,8 @@ for:
   storage:
   - allow:
     - '*'
-    equals:
-      path: keys/project/prj-sandbox
-      name: .*
+    match:
+      path: keys/project/prj-sandbox(/.*)?
 context:
   project: prj-sandbox
 


### PR DESCRIPTION
Changed to     

match:
      path: keys/project/prj-sandbox(/.*)?

Removed 
    name: .*