### PR TITLE
RUN-3921: Add Automated PR Feed Generator for SaaS Development Updates

### DIFF
--- a/PR-FEED-README.md
+++ b/PR-FEED-README.md
@@ -93,7 +93,7 @@ npm run pr-feed -- --days=7
 npm run pr-feed -- --include-section="Customer Summary"
 
 # Different repository
-node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck
+node ./docs/.vuepress/pr-feed.mjs --owner=rundeck --repo=rundeck
 ```
 
 ### Command-Line Options
@@ -239,17 +239,17 @@ If you see prefixes that weren't removed, they may not match this pattern.
 ### Label Filtering
 Use different labels:
 ```bash
-node ./docs/.vuepress/generate-pr-feed.mjs --labels feature bugfix enhancement
+node ./docs/.vuepress/pr-feed.mjs --labels feature bugfix enhancement
 ```
 
 ### Different Repository
 ```bash
-node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck --days=14
+node ./docs/.vuepress/pr-feed.mjs --owner=rundeck --repo=rundeck --days=14
 ```
 
 ### Output Location
 ```bash
-node ./docs/.vuepress/generate-pr-feed.mjs --output-dir=./docs/some-other-location
+node ./docs/.vuepress/pr-feed.mjs --output-dir=./docs/some-other-location
 ```
 
 ## Implementation Notes

--- a/PR-FEED-README.md
+++ b/PR-FEED-README.md
@@ -1,15 +1,17 @@
 # PR Feed Generator
 
-This script generates RSS/Atom feeds and markdown pages from recently merged pull requests in the private rundeckpro repository. It's designed to be run as part of the SaaS release process to keep customers informed about development updates deployed to the Runbook Automation SaaS platform.
+This script generates RSS/Atom feeds and markdown pages from recently merged pull requests in both the Rundeck repositories. It's designed to be run as part of the SaaS release process to keep customers informed about development updates deployed to the Runbook Automation SaaS platform.
 
 ## Use Case
 
-**SaaS Release Communication**: The Runbook Automation team releases to SaaS approximately weekly (and sometimes more frequently for urgent updates). These changes come from both the public `rundeck` repo and the private `rundeckpro` repo. Since customers can see public repo changes but not private ones, this tool captures and communicates the full scope of updates deployed to the SaaS platform.
+**SaaS Release Communication**: The Runbook Automation team releases to SaaS approximately weekly (and sometimes more frequently for urgent updates). These changes come from both the public `rundeck/rundeck` repo and the private `rundeckpro/rundeckpro` repo. Since customers can see public repo changes but not private ones, this tool captures and communicates the full scope of updates deployed to the SaaS platform.
 
 ## Features
 
-- ✅ Fetches merged PRs from private `rundeckpro/rundeckpro` repository
-- ✅ Filters PRs with the `release-notes/include` label
+- ✅ Fetches merged PRs from **both** repositories:
+  - **Private**: `rundeckpro/rundeckpro` (filtered by `release-notes/include` label)
+  - **Public**: `rundeck/rundeck` (filtered by `release-notes/include` label)
+- ✅ Combines and sorts PRs by merge date across both repos
 - ✅ Automatically removes `RUN-XXXX` prefixes from PR titles (matching notes.mjs logic)
 - ✅ Generates both RSS 2.0 and Atom feeds
 - ✅ Creates VuePress-compatible markdown pages
@@ -110,14 +112,21 @@ node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck
 
 ### How It Works
 
+**Dual-Repository Fetching:**
+1. Fetches PRs from `rundeckpro/rundeckpro` (filtered by `release-notes/include` label)
+2. Fetches PRs from `rundeck/rundeck` (filtered by `release-notes/include` label)
+3. Combines results and sorts by merge date
+4. Removes duplicate PR titles if they appear in both repos (rare but possible)
+
 **Default Behavior (`--since-release`):**
 - Reads `pr-feed-config.json` to find last self-hosted release date
-- Shows all PRs merged after that date
+- Shows all PRs merged after that date from both repositories
 - No need to remember when you last ran it
 
 **Override with `--days`:**
 - Explicitly specify a lookback window
 - Useful for testing or special cases
+- Still fetches from both repos
 
 ## What Gets Generated
 

--- a/PR-FEED-README.md
+++ b/PR-FEED-README.md
@@ -1,0 +1,556 @@
+# PR Feed Generator
+
+This script generates RSS/Atom feeds and markdown pages from recently merged pull requests in the private rundeckpro repository. It's designed to be run as part of the SaaS release process to keep customers informed about development updates deployed to the Runbook Automation SaaS platform.
+
+## Use Case
+
+**SaaS Release Communication**: The Runbook Automation team releases to SaaS approximately weekly (and sometimes more frequently for urgent updates). These changes come from both the public `rundeck` repo and the private `rundeckpro` repo. Since customers can see public repo changes but not private ones, this tool captures and communicates the full scope of updates deployed to the SaaS platform.
+
+## Features
+
+- ✅ Fetches merged PRs from private `rundeckpro/rundeckpro` repository
+- ✅ Filters PRs with the `release-notes/include` label
+- ✅ Automatically removes `RUN-XXXX` prefixes from PR titles (matching notes.mjs logic)
+- ✅ Groups PRs by category for better organization
+- ✅ Generates both RSS 2.0 and Atom feeds
+- ✅ Creates VuePress-compatible markdown pages
+- ✅ Configurable lookback period (days)
+- ✅ Comprehensive error handling
+- ✅ Follows the same patterns as the existing notes.mjs script
+
+# Quick Start: PR Feed Generator
+
+## Initial Setup (One-time)
+
+1. Create `.env` file in project root:
+```bash
+cp .env.example .env
+```
+
+2. Edit `.env` and add your GitHub token:
+```env
+GH_API_TOKEN=ghp_your_actual_token_here
+```
+
+Get a token at: https://github.com/settings/tokens (needs `repo` scope)
+
+## Weekly Release Process
+
+**Simple approach - just run after each SaaS deployment:**
+
+```bash
+npm run pr-feed
+```
+
+The script will automatically show all PRs merged since the last self-hosted release (configured in `pr-feed-config.json`).
+
+Then commit the generated files:
+
+```bash
+git add docs/history/updates/recent-changes.md
+git add docs/.vuepress/public/feeds/
+git commit -m "SaaS deployment updates"
+git push
+```
+
+**Timing**: Run after deploying to production SaaS, typically weekly or as needed for urgent releases.
+
+### Updating the Release Baseline
+
+**Automatic**: When you run `notes.mjs` to create release notes, it automatically updates `pr-feed-config.json`:
+
+```bash
+node ./docs/.vuepress/notes.mjs --milestone=5.9.0
+# This automatically updates pr-feed-config.json with version 5.9.0 and today's date
+```
+
+**Manual** (if needed):
+
+```json
+{
+  "lastSelfHostedRelease": {
+    "version": "5.9.0",
+    "date": "2024-11-15",
+    "description": "Last self-hosted release version and date"
+  }
+}
+```
+
+This automatically resets the baseline - no need to track when you last ran the script!
+
+## Common Commands
+
+```bash
+# Default: Show PRs since last self-hosted release (from pr-feed-config.json)
+npm run pr-feed
+
+# Override to use time-based lookback instead
+npm run pr-feed -- --days=7
+
+# Include a specific section from PR descriptions (e.g., "Customer Summary")
+npm run pr-feed -- --include-section="Customer Summary"
+
+# Weekly lookback (ignores config file)
+npm run pr-feed:weekly
+
+# Monthly lookback (ignores config file)
+npm run pr-feed:monthly
+
+# Different repository
+node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck
+```
+
+### How It Works
+
+**Default Behavior (`--since-release`):**
+- Reads `pr-feed-config.json` to find last self-hosted release date
+- Shows all PRs merged after that date
+- No need to remember when you last ran it
+- Perfect for showing "everything new since the last versioned release"
+
+**Override with `--days`:**
+- Explicitly specify a lookback window
+- Useful for testing or special cases
+- Example: `--days=3` for just this week's urgent release
+
+## PR Description Best Practices
+
+To take advantage of the `--include-section` feature, structure your PR descriptions with clear sections:
+
+```markdown
+## Customer Summary
+Brief description of the change from a customer perspective.
+This section will be included in the feed if --include-section="Customer Summary" is used.
+
+## Technical Details
+Implementation specifics (not included in feed by default)
+
+## Testing
+Testing approach (not included in feed by default)
+```
+
+**Recommended sections for customer-facing PRs:**
+- `## Customer Summary` - User-facing description
+- `## Release Notes` - What to include in release notes
+- `## Breaking Changes` - Any breaking changes
+
+The script will automatically extract just the specified section and include it beneath the PR title in the generated feed.
+
+## What Gets Generated
+
+1. **Markdown Page**: `docs/history/updates/recent-changes.md`
+   - Viewable at: https://docs.rundeck.com/docs/history/updates/recent-changes.html
+   - This is a **complete standalone page** with context, subscription info, and the list of changes
+   - Completely regenerated each time (any manual edits will be overwritten)
+
+2. **RSS Feed**: `docs/.vuepress/public/feeds/development.xml`
+   - Subscribe at: https://docs.rundeck.com/feeds/development.xml
+
+3. **Atom Feed**: `docs/.vuepress/public/feeds/development-atom.xml`
+   - Subscribe at: https://docs.rundeck.com/feeds/development-atom.xml
+
+## Editing Static Content
+
+The generated `index.md` page is created from a [Nunjucks](https://mozilla.github.io/nunjucks/) template, similar to how `notes.mjs` works:
+
+**Template Location**: `docs/.vuepress/pr-feed.md.nj`
+
+To change the static parts of the page (headings, descriptions, subscription text, etc.), edit the template file directly. The template uses these variables:
+
+- `{{currentDate}}` - ISO timestamp for frontmatter
+- `{{lastUpdated}}` - Formatted date string (YYYY-MM-DD)
+- `{{periodDescription}}` - Description like "merged since the last self-hosted release"
+- `{{releaseInfo}}` - Optional release version and date info
+- `{{prs}}` - Array of PR objects with:
+  - `cleanTitle` - PR title with RUN-XXXX prefixes removed
+  - `mergedDate` - Formatted merge date
+  - `sectionContent` - Optional extracted section (if `--include-section` used)
+
+**Example edits**:
+- Change the main heading → Edit `# Recent Development Updates` in the template
+- Update subscription text → Edit the `## Subscribe to Updates` section
+- Modify the about section → Edit the `## About These Updates` section
+
+After editing the template, run `npm run pr-feed` to regenerate the page with your changes.
+
+## Troubleshooting
+
+**"GH_API_TOKEN not set"**
+→ Create `.env` file with your GitHub token
+
+**"Repository not found"**
+→ Check token has `repo` scope and access to rundeckpro/rundeckpro
+
+**"No PRs found"**
+→ Try longer timeframe: `--days=30` or check label filters
+
+## Full Documentation
+
+See `PR-FEED-README.md` for complete documentation.
+
+
+## Prerequisites
+
+1. **GitHub Personal Access Token**: You need a GitHub token with access to the private `rundeckpro/rundeckpro` repository.
+   - Create a token at: https://github.com/settings/tokens
+   - Required scopes: `repo` (Full control of private repositories)
+
+2. **Environment Variables**: Set up your `.env` file (see below)
+
+## Setup
+
+### 1. Create `.env` file
+
+Create a `.env` file in the root of the docs repository:
+
+```bash
+# GitHub API Token (required)
+# Get yours at: https://github.com/settings/tokens
+GH_API_TOKEN=ghp_your_token_here
+```
+
+**Important**: Never commit your `.env` file to version control. It should already be in `.gitignore`.
+
+### 2. Verify Dependencies
+
+All required dependencies are already in `package.json`:
+- `@octokit/rest` - GitHub API client
+- `dotenv` - Environment variable loading
+- `yargs` - Command-line argument parsing
+
+### 3. Configure Release Baseline
+
+The script uses `docs/.vuepress/pr-feed-config.json` to track the last self-hosted release:
+
+```json
+{
+  "lastSelfHostedRelease": {
+    "version": "5.8.0",
+    "date": "2024-10-15",
+    "description": "Last self-hosted release version and date"
+  }
+}
+```
+
+**Note**: This file is automatically updated when you run `notes.mjs` to create release notes. You rarely need to edit it manually.
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Generate feed for the last 7 days (default)
+npm run pr-feed
+
+# Generate feed for the last 7 days (explicit)
+npm run pr-feed:weekly
+
+# Generate feed for the last 30 days
+npm run pr-feed:monthly
+
+# Custom number of days
+node ./docs/.vuepress/generate-pr-feed.mjs --days=14
+```
+
+### Advanced Options
+
+```bash
+# Full command with all options
+node ./docs/.vuepress/generate-pr-feed.mjs \
+  --days=7 \
+  --owner=rundeckpro \
+  --repo=rundeckpro \
+  --labels release-notes/include \
+  --exclude-labels wip do-not-publish \
+  --max-prs=100
+```
+
+### Command-Line Options
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--days` | `-d` | *(none - uses config)* | Number of days to look back (overrides --since-release) |
+| `--since-release` | | `true` | Show PRs since last self-hosted release from config |
+| `--owner` | `-o` | `rundeckpro` | GitHub repository owner |
+| `--repo` | `-r` | `rundeckpro` | GitHub repository name |
+| `--labels` | `-l` | `release-notes/include` | Labels to include (space-separated) |
+| `--exclude-labels` | | `wip, do-not-publish` | Labels to exclude (space-separated) |
+| `--max-prs` | | `100` | Maximum number of PRs to fetch |
+| `--output-dir` | | `./docs/history/updates` | Output directory for markdown page |
+| `--include-section` | | *(none)* | Include specific section from PR body (e.g., "Customer Summary") |
+| `--help` | | | Show help message |
+
+### Output Format
+
+**Default**: Each PR is shown as a simple list item with title and date:
+```markdown
+- **Add webhook support for notifications** _(Nov 3, 2025)_
+- **Fix job execution timeout issue** _(Nov 2, 2025)_
+```
+
+**With `--include-section`**: If PRs have a specific markdown section (like `## Customer Summary`), you can include it:
+```bash
+npm run pr-feed -- --include-section="Customer Summary"
+```
+
+This will look for that section in each PR's description and include it below the title:
+```markdown
+- **Add webhook support for notifications** _(Nov 3, 2025)_
+  This adds support for sending notifications via webhooks to external systems.
+  
+- **Fix job execution timeout issue** _(Nov 2, 2025)_
+  Jobs will no longer timeout prematurely when running long operations.
+```
+
+## Output
+
+The script generates three files:
+
+## What Gets Generated
+
+The script generates three types of output:
+
+### 1. Markdown Page
+**Location**: `docs/history/updates/index.md`
+
+A complete, standalone VuePress page generated from the Nunjucks template at `docs/.vuepress/pr-feed.md.nj`:
+- Context about the updates and SaaS releases
+- Subscription links for RSS/Atom feeds
+- Information about the difference between SaaS and self-hosted
+- All PRs listed under "Recent Changes" heading
+- Rich formatting with cleaned PR titles and merge dates
+- Optional "Release Notes" sections from PR descriptions
+- Automatic reference to the last self-hosted release version
+
+**Note**: This file is regenerated on each run from the template. To modify the static content (headings, descriptions, etc.), edit `docs/.vuepress/pr-feed.md.nj`.
+
+### 2. RSS Feed
+**Location**: `docs/.vuepress/public/feeds/development.xml`
+**URL**: `https://docs.rundeck.com/feeds/development.xml`
+
+RSS 2.0 feed compatible with most feed readers.
+
+### 3. Atom Feed
+**Location**: `docs/.vuepress/public/feeds/development-atom.xml`
+**URL**: `https://docs.rundeck.com/feeds/development-atom.xml`
+
+Atom 1.0 feed for modern feed readers.
+
+## Integration with Release Process
+
+### SaaS Release Workflow
+
+1. **After SaaS deployment** (typically weekly or as needed):
+   ```bash
+   npm run pr-feed
+   ```
+
+2. **Review the generated files**:
+   - Check `docs/history/updates/recent-changes.md` for accuracy
+   - Verify PRs are properly categorized
+   - Ensure RUN-XXXX prefixes were removed from titles
+   - Edit manually if needed (the markdown is human-readable)
+
+3. **Commit and deploy to docs site**:
+   ```bash
+   git add docs/history/updates/recent-changes.md
+   git add docs/.vuepress/public/feeds/
+   git commit -m "SaaS deployment updates for [date]"
+   git push
+   ```
+
+4. **Build and deploy** your documentation site:
+   ```bash
+   npm run docs:build
+   ```
+
+The feeds will be automatically available at the public URLs, keeping SaaS customers informed of the latest platform updates.
+
+### Self-Hosted Release Workflow
+
+When creating a new self-hosted release:
+
+1. **Generate release notes** (this automatically updates the PR feed baseline):
+   ```bash
+   node ./docs/.vuepress/notes.mjs --milestone=5.9.0
+   # This updates pr-feed-config.json automatically
+   ```
+
+2. **Next time you run `pr-feed`**, it will show PRs merged after this release date
+   - No manual tracking needed
+   - The config file is your single source of truth
+
+## Customization
+
+### Label Filtering
+
+By default, the script only fetches PRs with the `release-notes/include` label from the `rundeckpro/rundeckpro` repository. This matches the logic used in the release notes generation.
+
+To use different labels:
+
+```bash
+# Multiple labels
+node ./docs/.vuepress/generate-pr-feed.mjs --labels feature bugfix enhancement
+
+# Single label
+node ./docs/.vuepress/generate-pr-feed.mjs --labels customer-visible
+```
+
+### Using with Different Repositories
+
+To generate feeds from other repositories:
+
+```bash
+# From the public rundeck/rundeck repo
+node ./docs/.vuepress/generate-pr-feed.mjs \
+  --owner=rundeck \
+  --repo=rundeck \
+  --days=14
+```
+
+### Modifying Output Location
+
+The default output location is `docs/history/updates/`. To change it:
+
+```bash
+node ./docs/.vuepress/generate-pr-feed.mjs \
+  --output-dir=./docs/some-other-location
+```
+
+## Troubleshooting
+
+### "Error: GH_API_TOKEN environment variable is not set"
+
+**Solution**: Create a `.env` file with your GitHub token (see Setup section).
+
+### "Repository not found or token lacks access"
+
+**Solutions**:
+- Verify your token has the `repo` scope
+- Check that you have access to the private repository
+- Ensure the owner/repo names are correct
+
+### "No PRs found matching criteria"
+
+**Possible causes**:
+- No PRs were merged in the specified time period
+- No PRs have the required labels
+- Try expanding the date range: `--days=14` or `--days=30`
+- Check your label filters with `--labels feature bugfix enhancement`
+
+### PR bodies contain broken markdown
+
+The script attempts to clean up PR descriptions, but some GitHub-specific markdown may not render perfectly. You can manually edit `docs/history/updates/recent-changes.md` after generation.
+
+### PR titles still have RUN-XXXX prefixes
+
+The script automatically removes `RUN-XXXX` prefixes using the regex pattern: `/^(RUN-[0-9]+\s*)+:?\s*/g`
+
+This matches the logic in `notes.md.nj`. If you see prefixes that weren't removed, check that they match this pattern.
+
+## Implementation Notes
+
+### Pattern Matching with notes.mjs
+
+This script follows the same patterns as `notes.mjs`:
+- Uses ES modules (`.mjs` extension)
+- Uses Octokit for GitHub API access
+- Loads environment variables with `dotenv`
+- Parses CLI arguments with `yargs`
+- Includes comprehensive error handling
+- Follows the same code style and structure
+
+### Key Differences from notes.mjs
+
+- **SaaS vs Self-Hosted**: Focuses on SaaS deployments vs version-specific self-hosted releases
+- **Time-based vs Milestone-based**: Uses recent time periods instead of specific version milestones
+- **Continuous updates**: Generates standalone pages for ongoing updates vs version release notes
+- **Customer communication**: Designed for SaaS customers via RSS/Atom feeds
+- **Category grouping**: Automatically groups PRs by type (features, bugfixes, etc.)
+- **Label filtering**: Uses `release-notes/include` for rundeckpro PRs (vs milestone-based)
+- **Shared logic**: Uses same PR title cleaning regex as notes.md.nj template
+- **Repository scope**: Captures private repo changes that aren't visible in public rundeck repo
+
+## Example Output
+
+### Sample Markdown Page
+
+```markdown
+---
+title: Recent Development Updates
+description: Latest merged changes from the Rundeck development team
+date: 2025-11-05T10:30:00.000Z
+feed: true
+article: true
+---
+
+# Recent Development Updates
+
+Last updated: **2025-11-05**
+
+## 🚀 Features
+
+### Add support for webhook notifications
+
+**Merged:** Nov 3, 2025 | **Author:** [@username](https://github.com/username) | **PR:** [#1234](https://github.com/rundeckpro/rundeckpro/pull/1234)
+
+**Labels:** `feature` `customer-visible`
+
+This PR adds webhook notification support...
+
+---
+
+## 🐛 Bug Fixes
+
+### Fix job execution timeout issue
+
+**Merged:** Nov 2, 2025 | **Author:** [@contributor](https://github.com/contributor) | **PR:** [#1233](https://github.com/rundeckpro/rundeckpro/pull/1233)
+
+**Labels:** `bugfix` `changelog`
+
+Resolves issue where job executions would timeout...
+
+---
+```
+
+## Maintenance
+
+### Updating Default Labels
+
+Edit the `--labels` default in `generate-pr-feed.mjs`:
+
+```javascript
+.option('labels', {
+  alias: 'l',
+  type: 'array',
+  description: 'Labels to filter PRs (space-separated)',
+  default: ['release-notes/include']  // Change this array as needed
+})
+```
+
+**Current default**: Only PRs with `release-notes/include` label are included.
+
+### Changing Feed Metadata
+
+Edit the CONFIG object in `generate-pr-feed.mjs`:
+
+```javascript
+const CONFIG = {
+  // ... other options
+  feedTitle: 'Your Custom Feed Title',
+  feedDescription: 'Your custom feed description',
+  siteUrl: 'https://your-site.com',
+};
+```
+
+## Support
+
+For issues or questions:
+1. Check this README first
+2. Review the existing `notes.mjs` implementation for reference
+3. Check GitHub API documentation: https://docs.github.com/en/rest
+4. Contact the documentation team
+
+## License
+
+This script is part of the Rundeck documentation project and follows the same license as the main repository.

--- a/PR-FEED-README.md
+++ b/PR-FEED-README.md
@@ -11,32 +11,34 @@ This script generates RSS/Atom feeds and markdown pages from recently merged pul
 - ✅ Fetches merged PRs from private `rundeckpro/rundeckpro` repository
 - ✅ Filters PRs with the `release-notes/include` label
 - ✅ Automatically removes `RUN-XXXX` prefixes from PR titles (matching notes.mjs logic)
-- ✅ Groups PRs by category for better organization
 - ✅ Generates both RSS 2.0 and Atom feeds
 - ✅ Creates VuePress-compatible markdown pages
-- ✅ Configurable lookback period (days)
+- ✅ Template-based content using Nunjucks (like notes.mjs)
 - ✅ Comprehensive error handling
-- ✅ Follows the same patterns as the existing notes.mjs script
-
-# Quick Start: PR Feed Generator
 
 ## Initial Setup (One-time)
 
-1. Create `.env` file in project root:
-```bash
-cp .env.example .env
-```
+1. **Create `.env` file** in project root:
+   ```bash
+   touch .env
+   ```
 
-2. Edit `.env` and add your GitHub token:
-```env
-GH_API_TOKEN=ghp_your_actual_token_here
-```
+2. **Add your GitHub token**:
+   ```env
+   GH_API_TOKEN=ghp_your_actual_token_here
+   ```
+   
+   Get a token at: https://github.com/settings/tokens (needs `repo` scope)
 
-Get a token at: https://github.com/settings/tokens (needs `repo` scope)
+3. **Verify Dependencies** - Already in `package.json`:
+   - `@octokit/rest` - GitHub API client
+   - `dotenv` - Environment variable loading
+   - `yargs` - Command-line argument parsing
+   - `nunjucks` - Template engine
 
 ## Weekly Release Process
 
-**Simple approach - just run after each SaaS deployment:**
+Run after each SaaS deployment:
 
 ```bash
 npm run pr-feed
@@ -47,13 +49,11 @@ The script will automatically show all PRs merged since the last self-hosted rel
 Then commit the generated files:
 
 ```bash
-git add docs/history/updates/recent-changes.md
+git add docs/history/updates/index.md
 git add docs/.vuepress/public/feeds/
-git commit -m "SaaS deployment updates"
+git commit -m "Update SaaS deployment feed"
 git push
 ```
-
-**Timing**: Run after deploying to production SaaS, typically weekly or as needed for urgent releases.
 
 ### Updating the Release Baseline
 
@@ -64,7 +64,7 @@ node ./docs/.vuepress/notes.mjs --milestone=5.9.0
 # This automatically updates pr-feed-config.json with version 5.9.0 and today's date
 ```
 
-**Manual** (if needed):
+**Manual** (if needed), edit `docs/.vuepress/pr-feed-config.json`:
 
 ```json
 {
@@ -76,29 +76,37 @@ node ./docs/.vuepress/notes.mjs --milestone=5.9.0
 }
 ```
 
-This automatically resets the baseline - no need to track when you last ran the script!
+## Command Reference
 
-## Common Commands
+### Basic Commands
 
 ```bash
-# Default: Show PRs since last self-hosted release (from pr-feed-config.json)
+# Default: Show PRs since last self-hosted release
 npm run pr-feed
 
-# Override to use time-based lookback instead
+# Override to use time-based lookback
 npm run pr-feed -- --days=7
 
-# Include a specific section from PR descriptions (e.g., "Customer Summary")
+# Include specific section from PR descriptions
 npm run pr-feed -- --include-section="Customer Summary"
-
-# Weekly lookback (ignores config file)
-npm run pr-feed:weekly
-
-# Monthly lookback (ignores config file)
-npm run pr-feed:monthly
 
 # Different repository
 node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck
 ```
+
+### Command-Line Options
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--days` | `-d` | *(uses config)* | Number of days to look back (overrides --since-release) |
+| `--since-release` | | `true` | Show PRs since last self-hosted release from config |
+| `--owner` | `-o` | `rundeckpro` | GitHub repository owner |
+| `--repo` | `-r` | `rundeckpro` | GitHub repository name |
+| `--labels` | `-l` | `release-notes/include` | Labels to include (space-separated) |
+| `--exclude-labels` | | `wip, do-not-publish` | Labels to exclude |
+| `--max-prs` | | `100` | Maximum number of PRs to fetch |
+| `--include-section` | | `Release Notes` | Include specific section from PR body |
+| `--help` | | | Show help message |
 
 ### How It Works
 
@@ -106,56 +114,49 @@ node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck
 - Reads `pr-feed-config.json` to find last self-hosted release date
 - Shows all PRs merged after that date
 - No need to remember when you last ran it
-- Perfect for showing "everything new since the last versioned release"
 
 **Override with `--days`:**
 - Explicitly specify a lookback window
 - Useful for testing or special cases
-- Example: `--days=3` for just this week's urgent release
-
-## PR Description Best Practices
-
-To take advantage of the `--include-section` feature, structure your PR descriptions with clear sections:
-
-```markdown
-## Customer Summary
-Brief description of the change from a customer perspective.
-This section will be included in the feed if --include-section="Customer Summary" is used.
-
-## Technical Details
-Implementation specifics (not included in feed by default)
-
-## Testing
-Testing approach (not included in feed by default)
-```
-
-**Recommended sections for customer-facing PRs:**
-- `## Customer Summary` - User-facing description
-- `## Release Notes` - What to include in release notes
-- `## Breaking Changes` - Any breaking changes
-
-The script will automatically extract just the specified section and include it beneath the PR title in the generated feed.
 
 ## What Gets Generated
 
-1. **Markdown Page**: `docs/history/updates/recent-changes.md`
-   - Viewable at: https://docs.rundeck.com/docs/history/updates/recent-changes.html
-   - This is a **complete standalone page** with context, subscription info, and the list of changes
-   - Completely regenerated each time (any manual edits will be overwritten)
+### 1. Markdown Page
+**Location**: `docs/history/updates/index.md`  
+**URL**: https://docs.rundeck.com/docs/history/updates/
 
-2. **RSS Feed**: `docs/.vuepress/public/feeds/development.xml`
-   - Subscribe at: https://docs.rundeck.com/feeds/development.xml
+A complete, standalone VuePress page with:
+- Context about the updates and SaaS releases
+- Subscription links for RSS/Atom feeds
+- Information about the difference between SaaS and self-hosted
+- All PRs listed under "Recent Changes" heading
+- Rich formatting with cleaned PR titles and merge dates
+- Optional "Release Notes" sections from PR descriptions
+- Automatic reference to the last self-hosted release version
 
-3. **Atom Feed**: `docs/.vuepress/public/feeds/development-atom.xml`
-   - Subscribe at: https://docs.rundeck.com/feeds/development-atom.xml
+**Note**: This file is completely regenerated on each run from the template. To modify static content, edit the template (see below).
+
+### 2. RSS Feed
+**Location**: `docs/.vuepress/public/feeds/development.xml`  
+**URL**: https://docs.rundeck.com/feeds/development.xml
+
+RSS 2.0 feed compatible with most feed readers.
+
+### 3. Atom Feed
+**Location**: `docs/.vuepress/public/feeds/development-atom.xml`  
+**URL**: https://docs.rundeck.com/feeds/development-atom.xml
+
+Atom 1.0 feed for modern feed readers.
 
 ## Editing Static Content
 
-The generated `index.md` page is created from a [Nunjucks](https://mozilla.github.io/nunjucks/) template, similar to how `notes.mjs` works:
+The generated `index.md` page is created from a Nunjucks template, similar to how `notes.mjs` works:
 
 **Template Location**: `docs/.vuepress/pr-feed.md.nj`
 
-To change the static parts of the page (headings, descriptions, subscription text, etc.), edit the template file directly. The template uses these variables:
+To change the static parts of the page (headings, descriptions, subscription text, etc.), edit the template file directly.
+
+### Template Variables
 
 - `{{currentDate}}` - ISO timestamp for frontmatter
 - `{{lastUpdated}}` - Formatted date string (YYYY-MM-DD)
@@ -166,390 +167,100 @@ To change the static parts of the page (headings, descriptions, subscription tex
   - `mergedDate` - Formatted merge date
   - `sectionContent` - Optional extracted section (if `--include-section` used)
 
-**Example edits**:
-- Change the main heading → Edit `# Recent Development Updates` in the template
-- Update subscription text → Edit the `## Subscribe to Updates` section
-- Modify the about section → Edit the `## About These Updates` section
-
 After editing the template, run `npm run pr-feed` to regenerate the page with your changes.
 
-## Troubleshooting
+## PR Description Best Practices
 
-**"GH_API_TOKEN not set"**
-→ Create `.env` file with your GitHub token
+Structure your PR descriptions with clear sections to take advantage of the `--include-section` feature:
 
-**"Repository not found"**
-→ Check token has `repo` scope and access to rundeckpro/rundeckpro
-
-**"No PRs found"**
-→ Try longer timeframe: `--days=30` or check label filters
-
-## Full Documentation
-
-See `PR-FEED-README.md` for complete documentation.
-
-
-## Prerequisites
-
-1. **GitHub Personal Access Token**: You need a GitHub token with access to the private `rundeckpro/rundeckpro` repository.
-   - Create a token at: https://github.com/settings/tokens
-   - Required scopes: `repo` (Full control of private repositories)
-
-2. **Environment Variables**: Set up your `.env` file (see below)
-
-## Setup
-
-### 1. Create `.env` file
-
-Create a `.env` file in the root of the docs repository:
-
-```bash
-# GitHub API Token (required)
-# Get yours at: https://github.com/settings/tokens
-GH_API_TOKEN=ghp_your_token_here
-```
-
-**Important**: Never commit your `.env` file to version control. It should already be in `.gitignore`.
-
-### 2. Verify Dependencies
-
-All required dependencies are already in `package.json`:
-- `@octokit/rest` - GitHub API client
-- `dotenv` - Environment variable loading
-- `yargs` - Command-line argument parsing
-
-### 3. Configure Release Baseline
-
-The script uses `docs/.vuepress/pr-feed-config.json` to track the last self-hosted release:
-
-```json
-{
-  "lastSelfHostedRelease": {
-    "version": "5.8.0",
-    "date": "2024-10-15",
-    "description": "Last self-hosted release version and date"
-  }
-}
-```
-
-**Note**: This file is automatically updated when you run `notes.mjs` to create release notes. You rarely need to edit it manually.
-
-## Usage
-
-### Basic Commands
-
-```bash
-# Generate feed for the last 7 days (default)
-npm run pr-feed
-
-# Generate feed for the last 7 days (explicit)
-npm run pr-feed:weekly
-
-# Generate feed for the last 30 days
-npm run pr-feed:monthly
-
-# Custom number of days
-node ./docs/.vuepress/generate-pr-feed.mjs --days=14
-```
-
-### Advanced Options
-
-```bash
-# Full command with all options
-node ./docs/.vuepress/generate-pr-feed.mjs \
-  --days=7 \
-  --owner=rundeckpro \
-  --repo=rundeckpro \
-  --labels release-notes/include \
-  --exclude-labels wip do-not-publish \
-  --max-prs=100
-```
-
-### Command-Line Options
-
-| Option | Alias | Default | Description |
-|--------|-------|---------|-------------|
-| `--days` | `-d` | *(none - uses config)* | Number of days to look back (overrides --since-release) |
-| `--since-release` | | `true` | Show PRs since last self-hosted release from config |
-| `--owner` | `-o` | `rundeckpro` | GitHub repository owner |
-| `--repo` | `-r` | `rundeckpro` | GitHub repository name |
-| `--labels` | `-l` | `release-notes/include` | Labels to include (space-separated) |
-| `--exclude-labels` | | `wip, do-not-publish` | Labels to exclude (space-separated) |
-| `--max-prs` | | `100` | Maximum number of PRs to fetch |
-| `--output-dir` | | `./docs/history/updates` | Output directory for markdown page |
-| `--include-section` | | *(none)* | Include specific section from PR body (e.g., "Customer Summary") |
-| `--help` | | | Show help message |
-
-### Output Format
-
-**Default**: Each PR is shown as a simple list item with title and date:
 ```markdown
-- **Add webhook support for notifications** _(Nov 3, 2025)_
-- **Fix job execution timeout issue** _(Nov 2, 2025)_
+## Release Notes
+Brief customer-facing description of the change.
+This will be included in the feed by default.
+
+## PR Details
+Implementation specifics and technical details.
+
+## Testing
+Testing approach and verification steps.
 ```
 
-**With `--include-section`**: If PRs have a specific markdown section (like `## Customer Summary`), you can include it:
-```bash
-npm run pr-feed -- --include-section="Customer Summary"
-```
-
-This will look for that section in each PR's description and include it below the title:
-```markdown
-- **Add webhook support for notifications** _(Nov 3, 2025)_
-  This adds support for sending notifications via webhooks to external systems.
-  
-- **Fix job execution timeout issue** _(Nov 2, 2025)_
-  Jobs will no longer timeout prematurely when running long operations.
-```
-
-## Output
-
-The script generates three files:
-
-## What Gets Generated
-
-The script generates three types of output:
-
-### 1. Markdown Page
-**Location**: `docs/history/updates/index.md`
-
-A complete, standalone VuePress page generated from the Nunjucks template at `docs/.vuepress/pr-feed.md.nj`:
-- Context about the updates and SaaS releases
-- Subscription links for RSS/Atom feeds
-- Information about the difference between SaaS and self-hosted
-- All PRs listed under "Recent Changes" heading
-- Rich formatting with cleaned PR titles and merge dates
-- Optional "Release Notes" sections from PR descriptions
-- Automatic reference to the last self-hosted release version
-
-**Note**: This file is regenerated on each run from the template. To modify the static content (headings, descriptions, etc.), edit `docs/.vuepress/pr-feed.md.nj`.
-
-### 2. RSS Feed
-**Location**: `docs/.vuepress/public/feeds/development.xml`
-**URL**: `https://docs.rundeck.com/feeds/development.xml`
-
-RSS 2.0 feed compatible with most feed readers.
-
-### 3. Atom Feed
-**Location**: `docs/.vuepress/public/feeds/development-atom.xml`
-**URL**: `https://docs.rundeck.com/feeds/development-atom.xml`
-
-Atom 1.0 feed for modern feed readers.
+**Default section**: `## Release Notes` is extracted by default. Make sure to include another section header (like `## PR Details`) to separate customer-facing content from internal details.
 
 ## Integration with Release Process
 
-### SaaS Release Workflow
+### SaaS Deployment
+1. Deploy to SaaS production
+2. Run `npm run pr-feed`
+3. Review generated `docs/history/updates/index.md`
+4. Commit and push changes
 
-1. **After SaaS deployment** (typically weekly or as needed):
-   ```bash
-   npm run pr-feed
-   ```
-
-2. **Review the generated files**:
-   - Check `docs/history/updates/recent-changes.md` for accuracy
-   - Verify PRs are properly categorized
-   - Ensure RUN-XXXX prefixes were removed from titles
-   - Edit manually if needed (the markdown is human-readable)
-
-3. **Commit and deploy to docs site**:
-   ```bash
-   git add docs/history/updates/recent-changes.md
-   git add docs/.vuepress/public/feeds/
-   git commit -m "SaaS deployment updates for [date]"
-   git push
-   ```
-
-4. **Build and deploy** your documentation site:
-   ```bash
-   npm run docs:build
-   ```
-
-The feeds will be automatically available at the public URLs, keeping SaaS customers informed of the latest platform updates.
-
-### Self-Hosted Release Workflow
-
-When creating a new self-hosted release:
-
-1. **Generate release notes** (this automatically updates the PR feed baseline):
-   ```bash
-   node ./docs/.vuepress/notes.mjs --milestone=5.9.0
-   # This updates pr-feed-config.json automatically
-   ```
-
-2. **Next time you run `pr-feed`**, it will show PRs merged after this release date
-   - No manual tracking needed
-   - The config file is your single source of truth
-
-## Customization
-
-### Label Filtering
-
-By default, the script only fetches PRs with the `release-notes/include` label from the `rundeckpro/rundeckpro` repository. This matches the logic used in the release notes generation.
-
-To use different labels:
+### Self-Hosted Release
+When creating a new self-hosted release, `notes.mjs` automatically updates the PR feed baseline:
 
 ```bash
-# Multiple labels
-node ./docs/.vuepress/generate-pr-feed.mjs --labels feature bugfix enhancement
-
-# Single label
-node ./docs/.vuepress/generate-pr-feed.mjs --labels customer-visible
+node ./docs/.vuepress/notes.mjs --milestone=5.9.0
+# Automatically updates pr-feed-config.json
 ```
 
-### Using with Different Repositories
-
-To generate feeds from other repositories:
-
-```bash
-# From the public rundeck/rundeck repo
-node ./docs/.vuepress/generate-pr-feed.mjs \
-  --owner=rundeck \
-  --repo=rundeck \
-  --days=14
-```
-
-### Modifying Output Location
-
-The default output location is `docs/history/updates/`. To change it:
-
-```bash
-node ./docs/.vuepress/generate-pr-feed.mjs \
-  --output-dir=./docs/some-other-location
-```
+Next time you run `npm run pr-feed`, it will show PRs merged after this release date.
 
 ## Troubleshooting
 
-### "Error: GH_API_TOKEN environment variable is not set"
+### "GH_API_TOKEN not set"
+Create `.env` file with your GitHub token (see Initial Setup).
 
-**Solution**: Create a `.env` file with your GitHub token (see Setup section).
-
-### "Repository not found or token lacks access"
-
-**Solutions**:
+### "Repository not found"
 - Verify your token has the `repo` scope
 - Check that you have access to the private repository
 - Ensure the owner/repo names are correct
 
-### "No PRs found matching criteria"
-
-**Possible causes**:
+### "No PRs found"
 - No PRs were merged in the specified time period
 - No PRs have the required labels
-- Try expanding the date range: `--days=14` or `--days=30`
-- Check your label filters with `--labels feature bugfix enhancement`
-
-### PR bodies contain broken markdown
-
-The script attempts to clean up PR descriptions, but some GitHub-specific markdown may not render perfectly. You can manually edit `docs/history/updates/recent-changes.md` after generation.
+- Try expanding the date range: `--days=30`
 
 ### PR titles still have RUN-XXXX prefixes
-
 The script automatically removes `RUN-XXXX` prefixes using the regex pattern: `/^(RUN-[0-9]+\s*)+:?\s*/g`
 
-This matches the logic in `notes.md.nj`. If you see prefixes that weren't removed, check that they match this pattern.
+If you see prefixes that weren't removed, they may not match this pattern.
+
+## Customization
+
+### Label Filtering
+Use different labels:
+```bash
+node ./docs/.vuepress/generate-pr-feed.mjs --labels feature bugfix enhancement
+```
+
+### Different Repository
+```bash
+node ./docs/.vuepress/generate-pr-feed.mjs --owner=rundeck --repo=rundeck --days=14
+```
+
+### Output Location
+```bash
+node ./docs/.vuepress/generate-pr-feed.mjs --output-dir=./docs/some-other-location
+```
 
 ## Implementation Notes
 
 ### Pattern Matching with notes.mjs
-
 This script follows the same patterns as `notes.mjs`:
 - Uses ES modules (`.mjs` extension)
+- Uses Nunjucks templates for content generation
 - Uses Octokit for GitHub API access
 - Loads environment variables with `dotenv`
 - Parses CLI arguments with `yargs`
-- Includes comprehensive error handling
 - Follows the same code style and structure
 
 ### Key Differences from notes.mjs
-
 - **SaaS vs Self-Hosted**: Focuses on SaaS deployments vs version-specific self-hosted releases
-- **Time-based vs Milestone-based**: Uses recent time periods instead of specific version milestones
-- **Continuous updates**: Generates standalone pages for ongoing updates vs version release notes
+- **Time/Release-based**: Uses recent time periods or release dates instead of specific milestones
+- **Continuous updates**: Generates standalone pages for ongoing updates
 - **Customer communication**: Designed for SaaS customers via RSS/Atom feeds
-- **Category grouping**: Automatically groups PRs by type (features, bugfixes, etc.)
-- **Label filtering**: Uses `release-notes/include` for rundeckpro PRs (vs milestone-based)
+- **Label filtering**: Uses `release-notes/include` for rundeckpro PRs
 - **Shared logic**: Uses same PR title cleaning regex as notes.md.nj template
-- **Repository scope**: Captures private repo changes that aren't visible in public rundeck repo
-
-## Example Output
-
-### Sample Markdown Page
-
-```markdown
----
-title: Recent Development Updates
-description: Latest merged changes from the Rundeck development team
-date: 2025-11-05T10:30:00.000Z
-feed: true
-article: true
----
-
-# Recent Development Updates
-
-Last updated: **2025-11-05**
-
-## 🚀 Features
-
-### Add support for webhook notifications
-
-**Merged:** Nov 3, 2025 | **Author:** [@username](https://github.com/username) | **PR:** [#1234](https://github.com/rundeckpro/rundeckpro/pull/1234)
-
-**Labels:** `feature` `customer-visible`
-
-This PR adds webhook notification support...
-
----
-
-## 🐛 Bug Fixes
-
-### Fix job execution timeout issue
-
-**Merged:** Nov 2, 2025 | **Author:** [@contributor](https://github.com/contributor) | **PR:** [#1233](https://github.com/rundeckpro/rundeckpro/pull/1233)
-
-**Labels:** `bugfix` `changelog`
-
-Resolves issue where job executions would timeout...
-
----
-```
-
-## Maintenance
-
-### Updating Default Labels
-
-Edit the `--labels` default in `generate-pr-feed.mjs`:
-
-```javascript
-.option('labels', {
-  alias: 'l',
-  type: 'array',
-  description: 'Labels to filter PRs (space-separated)',
-  default: ['release-notes/include']  // Change this array as needed
-})
-```
-
-**Current default**: Only PRs with `release-notes/include` label are included.
-
-### Changing Feed Metadata
-
-Edit the CONFIG object in `generate-pr-feed.mjs`:
-
-```javascript
-const CONFIG = {
-  // ... other options
-  feedTitle: 'Your Custom Feed Title',
-  feedDescription: 'Your custom feed description',
-  siteUrl: 'https://your-site.com',
-};
-```
-
-## Support
-
-For issues or questions:
-1. Check this README first
-2. Review the existing `notes.mjs` implementation for reference
-3. Check GitHub API documentation: https://docs.github.com/en/rest
-4. Contact the documentation team
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ Run the following with the milestone for the release. This will create the file 
 npm run notes -- --milestone=${1?milestone name} --draft
 ```
 
+## SaaS Development Updates Feed
+
+For generating RSS/Atom feeds and markdown pages showing recent PRs deployed to the SaaS platform (but not yet in self-hosted releases), see [PR-FEED-README.md](./PR-FEED-README.md).
+
+This feed automatically tracks changes since the last self-hosted release and is updated after each SaaS deployment:
+
+```bash
+npm run pr-feed
+```
+
+The feed is automatically updated when you create release notes - no manual configuration needed!
+
 ## Troubleshooting
 
 If you encounter errors running the site locally, follow these steps to ensure a clean environment and proper setup:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This feed automatically tracks changes since the last self-hosted release and is
 npm run pr-feed
 ```
 
-The feed is automatically updated when you create release notes - no manual configuration needed!
+The feed date range is automatically updated when you create release notes - no manual configuration needed!
 
 ## Troubleshooting
 

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -265,7 +265,7 @@ export default defineUserConfig({
           dateSorter(pageA.frontmatter.date, pageB.frontmatter.date)
       },
       icon: {
-        assets: "fontawesome"
+        assets: "fontawesome-with-brands",
       },
       components: {
         components: [

--- a/docs/.vuepress/generate-pr-feed.mjs
+++ b/docs/.vuepress/generate-pr-feed.mjs
@@ -264,10 +264,17 @@ function generateMarkdown(prs) {
   let releaseInfo = '';
   if (feedConfig && feedConfig.lastSelfHostedRelease && !argv.days) {
     const releaseVersion = feedConfig.lastSelfHostedRelease.version;
-    const releaseDate = new Date(feedConfig.lastSelfHostedRelease.date).toLocaleDateString('en-US', {
+    // Parse date as UTC to avoid timezone issues
+    const releaseDateParts = feedConfig.lastSelfHostedRelease.date.split('-');
+    const releaseDate = new Date(Date.UTC(
+      parseInt(releaseDateParts[0]), 
+      parseInt(releaseDateParts[1]) - 1, 
+      parseInt(releaseDateParts[2])
+    )).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
-      day: 'numeric'
+      day: 'numeric',
+      timeZone: 'UTC'
     });
     periodDescription = `merged since the last self-hosted release`;
     releaseInfo = ` of [${releaseVersion}](/history/5_x/version-${releaseVersion}.md) on ${releaseDate}`;

--- a/docs/.vuepress/generate-pr-feed.mjs
+++ b/docs/.vuepress/generate-pr-feed.mjs
@@ -1,0 +1,622 @@
+/**
+ * generate-pr-feed.mjs
+ * 
+ * Generates RSS/Atom feeds and markdown pages from recently merged PRs
+ * in the private rundeckpro repository. Designed for weekly release updates.
+ * 
+ * Usage:
+ *   node generate-pr-feed.mjs --days=7 [--owner=rundeckpro] [--repo=rundeckpro]
+ * 
+ * Environment Variables:
+ *   GH_API_TOKEN - GitHub API token with access to private repos
+ */
+
+import fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { Octokit } from '@octokit/rest';
+import dotenv from 'dotenv';
+import _yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import nunjucks from 'nunjucks';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load the template
+const template = fs.readFileSync('./docs/.vuepress/pr-feed.md.nj');
+
+// Load environment variables
+dotenv.config();
+
+// Parse command line arguments
+const argv = _yargs(hideBin(process.argv))
+  .option('days', {
+    alias: 'd',
+    type: 'number',
+    description: 'Number of days to look back for merged PRs (overrides --since-release)',
+  })
+  .option('since-release', {
+    type: 'boolean',
+    description: 'Show PRs since last self-hosted release (from pr-feed-config.json)',
+    default: true
+  })
+  .option('owner', {
+    alias: 'o',
+    type: 'string',
+    description: 'GitHub repository owner',
+    default: 'rundeckpro'
+  })
+  .option('repo', {
+    alias: 'r',
+    type: 'string',
+    description: 'GitHub repository name',
+    default: 'rundeckpro'
+  })
+  .option('output-dir', {
+    type: 'string',
+    description: 'Output directory for markdown page',
+    default: path.join(__dirname, '../history/updates')
+  })
+  .option('labels', {
+    alias: 'l',
+    type: 'array',
+    description: 'Labels to filter PRs (space-separated)',
+    default: ['release-notes/include']
+  })
+  .option('exclude-labels', {
+    type: 'array',
+    description: 'Labels to exclude from results',
+    default: ['wip', 'do-not-publish']
+  })
+  .option('max-prs', {
+    type: 'number',
+    description: 'Maximum number of PRs to fetch',
+    default: 100
+  })
+  .option('include-section', {
+    type: 'string',
+    description: 'Include a specific section from PR body (e.g., "Customer Summary")',
+  })
+  .help()
+  .argv;
+
+/**
+ * Load the PR feed configuration
+ * @returns {Object} Configuration object with lastSelfHostedRelease info
+ */
+function loadConfig() {
+  const configPath = path.join(__dirname, 'pr-feed-config.json');
+  try {
+    const configData = fs.readFileSync(configPath, 'utf8');
+    return JSON.parse(configData);
+  } catch (error) {
+    console.warn(`Warning: Could not load pr-feed-config.json: ${error.message}`);
+    console.warn('Falling back to --days parameter.');
+    return null;
+  }
+}
+
+/**
+ * Calculate the "since" date based on config or --days parameter
+ * @param {Object|null} config - Config object from pr-feed-config.json
+ * @returns {Date} Date to use as cutoff for PRs
+ */
+function calculateSinceDate(config) {
+  // If --days is explicitly provided, use it
+  if (argv.days) {
+    const since = new Date();
+    since.setDate(since.getDate() - argv.days);
+    console.log(`Using explicit --days=${argv.days} parameter`);
+    return since;
+  }
+  
+  // If --since-release is true and config exists, use release date
+  if (argv['since-release'] && config && config.lastSelfHostedRelease) {
+    const releaseDate = new Date(config.lastSelfHostedRelease.date);
+    console.log(`Using last self-hosted release: ${config.lastSelfHostedRelease.version} (${config.lastSelfHostedRelease.date})`);
+    return releaseDate;
+  }
+  
+  // Fallback to 7 days
+  const since = new Date();
+  since.setDate(since.getDate() - 7);
+  console.log('No config found, falling back to 7 days');
+  return since;
+}
+
+// Load configuration
+const feedConfig = loadConfig();
+
+// Configuration
+const CONFIG = {
+  owner: argv.owner,
+  repo: argv.repo,
+  sinceDate: calculateSinceDate(feedConfig),
+  includeLabels: argv.labels,
+  excludeLabels: argv['exclude-labels'],
+  maxPRs: argv['max-prs'],
+  outputDir: argv['output-dir'],
+  feedsDir: path.join(__dirname, '../.vuepress/public/feeds'),
+  siteUrl: 'https://docs.rundeck.com',
+  feedTitle: 'Rundeck Development Updates',
+  feedDescription: 'Recent merged pull requests and development updates from Rundeck'
+};
+
+/**
+ * Initialize Octokit with GitHub API token
+ */
+function initOctokit() {
+  const token = process.env.GH_API_TOKEN;
+  
+  if (!token) {
+    console.error('Error: GH_API_TOKEN environment variable is not set.');
+    console.error('Please set your GitHub API token to access private repositories.');
+    process.exit(1);
+  }
+  
+  return new Octokit({ auth: token });
+}
+
+/**
+ * Fetch recently merged PRs from GitHub
+ * @param {Octokit} octokit - GitHub API client
+ * @returns {Promise<Array>} Array of PR objects
+ */
+async function fetchRecentPRs(octokit) {
+  const since = CONFIG.sinceDate;
+  
+  console.log(`Fetching PRs from ${CONFIG.owner}/${CONFIG.repo}...`);
+  console.log(`Looking for PRs merged after ${since.toISOString().split('T')[0]}`);
+  
+  try {
+    // Use paginate to get all PRs if more than per_page limit
+    const pullRequests = await octokit.paginate(
+      octokit.pulls.list,
+      {
+        owner: CONFIG.owner,
+        repo: CONFIG.repo,
+        state: 'closed',
+        sort: 'updated',
+        direction: 'desc',
+        per_page: 100
+      },
+      (response) => response.data.slice(0, CONFIG.maxPRs)
+    );
+
+    console.log(`Retrieved ${pullRequests.length} closed PRs`);
+
+    // Filter for merged PRs within the date range
+    const mergedPRs = pullRequests.filter(pr => {
+      if (!pr.merged_at) return false;
+      
+      const mergedDate = new Date(pr.merged_at);
+      if (mergedDate <= since) return false;
+      
+      // Check for included labels
+      const hasIncludedLabel = CONFIG.includeLabels.length === 0 || 
+        pr.labels.some(label => CONFIG.includeLabels.includes(label.name));
+      
+      // Check for excluded labels
+      const hasExcludedLabel = pr.labels.some(label => 
+        CONFIG.excludeLabels.includes(label.name)
+      );
+      
+      return hasIncludedLabel && !hasExcludedLabel;
+    });
+
+    console.log(`Found ${mergedPRs.length} merged PRs matching criteria`);
+    
+    // Sort by merge date, most recent first
+    mergedPRs.sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
+    
+    return mergedPRs;
+    
+  } catch (error) {
+    console.error(`Error fetching PRs: ${error.message}`);
+    if (error.status === 404) {
+      console.error(`Repository ${CONFIG.owner}/${CONFIG.repo} not found or token lacks access.`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Group PRs by label categories
+ * @param {Array} prs - Array of PR objects
+ * @returns {Object} PRs grouped by category
+ */
+function groupPRsByCategory(prs) {
+  const categories = {
+    features: [],
+    bugfixes: [],
+    enhancements: [],
+    other: []
+  };
+  
+  prs.forEach(pr => {
+    const labels = pr.labels.map(l => l.name.toLowerCase());
+    
+    if (labels.includes('feature')) {
+      categories.features.push(pr);
+    } else if (labels.includes('bugfix') || labels.includes('bug')) {
+      categories.bugfixes.push(pr);
+    } else if (labels.includes('enhancement') || labels.includes('improvement')) {
+      categories.enhancements.push(pr);
+    } else {
+      categories.other.push(pr);
+    }
+  });
+  
+  return categories;
+}
+
+/**
+ * Generate markdown content for VuePress
+ * @param {Array} prs - Array of PR objects
+ * @returns {string} Markdown content
+ */
+function generateMarkdown(prs) {
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0];
+  
+  // Determine what to show in the description
+  let periodDescription;
+  let releaseInfo = '';
+  if (feedConfig && feedConfig.lastSelfHostedRelease && !argv.days) {
+    const releaseVersion = feedConfig.lastSelfHostedRelease.version;
+    const releaseDate = new Date(feedConfig.lastSelfHostedRelease.date).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+    periodDescription = `merged since the last self-hosted release`;
+    releaseInfo = ` of [${releaseVersion}](/history/5_x/version-${releaseVersion}.md) on ${releaseDate}`;
+  } else {
+    const daysDiff = Math.floor((now - CONFIG.sinceDate) / (1000 * 60 * 60 * 24));
+    periodDescription = `merged in the last ${daysDiff} days`;
+  }
+  
+  // Prepare PR data for template
+  const prData = prs.map(pr => {
+    const mergedDate = new Date(pr.merged_at).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+    
+    const cleanTitle = cleanPRTitle(pr.title);
+    
+    let sectionContent = null;
+    if (argv['include-section'] && pr.body) {
+      const section = extractPRSection(pr.body, argv['include-section']);
+      if (section) {
+        // Indent the section content for proper markdown formatting
+        sectionContent = section
+          .split('\n')
+          .map(line => line ? `  ${line}` : '')
+          .join('\n');
+      }
+    }
+    
+    return {
+      cleanTitle,
+      mergedDate,
+      sectionContent
+    };
+  });
+  
+  // Prepare context for nunjucks
+  const context = {
+    currentDate: now.toISOString(),
+    lastUpdated: dateStr,
+    periodDescription,
+    releaseInfo,
+    prs: prData
+  };
+  
+  // Render template with context
+  return nunjucks.renderString(template.toString(), context);
+}
+
+/**
+ * Clean PR title by removing RUN-XXXX prefixes
+*/
+function cleanPRTitle(title) {
+  if (!title) return '';
+  // Remove one or more RUN-XXXX prefixes with optional colons and spaces
+  return title.replace(/^(RUN-[0-9]+\s*)+:?\s*/g, '').trim();
+}
+
+/**
+ * Extract a specific section from PR body
+ * Looks for sections like "## Customer Summary" or "### Release Notes"
+ * @param {string} body - PR body text
+ * @param {string} sectionName - Section header to look for (case insensitive)
+ * @returns {string|null} Section content or null if not found
+ */
+function extractPRSection(body, sectionName) {
+  if (!body) return null;
+  
+  // Match section headers like "## Customer Summary" or "### Release Notes"
+  const sectionRegex = new RegExp(
+    `^#+\\s*${sectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`,
+    'im'
+  );
+  
+  const lines = body.split('\n');
+  let inSection = false;
+  let sectionContent = [];
+  let sectionLevel = 0;
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    
+    if (sectionRegex.test(line)) {
+      // Found the section header
+      inSection = true;
+      sectionLevel = line.match(/^#+/)[0].length;
+      continue;
+    }
+    
+    if (inSection) {
+      // Check if we've hit another section at same or higher level
+      const headerMatch = line.match(/^(#+)\s/);
+      if (headerMatch && headerMatch[1].length <= sectionLevel) {
+        break; // End of our section
+      }
+      sectionContent.push(line);
+    }
+  }
+  
+  const content = sectionContent.join('\n').trim();
+  return content || null;
+}
+
+/**
+ * Format a single PR as markdown
+ * @param {Object} pr - PR object
+ * @returns {string} Formatted markdown
+ */
+function formatPRMarkdown(pr) {
+  const mergedDate = new Date(pr.merged_at).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+  
+  // Clean the PR title to remove RUN-XXXX prefixes
+  const cleanTitle = cleanPRTitle(pr.title);
+  
+  // Simple format: just title and date as a list item
+  let markdown = `- **${escapeMarkdown(cleanTitle)}** _(${mergedDate})_\n`;
+  
+  // Optionally include a specific section from the PR body
+  if (argv['include-section'] && pr.body) {
+    const section = extractPRSection(pr.body, argv['include-section']);
+    if (section) {
+      // Indent the section content
+      const indentedSection = section
+        .split('\n')
+        .map(line => line ? `  ${line}` : '')
+        .join('\n');
+      markdown += `${indentedSection}\n`;
+    }
+  }
+  
+  return markdown;
+}
+
+/**
+ * Escape markdown special characters
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text
+ */
+function escapeMarkdown(text) {
+  if (!text) return '';
+  // Don't escape characters inside code blocks
+  return text.replace(/([*_~`])/g, '\\$1');
+}
+
+/**
+ * Generate RSS 2.0 feed
+ * @param {Array} prs - Array of PR objects
+ * @returns {string} RSS XML content
+ */
+function generateRSS(prs) {
+  const now = new Date();
+  const items = prs.map(pr => {
+    const cleanTitle = cleanPRTitle(pr.title);
+    const mergedDate = new Date(pr.merged_at).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+    
+    // Simple description with just the title and date
+    const description = `${cleanTitle} (Merged: ${mergedDate})`;
+    
+    return `    <item>
+      <title>${escapeXml(cleanTitle)}</title>
+      <link>${escapeXml(pr.html_url)}</link>
+      <description>${escapeXml(description)}</description>
+      <pubDate>${new Date(pr.merged_at).toUTCString()}</pubDate>
+      <guid isPermaLink="false">rundeck-pr-${CONFIG.repo}-${pr.number}</guid>
+    </item>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(CONFIG.feedTitle)}</title>
+    <link>${CONFIG.siteUrl}/docs</link>
+    <description>${escapeXml(CONFIG.feedDescription)}</description>
+    <language>en-us</language>
+    <lastBuildDate>${now.toUTCString()}</lastBuildDate>
+    <atom:link href="${CONFIG.siteUrl}/feeds/development.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+}
+
+/**
+ * Generate Atom feed
+ * @param {Array} prs - Array of PR objects
+ * @returns {string} Atom XML content
+ */
+function generateAtom(prs) {
+  const now = new Date();
+  const entries = prs.map(pr => {
+    const cleanTitle = cleanPRTitle(pr.title);
+    const mergedDate = new Date(pr.merged_at).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+    
+    // Simple content with just the title and date
+    const content = escapeXml(`${cleanTitle} (Merged: ${mergedDate})`);
+    
+    return `  <entry>
+    <title>${escapeXml(cleanTitle)}</title>
+    <link href="${escapeXml(pr.html_url)}" />
+    <id>rundeck-pr-${CONFIG.repo}-${pr.number}</id>
+    <updated>${new Date(pr.merged_at).toISOString()}</updated>
+    <content type="text">${content}</content>
+  </entry>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(CONFIG.feedTitle)}</title>
+  <link href="${CONFIG.siteUrl}/feeds/development.xml" rel="self" />
+  <link href="${CONFIG.siteUrl}/docs" />
+  <updated>${now.toISOString()}</updated>
+  <id>${CONFIG.siteUrl}/feeds/development</id>
+  <subtitle>${escapeXml(CONFIG.feedDescription)}</subtitle>
+${entries}
+</feed>`;
+}
+
+/**
+ * Escape XML special characters
+ * @param {string} str - String to escape
+ * @returns {string} Escaped string
+ */
+function escapeXml(str) {
+  if (!str) return '';
+  return str.toString().replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '&': return '&amp;';
+      case "'": return '&apos;';
+      case '"': return '&quot;';
+      default: return c;
+    }
+  });
+}
+
+/**
+ * Ensure directory exists, create if not
+ * @param {string} dirPath - Directory path
+ */
+function ensureDirectoryExists(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+    console.log(`Created directory: ${dirPath}`);
+  }
+}
+
+/**
+ * Write file with error handling
+ * @param {string} filePath - File path
+ * @param {string} content - Content to write
+ * @param {string} description - Description for logging
+ */
+function writeFile(filePath, content, description) {
+  try {
+    fs.writeFileSync(filePath, content, 'utf8');
+    console.log(`✓ Generated ${description}: ${filePath}`);
+  } catch (error) {
+    console.error(`✗ Error writing ${description}: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+  console.log('=== Rundeck PR Feed Generator ===\n');
+  console.log('Configuration:');
+  console.log(`  Repository: ${CONFIG.owner}/${CONFIG.repo}`);
+  
+  if (feedConfig && feedConfig.lastSelfHostedRelease && !argv.days) {
+    console.log(`  Mode: Since last self-hosted release`);
+    console.log(`  Last release: ${feedConfig.lastSelfHostedRelease.version} (${feedConfig.lastSelfHostedRelease.date})`);
+  } else {
+    const daysDiff = Math.floor((new Date() - CONFIG.sinceDate) / (1000 * 60 * 60 * 24));
+    console.log(`  Mode: Time-based lookback`);
+    console.log(`  Days back: ${daysDiff}`);
+  }
+  
+  console.log(`  Since date: ${CONFIG.sinceDate.toISOString().split('T')[0]}`);
+  console.log(`  Include labels: ${CONFIG.includeLabels.join(', ')}`);
+  console.log(`  Exclude labels: ${CONFIG.excludeLabels.join(', ')}`);
+  console.log(`  Max PRs: ${CONFIG.maxPRs}`);
+  console.log('');
+
+  try {
+    // Initialize GitHub client
+    const octokit = initOctokit();
+    
+    // Fetch PRs
+    const prs = await fetchRecentPRs(octokit);
+    
+    if (prs.length === 0) {
+      console.log('\nNo PRs found matching the criteria.');
+      console.log('Generating empty feeds...\n');
+    }
+    
+    // Ensure output directories exist
+    ensureDirectoryExists(CONFIG.outputDir);
+    ensureDirectoryExists(CONFIG.feedsDir);
+    
+    // Generate markdown page
+    const markdown = generateMarkdown(prs);
+    const markdownPath = path.join(CONFIG.outputDir, 'index.md');
+    writeFile(markdownPath, markdown, 'markdown page');
+    
+    // Generate RSS feed
+    const rss = generateRSS(prs);
+    const rssPath = path.join(CONFIG.feedsDir, 'development.xml');
+    writeFile(rssPath, rss, 'RSS feed');
+    
+    // Generate Atom feed
+    const atom = generateAtom(prs);
+    const atomPath = path.join(CONFIG.feedsDir, 'development-atom.xml');
+    writeFile(atomPath, atom, 'Atom feed');
+    
+    console.log('\n=== Summary ===');
+    console.log(`Total PRs processed: ${prs.length}`);
+    console.log(`Markdown page: ${markdownPath}`);
+    console.log(`RSS feed: ${rssPath}`);
+    console.log(`Atom feed: ${atomPath}`);
+    console.log(`Feed URL (RSS): ${CONFIG.siteUrl}/feeds/development.xml`);
+    console.log(`Feed URL (Atom): ${CONFIG.siteUrl}/feeds/development-atom.xml`);
+    console.log('\n✓ Generation complete!');
+    
+  } catch (error) {
+    console.error('\n✗ Fatal error:', error.message);
+    if (error.stack) {
+      console.error('\nStack trace:');
+      console.error(error.stack);
+    }
+    process.exit(1);
+  }
+}
+
+// Execute main function
+(async () => {
+  await main();
+})();

--- a/docs/.vuepress/generate-pr-feed.mjs
+++ b/docs/.vuepress/generate-pr-feed.mjs
@@ -424,6 +424,8 @@ function escapeMarkdown(text) {
  */
 function generateRSS(prs) {
   const now = new Date();
+  const updatesPageUrl = `${CONFIG.siteUrl}/docs/history/updates/`;
+  
   const items = prs.map(pr => {
     const cleanTitle = cleanPRTitle(pr.title);
     const mergedDate = new Date(pr.merged_at).toLocaleDateString('en-US', {
@@ -437,7 +439,7 @@ function generateRSS(prs) {
     
     return `    <item>
       <title>${escapeXml(cleanTitle)}</title>
-      <link>${escapeXml(pr.html_url)}</link>
+      <link>${updatesPageUrl}</link>
       <description>${escapeXml(description)}</description>
       <pubDate>${new Date(pr.merged_at).toUTCString()}</pubDate>
       <guid isPermaLink="false">rundeck-pr-${CONFIG.repo}-${pr.number}</guid>
@@ -465,6 +467,8 @@ ${items}
  */
 function generateAtom(prs) {
   const now = new Date();
+  const updatesPageUrl = `${CONFIG.siteUrl}/docs/history/updates/`;
+  
   const entries = prs.map(pr => {
     const cleanTitle = cleanPRTitle(pr.title);
     const mergedDate = new Date(pr.merged_at).toLocaleDateString('en-US', {
@@ -478,7 +482,7 @@ function generateAtom(prs) {
     
     return `  <entry>
     <title>${escapeXml(cleanTitle)}</title>
-    <link href="${escapeXml(pr.html_url)}" />
+    <link href="${updatesPageUrl}" />
     <id>rundeck-pr-${CONFIG.repo}-${pr.number}</id>
     <updated>${new Date(pr.merged_at).toISOString()}</updated>
     <content type="text">${content}</content>

--- a/docs/.vuepress/generate-pr-feed.mjs
+++ b/docs/.vuepress/generate-pr-feed.mjs
@@ -158,65 +158,100 @@ function initOctokit() {
 }
 
 /**
- * Fetch recently merged PRs from GitHub
- * @param {Octokit} octokit - GitHub API client
+ * Fetch recent merged PRs from a specific repository
+ * @param {Object} octokit - Initialized Octokit instance
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {Array<string>} includeLabels - Labels that PRs must have (empty array = all PRs)
  * @returns {Promise<Array>} Array of PR objects
  */
-async function fetchRecentPRs(octokit) {
-  const since = CONFIG.sinceDate;
-  
-  console.log(`Fetching PRs from ${CONFIG.owner}/${CONFIG.repo}...`);
-  console.log(`Looking for PRs merged after ${since.toISOString().split('T')[0]}`);
+async function fetchRecentPRs(octokit, owner, repo, includeLabels = []) {
+  console.log(`  Repository: ${owner}/${repo}`);
+  if (includeLabels.length > 0) {
+    console.log(`  Required labels: ${includeLabels.join(', ')}`);
+  } else {
+    console.log(`  No label filtering`);
+  }
   
   try {
-    // Use paginate to get all PRs if more than per_page limit
+    // Use paginate to handle large result sets automatically
     const pullRequests = await octokit.paginate(
-      octokit.pulls.list,
+      octokit.rest.pulls.list,
       {
-        owner: CONFIG.owner,
-        repo: CONFIG.repo,
+        owner,
+        repo,
         state: 'closed',
         sort: 'updated',
         direction: 'desc',
         per_page: 100
       },
-      (response) => response.data.slice(0, CONFIG.maxPRs)
+      (response, done) => {
+        // Filter only merged PRs within our date range
+        const filtered = response.data.filter(pr => {
+          // Must be merged (not just closed)
+          if (!pr.merged_at) return false;
+          
+          // Must be within date range
+          const mergedDate = new Date(pr.merged_at);
+          if (mergedDate < CONFIG.sinceDate) {
+            done(); // Stop pagination once we're past our date range
+            return false;
+          }
+          
+          return true;
+        });
+        
+        return filtered;
+      }
     );
-
-    console.log(`Retrieved ${pullRequests.length} closed PRs`);
-
-    // Filter for merged PRs within the date range
-    const mergedPRs = pullRequests.filter(pr => {
-      if (!pr.merged_at) return false;
+    
+    console.log(`  Found ${pullRequests.length} merged PRs since ${CONFIG.sinceDate.toISOString().split('T')[0]}`);
+    
+    // Filter by labels
+    const filteredPRs = pullRequests.filter(pr => {
+      const prLabels = pr.labels.map(label => label.name);
       
-      const mergedDate = new Date(pr.merged_at);
-      if (mergedDate <= since) return false;
+      // Check exclude labels first
+      if (CONFIG.excludeLabels.some(label => prLabels.includes(label))) {
+        return false;
+      }
       
-      // Check for included labels
-      const hasIncludedLabel = CONFIG.includeLabels.length === 0 || 
-        pr.labels.some(label => CONFIG.includeLabels.includes(label.name));
+      // Check include labels (must have at least one, if specified)
+      if (includeLabels.length > 0) {
+        return includeLabels.some(label => prLabels.includes(label));
+      }
       
-      // Check for excluded labels
-      const hasExcludedLabel = pr.labels.some(label => 
-        CONFIG.excludeLabels.includes(label.name)
-      );
-      
-      return hasIncludedLabel && !hasExcludedLabel;
+      return true;
     });
-
-    console.log(`Found ${mergedPRs.length} merged PRs matching criteria`);
     
-    // Sort by merge date, most recent first
-    mergedPRs.sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
+    console.log(`  After label filtering: ${filteredPRs.length} PRs`);
     
-    return mergedPRs;
+    // Limit to max PRs and sort by merge date (newest first)
+    const limitedPRs = filteredPRs
+      .sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at))
+      .slice(0, CONFIG.maxPRs);
+    
+    if (limitedPRs.length < filteredPRs.length) {
+      console.log(`  Limited to ${CONFIG.maxPRs} most recent PRs`);
+    }
+    
+    // Add repo information to each PR for later use
+    const prsWithRepo = limitedPRs.map(pr => ({
+      ...pr,
+      _repoOwner: owner,
+      _repoName: repo
+    }));
+    
+    return prsWithRepo;
     
   } catch (error) {
-    console.error(`Error fetching PRs: ${error.message}`);
     if (error.status === 404) {
-      console.error(`Repository ${CONFIG.owner}/${CONFIG.repo} not found or token lacks access.`);
+      throw new Error(`Repository ${owner}/${repo} not found. Check your credentials and repository name.`);
+    } else if (error.status === 401) {
+      throw new Error('Authentication failed. Check your GitHub token.');
+    } else {
+      throw new Error(`Failed to fetch PRs from ${owner}/${repo}: ${error.message}`);
     }
-    throw error;
   }
 }
 
@@ -308,7 +343,10 @@ function generateMarkdown(prs) {
     return {
       cleanTitle,
       mergedDate,
-      sectionContent
+      sectionContent,
+      repoName: pr._repoName,
+      prUrl: pr.html_url,
+      number: pr.number
     };
   });
   
@@ -449,7 +487,7 @@ function generateRSS(prs) {
       <link>${updatesPageUrl}</link>
       <description>${escapeXml(description)}</description>
       <pubDate>${new Date(pr.merged_at).toUTCString()}</pubDate>
-      <guid isPermaLink="false">rundeck-pr-${CONFIG.repo}-${pr.number}</guid>
+      <guid isPermaLink="false">rundeck-pr-${pr._repoName}-${pr.number}</guid>
     </item>`;
   }).join('\n');
 
@@ -490,7 +528,7 @@ function generateAtom(prs) {
     return `  <entry>
     <title>${escapeXml(cleanTitle)}</title>
     <link href="${updatesPageUrl}" />
-    <id>rundeck-pr-${CONFIG.repo}-${pr.number}</id>
+    <id>rundeck-pr-${pr._repoName}-${pr.number}</id>
     <updated>${new Date(pr.merged_at).toISOString()}</updated>
     <content type="text">${content}</content>
   </entry>`;
@@ -560,7 +598,7 @@ function writeFile(filePath, content, description) {
 async function main() {
   console.log('=== Rundeck PR Feed Generator ===\n');
   console.log('Configuration:');
-  console.log(`  Repository: ${CONFIG.owner}/${CONFIG.repo}`);
+  console.log(`  Repositories: rundeckpro/rundeckpro + rundeck/rundeck`);
   
   if (feedConfig && feedConfig.lastSelfHostedRelease && !argv.days) {
     console.log(`  Mode: Since last self-hosted release`);
@@ -572,19 +610,29 @@ async function main() {
   }
   
   console.log(`  Since date: ${CONFIG.sinceDate.toISOString().split('T')[0]}`);
-  console.log(`  Include labels: ${CONFIG.includeLabels.join(', ')}`);
+  console.log(`  Include labels (both repos): ${CONFIG.includeLabels.join(', ')}`);
   console.log(`  Exclude labels: ${CONFIG.excludeLabels.join(', ')}`);
-  console.log(`  Max PRs: ${CONFIG.maxPRs}`);
+  console.log(`  Max PRs per repo: ${CONFIG.maxPRs}`);
   console.log('');
 
   try {
     // Initialize GitHub client
     const octokit = initOctokit();
     
-    // Fetch PRs
-    const prs = await fetchRecentPRs(octokit);
+    // Fetch PRs from both repos
+    console.log('Fetching from rundeckpro/rundeckpro...');
+    const rundeckproPRs = await fetchRecentPRs(octokit, 'rundeckpro', 'rundeckpro', CONFIG.includeLabels);
     
-    if (prs.length === 0) {
+    console.log('\nFetching from rundeck/rundeck...');
+    const rundeckPRs = await fetchRecentPRs(octokit, 'rundeck', 'rundeck', CONFIG.includeLabels);
+    
+    // Combine and sort all PRs by merge date
+    const allPRs = [...rundeckproPRs, ...rundeckPRs];
+    allPRs.sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
+    
+    console.log(`\nTotal PRs from both repos: ${allPRs.length}`);
+    
+    if (allPRs.length === 0) {
       console.log('\nNo PRs found matching the criteria.');
       console.log('Generating empty feeds...\n');
     }
@@ -594,22 +642,22 @@ async function main() {
     ensureDirectoryExists(CONFIG.feedsDir);
     
     // Generate markdown page
-    const markdown = generateMarkdown(prs);
+    const markdown = generateMarkdown(allPRs);
     const markdownPath = path.join(CONFIG.outputDir, 'index.md');
     writeFile(markdownPath, markdown, 'markdown page');
     
     // Generate RSS feed
-    const rss = generateRSS(prs);
+    const rss = generateRSS(allPRs);
     const rssPath = path.join(CONFIG.feedsDir, 'development.xml');
     writeFile(rssPath, rss, 'RSS feed');
     
     // Generate Atom feed
-    const atom = generateAtom(prs);
+    const atom = generateAtom(allPRs);
     const atomPath = path.join(CONFIG.feedsDir, 'development-atom.xml');
     writeFile(atomPath, atom, 'Atom feed');
     
     console.log('\n=== Summary ===');
-    console.log(`Total PRs processed: ${prs.length}`);
+    console.log(`Total PRs processed: ${allPRs.length} (${rundeckproPRs.length} from rundeckpro, ${rundeckPRs.length} from rundeck)`);
     console.log(`Markdown page: ${markdownPath}`);
     console.log(`RSS feed: ${rssPath}`);
     console.log(`Atom feed: ${atomPath}`);

--- a/docs/.vuepress/navbar-menus/about.js
+++ b/docs/.vuepress/navbar-menus/about.js
@@ -21,6 +21,6 @@ export default [
   },
   {
     text: 'Release Notes',
-    link: '/history/'
+    link: '/history/5_x/version-5.17.0.md'
   }
 ]

--- a/docs/.vuepress/navbar-menus/development.js
+++ b/docs/.vuepress/navbar-menus/development.js
@@ -15,7 +15,7 @@ export default [{
     link: '/rd-cli/'
   },
   {
-    text: 'Release Notes',
+    text: 'Release History',
     link: '/history/'
   },
   {

--- a/docs/.vuepress/notes.md.nj
+++ b/docs/.vuepress/notes.md.nj
@@ -1,9 +1,9 @@
 ---
 
 title: "{{version.versionString}} Release Notes"
-date: 2025-01-01
+date: {{currentDate}}
 image: /images/chevron-logo-red-on-white.png
-description: "Rundeck | Runbook Automation Releases <VERSION> <DESCRIPTION>"
+description: "Rundeck | Runbook Automation Releases {{version.versionString}} - <DESCRIPTION>"
 feed:
  enable: true
  description: ""
@@ -18,12 +18,9 @@ feed:
 
 ## Runbook Automation Updates
 
-> Also includes all Open Source updates from below
-
 {% for pull in enterprise.pulls -%}
-#### ::circle-check:: {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
-
-{% if pull.releaseNotes %}
+##### {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
+{% if pull.releaseNotes %}  
 {{ pull.releaseNotes }}
 {% endif %}
 {% endfor %}
@@ -56,7 +53,7 @@ feed:
 
 Name: <span style="color: {{version.color()}}"><span class="glyphicon glyphicon-{{version.icon()}}"></span> "{{version.name()}} {{version.color()}} {{version.icon()}}"</span>
 
-Release Date: PUTADATEHERE
+Release Date: {{currentDateLong}}
 
 
 ## Community Contributors

--- a/docs/.vuepress/notes.md.nj
+++ b/docs/.vuepress/notes.md.nj
@@ -20,11 +20,12 @@ feed:
 
 > Also includes all Open Source updates from below
 
-### Additional Updates
-
-
 {% for pull in enterprise.pulls -%}
-* {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
+#### ::circle-check:: {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
+
+{% if pull.releaseNotes %}
+{{ pull.releaseNotes }}
+{% endif %}
 {% endfor %}
 
 ## Rundeck Open Source Product Updates

--- a/docs/.vuepress/notes.md.nj
+++ b/docs/.vuepress/notes.md.nj
@@ -19,28 +19,40 @@ feed:
 ## Runbook Automation Updates
 
 {% for pull in enterprise.pulls -%}
-##### {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
+##### ::circle-dot:: {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
 {% if pull.releaseNotes %}  
 {{ pull.releaseNotes }}
 {% endif %}
 {% endfor %}
-
 ## Rundeck Open Source Product Updates
 
 {% for pull in core.pulls -%}
-* [{{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}]({{pull.html_url}})
+#####  ::circle-dot:: [{{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}]({{pull.html_url}})
+{% if pull.releaseNotes %}  
+{{ pull.releaseNotes }}
+{% endif %}
 {% endfor %}
-
 [Here is a link to the full list of public PRs](https://github.com/rundeck/rundeck/pulls?q=is%3Apr+milestone%3A{{version.versionString}}+is%3Aclosed)
 
+{% if ansible.pulls.length > 0 %}
 ## Ansible Plugin Updates
 {% for pull in ansible.pulls -%}
-* [{{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}]({{pull.html_url}})
+#####  ::circle-dot:: [{{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}]({{pull.html_url}})
+{% if pull.releaseNotes %}  
+{{ pull.releaseNotes }}
+{% endif %}
 {% endfor %}
+{% endif %}
 
+{% if runner.pulls.length > 0 %}
+## Runner Updates
 {% for pull in runner.pulls -%}
-* {{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}
+#####  ::circle-dot:: [{{ pull.title | replace(r/^(RUN-[0-9]+\s*)+:?\s*/g, "") }}]({{pull.html_url}})
+{% if pull.releaseNotes %}  
+{{ pull.releaseNotes }}
+{% endif %}
 {% endfor %}
+{% endif %}
 
 ## Links
 

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -71,8 +71,10 @@ async function main() {
     // addReleaseRow(argv.milestone); // Removed: function not defined
     updateSetupJs(argv.milestone);
     addSidebarVersion(argv.milestone);
+    updateLatestReleaseLink(argv.milestone);
     updatePRFeedConfig(argv.milestone);
   }
+}
 
 // Helper: Add release row to release-calendar.md if not present
 // (Removed duplicate definition of addReleaseRow)
@@ -81,7 +83,7 @@ async function main() {
 function addSidebarVersion(version) {
   const sidebarPath = path.resolve(__dirname, 'sidebar-menus/history.ts');
   let content = fs.readFileSync(sidebarPath, 'utf-8');
-  const versionEntry = `              {\n                text: "${version}",\n                link: "https://docs.rundeck.com/${version}/"\n              },\n`;
+  const versionEntry = `          {\n            text: "${version}",\n            link: "https://docs.rundeck.com/${version}/"\n          },\n`;
   if (content.includes(`text: "${version}"`)) {
     console.log(`Sidebar version entry for ${version} already exists in history.ts, skipping.`);
     return;
@@ -97,6 +99,30 @@ function addSidebarVersion(version) {
     console.warn('Could not find Version 5.x section in sidebar-menus/history.ts');
   }
 }
+
+// Helper: Update the "Latest Release" link in sidebar
+function updateLatestReleaseLink(version) {
+  const sidebarPath = path.resolve(__dirname, 'sidebar-menus/history.ts');
+  let content = fs.readFileSync(sidebarPath, 'utf-8');
+  
+  // Find the major version number (e.g., "5" from "5.17.0")
+  const majorVersion = version.split('.')[0];
+  
+  // Pattern to match the "Latest Release" link line
+  const latestReleasePattern = /(text: 'Latest Release',[\s\S]*?link: ')\/history\/\d+_x\/version-[\d.]+\.md(',)/;
+  
+  if (content.match(latestReleasePattern)) {
+    // Replace with new version
+    content = content.replace(
+      latestReleasePattern,
+      `$1/history/${majorVersion}_x/version-${version}.md$2`
+    );
+    
+    fs.writeFileSync(sidebarPath, content);
+    console.log(`Updated "Latest Release" link to version ${version} in history.ts`);
+  } else {
+    console.warn('Could not find "Latest Release" link pattern in sidebar-menus/history.ts');
+  }
 }
 
 async function getRepoData(repo, includeLabels) {

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -34,7 +34,8 @@ const excludeUsernames = [
   'ltamaster',
   'ronaveva',
   'smartinellibenedetti',
-  'jayas006'
+  'jayas006',
+  'edbaltra'
 ];
 
 async function main() {

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -284,11 +284,10 @@ function updatePRFeedConfig(version) {
   const config = {
     lastSelfHostedRelease: {
       version: version,
-      date: today,
       description: "Last self-hosted release version and date"
     }
   };
   
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-  console.log(`Updated pr-feed-config.json with version ${version} and date ${today}`);
+  console.log(`Updated pr-feed-config.json with version ${version}`);
 }

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -45,9 +45,8 @@ async function main() {
   context.core = await getRepoData({ repo: 'rundeck', owner: 'rundeck' }, []);
   context.enterprise = await getRepoData({ repo: 'rundeckpro', owner: 'rundeckpro' }, ['release-notes/include']);
   context.docs = await getRepoData({ repo: 'docs', owner: 'rundeck' }, []);
-  context.ansible = await getRepoData({ repo: 'ansible-plugin', owner: 'rundeck-plugins' }, []);
+  context.ansible = await getRepoData({ repo: 'ansible-plugin', owner: 'rundeck-plugins' }, ['release-notes/include']);
   context.runner = await getRepoData({ repo: 'sidecar', owner: 'rundeckpro' }, ['release-notes/include']);
-  //context.sidecarVersion = await getSideCarVersion({ repo: 'rundeckpro', owner: 'rundeckpro' });
   context.contributors = { ...context.core.contributors, ...context.docs.contributors, ...context.ansible.contributors };
 
   context.version = new RundeckVersion({ versionString: argv.milestone });
@@ -93,7 +92,6 @@ async function main() {
   // Only run update functions if not a draft
   if (!argv.draft) {
     updateDocsearchVersion(argv.milestone);
-    // addReleaseRow(argv.milestone); // Removed: function not defined
     updateSetupJs(argv.milestone);
     addSidebarVersion(argv.milestone);
     updateLatestReleaseLink(argv.milestone);
@@ -101,9 +99,6 @@ async function main() {
     updatePRFeedConfig(argv.milestone);
   }
 }
-
-// Helper: Add release row to release-calendar.md if not present
-// (Removed duplicate definition of addReleaseRow)
 
 // Helper: Add sidebar version entry if not present
 function addSidebarVersion(version) {

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -52,6 +52,25 @@ async function main() {
 
   context.version = new RundeckVersion({ versionString: argv.milestone });
   
+  // Add current date in two formats
+  const now = new Date();
+  context.currentDate = now.toISOString().split('T')[0]; // Format: 2025-01-01
+  
+  // Format for "January 1st, 2025"
+  const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'];
+  const day = now.getDate();
+  const suffix = (day) => {
+    if (day > 3 && day < 21) return 'th';
+    switch (day % 10) {
+      case 1: return 'st';
+      case 2: return 'nd';
+      case 3: return 'rd';
+      default: return 'th';
+    }
+  };
+  context.currentDateLong = `${monthNames[now.getMonth()]} ${day}${suffix(day)}, ${now.getFullYear()}`;
+  
   // Extract "Release Notes" section from enterprise PRs
   context.enterprise.pulls = context.enterprise.pulls.map(pr => ({
     ...pr,

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -33,7 +33,8 @@ const excludeUsernames = [
   'hiawvp',
   'ltamaster',
   'ronaveva',
-  'smartinellibenedetti'
+  'smartinellibenedetti',
+  'jayas006'
 ];
 
 async function main() {

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -72,6 +72,7 @@ async function main() {
     updateSetupJs(argv.milestone);
     addSidebarVersion(argv.milestone);
     updateLatestReleaseLink(argv.milestone);
+    updateNavbarReleaseLink(argv.milestone);
     updatePRFeedConfig(argv.milestone);
   }
 }
@@ -122,6 +123,31 @@ function updateLatestReleaseLink(version) {
     console.log(`Updated "Latest Release" link to version ${version} in history.ts`);
   } else {
     console.warn('Could not find "Latest Release" link pattern in sidebar-menus/history.ts');
+  }
+}
+
+// Helper: Update the "Release Notes" link in navbar
+function updateNavbarReleaseLink(version) {
+  const navbarPath = path.resolve(__dirname, 'navbar-menus/about.js');
+  let content = fs.readFileSync(navbarPath, 'utf-8');
+  
+  // Find the major version number (e.g., "5" from "5.17.0")
+  const majorVersion = version.split('.')[0];
+  
+  // Pattern to match the Release Notes link line in navbar
+  const releaseNotesPattern = /(text: 'Release Notes',[\s\S]*?link: ')\/history\/\d+_x\/version-[\d.]+\.md(')/;
+  
+  if (content.match(releaseNotesPattern)) {
+    // Replace with new version
+    content = content.replace(
+      releaseNotesPattern,
+      `$1/history/${majorVersion}_x/version-${version}.md$2`
+    );
+    
+    fs.writeFileSync(navbarPath, content);
+    console.log(`Updated navbar "Release Notes" link to version ${version} in about.js`);
+  } else {
+    console.warn('Could not find "Release Notes" link pattern in navbar-menus/about.js');
   }
 }
 

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -279,13 +279,22 @@ function updateSetupJs(version) {
 
 function updatePRFeedConfig(version) {
   const configPath = path.resolve(__dirname, 'pr-feed-config.json');
-  const today = new Date().toISOString().split('T')[0];
   
-  const config = {
-    lastSelfHostedRelease: {
-      version: version,
-      description: "Last self-hosted release version and date"
+  // Read existing config to preserve existing fields like 'date'
+  let config = { lastSelfHostedRelease: {} };
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (error) {
+      console.warn('Could not parse existing pr-feed-config.json, creating new config.');
     }
+  }
+  
+  // Only update the version, preserve all other fields
+  config.lastSelfHostedRelease = {
+    ...config.lastSelfHostedRelease,
+    version: version,
+    description: "Last self-hosted release version and date"
   };
   
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -71,6 +71,7 @@ async function main() {
     // addReleaseRow(argv.milestone); // Removed: function not defined
     updateSetupJs(argv.milestone);
     addSidebarVersion(argv.milestone);
+    updatePRFeedConfig(argv.milestone);
   }
 
 // Helper: Add release row to release-calendar.md if not present
@@ -181,4 +182,20 @@ function updateSetupJs(version) {
     .replace(/const RUNDECK_VERSION_FULL='[^']*'/, `const RUNDECK_VERSION_FULL='${version}-SNAPSHOT'`);
   fs.writeFileSync(setupJsPath, setupJs);
   console.log(`Updated setup.js RUNDECK_VERSION to ${version} and RUNDECK_VERSION_FULL to ${version}-SNAPSHOT`);
+}
+
+function updatePRFeedConfig(version) {
+  const configPath = path.resolve(__dirname, 'pr-feed-config.json');
+  const today = new Date().toISOString().split('T')[0];
+  
+  const config = {
+    lastSelfHostedRelease: {
+      version: version,
+      date: today,
+      description: "Last self-hosted release version and date"
+    }
+  };
+  
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+  console.log(`Updated pr-feed-config.json with version ${version} and date ${today}`);
 }

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -65,12 +65,6 @@ async function main() {
     }
   };
   context.currentDateLong = `${monthNames[now.getMonth()]} ${day}${suffix(day)}, ${now.getFullYear()}`;
-  
-  // Extract "Release Notes" section from enterprise PRs
-  context.enterprise.pulls = context.enterprise.pulls.map(pr => ({
-    ...pr,
-    releaseNotes: extractPRSection(pr.body, 'Release Notes')
-  }));
 
   const notes = nunjucks.renderString(template.toString(), context);
 
@@ -237,9 +231,15 @@ async function getRepoData(repo, includeLabels) {
     contributors[user.data.login] = user.data;
   }
 
+  // Extract "Release Notes" section from all PRs
+  const pullsWithNotes = pulls.map(pr => ({
+    ...pr,
+    releaseNotes: extractPRSection(pr.body, 'Release Notes')
+  }));
+
   return {
     contributors,
-    pulls,
+    pulls: pullsWithNotes,
   };
 }
 

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -51,6 +51,12 @@ async function main() {
   context.contributors = { ...context.core.contributors, ...context.docs.contributors, ...context.ansible.contributors };
 
   context.version = new RundeckVersion({ versionString: argv.milestone });
+  
+  // Extract "Release Notes" section from enterprise PRs
+  context.enterprise.pulls = context.enterprise.pulls.map(pr => ({
+    ...pr,
+    releaseNotes: extractPRSection(pr.body, 'Release Notes')
+  }));
 
   const notes = nunjucks.renderString(template.toString(), context);
 
@@ -149,6 +155,45 @@ function updateNavbarReleaseLink(version) {
   } else {
     console.warn('Could not find "Release Notes" link pattern in navbar-menus/about.js');
   }
+}
+
+// Helper: Extract a specific section from PR body
+function extractPRSection(body, sectionName) {
+  if (!body) return null;
+  
+  // Match section headers like "## Release Notes" or "### Release Notes"
+  const sectionRegex = new RegExp(
+    `^#+\\s*${sectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`,
+    'im'
+  );
+  
+  const lines = body.split('\n');
+  let inSection = false;
+  let sectionContent = [];
+  let sectionLevel = 0;
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    
+    if (sectionRegex.test(line)) {
+      // Found the section header
+      inSection = true;
+      sectionLevel = line.match(/^#+/)[0].length;
+      continue;
+    }
+    
+    if (inSection) {
+      // Check if we've hit another section at same or higher level
+      const headerMatch = line.match(/^(#+)\s/);
+      if (headerMatch && headerMatch[1].length <= sectionLevel) {
+        break; // End of our section
+      }
+      sectionContent.push(line);
+    }
+  }
+  
+  const content = sectionContent.join('\n').trim();
+  return content || null;
 }
 
 async function getRepoData(repo, includeLabels) {

--- a/docs/.vuepress/notes.mjs
+++ b/docs/.vuepress/notes.mjs
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { Buffer } from 'buffer';
 import nunjucks from 'nunjucks';
 import { Octokit } from '@octokit/rest';
 import dotenv from 'dotenv';
@@ -11,11 +10,12 @@ import RundeckVersion from './version.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+dotenv.config();
+
 const argv = _yargs(hideBin(process.argv)).argv;
 
 const template = fs.readFileSync('./docs/.vuepress/notes.md.nj');
 
-const excludeLabels = ['release-notes/exclude'];
 // List of usernames to exclude from contributors
 const excludeUsernames = [
   'github-actions[bot]',
@@ -36,15 +36,11 @@ const excludeUsernames = [
   'smartinellibenedetti'
 ];
 
-const ghToken = process.env.GH_API_TOKEN;
-
-dotenv.config();
-
 async function main() {
   const context = {};
-  context.core = await getRepoData({ repo: 'rundeck', owner: 'rundeck' }, []);
+  context.core = await getRepoData({ repo: 'rundeck', owner: 'rundeck' }, ['release-notes/include']);
   context.enterprise = await getRepoData({ repo: 'rundeckpro', owner: 'rundeckpro' }, ['release-notes/include']);
-  context.docs = await getRepoData({ repo: 'docs', owner: 'rundeck' }, []);
+  context.docs = await getRepoData({ repo: 'docs', owner: 'rundeck' }, []); // No label filtering for docs (need all PRs for contributors)
   context.ansible = await getRepoData({ repo: 'ansible-plugin', owner: 'rundeck-plugins' }, ['release-notes/include']);
   context.runner = await getRepoData({ repo: 'sidecar', owner: 'rundeckpro' }, ['release-notes/include']);
   context.contributors = { ...context.core.contributors, ...context.docs.contributors, ...context.ansible.contributors };
@@ -219,47 +215,32 @@ async function getRepoData(repo, includeLabels) {
 
   if (!milestone) {
     console.error(`GitHub milestone ${argv.milestone} not found on ${repo.owner}/${repo.repo}.`);
-  } else {
-    const issuesResp = await gh.paginate(gh.issues.listForRepo, {
-      ...repo,
-      milestone: milestone.number,
-      state: 'closed',
-      labels: includeLabels.join(','),
-      per_page: 100,
-    });
-
-    const pulls = issuesResp
-      .filter((i) => i.pull_request)
-      .filter((i) => !i.labels.some((l) => excludeLabels.includes(l.name)));
-
-    const issues = issuesResp
-      .filter((i) => !i.pull_request)
-      .filter((i) => !i.labels.some((l) => !excludeLabels.includes(l.name)));
-
-    const contributors = {};
-    const reporters = {};
-
-    for (const p of pulls) {
-      if (excludeUsernames.includes(p.user.login)) continue;
-      if (contributors[p.user.login]) continue;
-      const user = await gh.users.getByUsername({ username: p.user.login });
-      contributors[user.data.login] = user.data;
-    }
-
-    for (const i of issues) {
-      if (excludeUsernames.includes(i.user.login)) continue;
-      if (reporters[i.user.login]) continue;
-      const user = await gh.users.getByUsername({ username: i.user.login });
-      reporters[user.data.login] = user.data;
-    }
-
-    return {
-      contributors,
-      reporters,
-      pulls,
-      issues,
-    };
+    return { contributors: {}, pulls: [] };
   }
+
+  const issuesResp = await gh.paginate(gh.issues.listForRepo, {
+    ...repo,
+    milestone: milestone.number,
+    state: 'closed',
+    labels: includeLabels.join(','),
+    per_page: 100,
+  });
+
+  const pulls = issuesResp.filter((i) => i.pull_request);
+
+  const contributors = {};
+
+  for (const p of pulls) {
+    if (excludeUsernames.includes(p.user.login)) continue;
+    if (contributors[p.user.login]) continue;
+    const user = await gh.users.getByUsername({ username: p.user.login });
+    contributors[user.data.login] = user.data;
+  }
+
+  return {
+    contributors,
+    pulls,
+  };
 }
 
 

--- a/docs/.vuepress/pr-feed-config.json
+++ b/docs/.vuepress/pr-feed-config.json
@@ -1,0 +1,7 @@
+{
+  "lastSelfHostedRelease": {
+    "version": "5.16.0",
+    "date": "2025-10-06",
+    "description": "Last self-hosted release version and date"
+  }
+}

--- a/docs/.vuepress/pr-feed-config.json
+++ b/docs/.vuepress/pr-feed-config.json
@@ -2,6 +2,7 @@
   "lastSelfHostedRelease": {
     "version": "5.17.0",
     "date": "2025-10-23",
+    "lastSaasRelease": "2025-11-04",
     "description": "Last self-hosted release version and date"
   }
 }

--- a/docs/.vuepress/pr-feed-config.json
+++ b/docs/.vuepress/pr-feed-config.json
@@ -1,7 +1,7 @@
 {
   "lastSelfHostedRelease": {
-    "version": "5.16.0",
-    "date": "2025-10-06",
+    "version": "5.17.0",
+    "date": "2025-10-03",
     "description": "Last self-hosted release version and date"
   }
 }

--- a/docs/.vuepress/pr-feed-config.json
+++ b/docs/.vuepress/pr-feed-config.json
@@ -1,7 +1,7 @@
 {
   "lastSelfHostedRelease": {
     "version": "5.17.0",
-    "date": "2025-10-27",
+    "date": "2025-11-06",
     "description": "Last self-hosted release version and date"
   }
 }

--- a/docs/.vuepress/pr-feed-config.json
+++ b/docs/.vuepress/pr-feed-config.json
@@ -1,7 +1,7 @@
 {
   "lastSelfHostedRelease": {
     "version": "5.17.0",
-    "date": "2025-10-03",
+    "date": "2025-10-27",
     "description": "Last self-hosted release version and date"
   }
 }

--- a/docs/.vuepress/pr-feed-config.json
+++ b/docs/.vuepress/pr-feed-config.json
@@ -1,7 +1,7 @@
 {
   "lastSelfHostedRelease": {
     "version": "5.17.0",
-    "date": "2025-11-06",
+    "date": "2025-10-23",
     "description": "Last self-hosted release version and date"
   }
 }

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -1,0 +1,45 @@
+---
+title: Recent Development Updates
+description: Latest merged changes from the Rundeck development team
+date: {{currentDate}}
+feed: true
+index: true
+---
+
+# Recent Development Updates
+
+Stay up to date with the latest changes and improvements from the Runbook Automation development team.
+
+## Subscribe to Updates
+
+Stay informed about Rundeck development by subscribing to our feeds:
+
+- [RSS Feed](/feeds/development.xml)
+- [Atom Feed](/feeds/development-atom.xml)
+
+These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight important changes that may not be available in our Self Hosted Releases yet.
+
+## About These Updates
+
+The development updates are automatically generated from our private development repository and filtered to show customer-visible changes. They provide insight into active development features available in the Runbook Automation SaaS solution.
+
+**Note**: These updates reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
+
+---
+
+**Last updated:** {{lastUpdated}}
+
+This page shows recently merged pull requests from the Rundeck development team {{periodDescription}}{{releaseInfo}}.
+
+## Recent Changes
+
+{% if prs.length === 0 %}
+*No updates available for this period.*
+{% else %}
+{% for pr in prs -%}
+#### {{ pr.cleanTitle }} _({{ pr.mergedDate }})_
+{% if pr.sectionContent %}
+{{ pr.sectionContent }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -12,13 +12,17 @@ Stay up to date with the latest changes and improvements from the Runbook Automa
 
 This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository {{periodDescription}}{{releaseInfo}}.
 
+{% if lastSaasRelease %}
+**Last SaaS Deployment:** {{lastSaasRelease}}
+{% endif %}
+
 ## Recent Changes
 
 {% if prs.length === 0 %}
 *No new updates to report since the last release.*
 {% else %}
 {% for pr in prs -%}
-#### ::circle-dot:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_{% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
+#### ::circle-dot:: {{ pr.cleanTitle }} {% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
 
 {% if pr.sectionContent %}
 {{ pr.sectionContent }}

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -38,7 +38,7 @@ The development updates are automatically generated from both our private reposi
 *No new updates to report since the last release.*
 {% else %}
 {% for pr in prs -%}
-#### ::circle-check:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_{% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
+#### ::circle-dot:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_{% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
 
 {% if pr.sectionContent %}
 {{ pr.sectionContent }}

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -10,7 +10,21 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository {{periodDescription}}{{releaseInfo}}. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository {{periodDescription}}{{releaseInfo}}.
+
+## Recent Changes
+
+{% if prs.length === 0 %}
+*No new updates to report since the last release.*
+{% else %}
+{% for pr in prs -%}
+#### ::circle-dot:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_{% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
+
+{% if pr.sectionContent %}
+{{ pr.sectionContent }}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 ## Subscribe to Updates
 
@@ -32,16 +46,4 @@ The development updates are automatically generated from both our private reposi
 
 **List Last updated:** {{lastUpdated}}
 
-## Recent Changes
 
-{% if prs.length === 0 %}
-*No new updates to report since the last release.*
-{% else %}
-{% for pr in prs -%}
-#### ::circle-dot:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_{% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
-
-{% if pr.sectionContent %}
-{{ pr.sectionContent }}
-{% endif %}
-{% endfor %}
-{% endif %}

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -27,17 +27,17 @@ The development updates are automatically generated from our private development
 
 ---
 
-**Last updated:** {{lastUpdated}}
+**List Last updated:** {{lastUpdated}}
 
 This page shows recently merged pull requests from the Rundeck development team {{periodDescription}}{{releaseInfo}}.
 
 ## Recent Changes
 
 {% if prs.length === 0 %}
-*No updates available for this period.*
+*No new updates to report since the last release.*
 {% else %}
 {% for pr in prs -%}
-#### {{ pr.cleanTitle }} _({{ pr.mergedDate }})_
+#### ::circle-check:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_
 {% if pr.sectionContent %}
 {{ pr.sectionContent }}
 {% endif %}

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -10,7 +10,7 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from the Runbook Automation product repository {{periodDescription}}{{releaseInfo}}. These changes are specific to the commercial Runbook Automation product, which is built on top of the open source Rundeck project. For updates to the open source Rundeck code, visit the [Rundeck GitHub repository](https://github.com/rundeck/rundeck).
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository {{periodDescription}}{{releaseInfo}}. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
 
 ## Subscribe to Updates
 
@@ -24,7 +24,7 @@ These feeds are updated after each deployment to our production Runbook Automati
 ## About These Updates
 
 
-The development updates are automatically generated from our private development repository to highlight key changes happening in the SaaS solution. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
+The development updates are automatically generated from both our private repository for the commercial product and the public open source repository to provide complete visibility into changes deployed to the SaaS platform. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
 
 **Note**: These updates only reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
 
@@ -38,7 +38,8 @@ The development updates are automatically generated from our private development
 *No new updates to report since the last release.*
 {% else %}
 {% for pr in prs -%}
-#### ::circle-check:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_
+#### ::circle-check:: {{ pr.cleanTitle }} _({{ pr.mergedDate }})_{% if pr.repoName === 'rundeck' %} [PR #{{ pr.number }}]({{ pr.prUrl }}){% endif %}
+
 {% if pr.sectionContent %}
 {{ pr.sectionContent }}
 {% endif %}

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -8,28 +8,29 @@ index: true
 
 # Recent Development Updates
 
-Stay up to date with the latest changes and improvements from the Runbook Automation development team.
+Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
+
+This page shows recently merged pull requests from the Runbook Automation product repository {{periodDescription}}{{releaseInfo}}. These changes are specific to the commercial Runbook Automation product, which is built on top of the open source Rundeck project. For updates to the open source Rundeck code, visit the [Rundeck GitHub repository](https://github.com/rundeck/rundeck).
 
 ## Subscribe to Updates
 
-Stay informed about Rundeck development by subscribing to our feeds:
+Stay informed about Rundeck development by subscribing to a feed:
 
 - [RSS Feed](/feeds/development.xml)
 - [Atom Feed](/feeds/development-atom.xml)
 
-These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight important changes that may not be available in our Self Hosted Releases yet.
+These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight changes that may not be available in our Self Hosted Releases yet.
 
 ## About These Updates
 
-The development updates are automatically generated from our private development repository and filtered to show customer-visible changes. They provide insight into active development features available in the Runbook Automation SaaS solution.
 
-**Note**: These updates reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
+The development updates are automatically generated from our private development repository to highlight key changes happening in the SaaS solution. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
+
+**Note**: These updates only reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
 
 ---
 
 **List Last updated:** {{lastUpdated}}
-
-This page shows recently merged pull requests from the Runbook Automation product repository {{periodDescription}}{{releaseInfo}}. These changes are specific to the commercial Runbook Automation product, which is built on top of the open source Rundeck project. For updates to the open source Rundeck code, visit the [Rundeck GitHub repository](https://github.com/rundeck/rundeck).
 
 ## Recent Changes
 

--- a/docs/.vuepress/pr-feed.md.nj
+++ b/docs/.vuepress/pr-feed.md.nj
@@ -29,7 +29,7 @@ The development updates are automatically generated from our private development
 
 **List Last updated:** {{lastUpdated}}
 
-This page shows recently merged pull requests from the Rundeck development team {{periodDescription}}{{releaseInfo}}.
+This page shows recently merged pull requests from the Runbook Automation product repository {{periodDescription}}{{releaseInfo}}. These changes are specific to the commercial Runbook Automation product, which is built on top of the open source Rundeck project. For updates to the open source Rundeck code, visit the [Rundeck GitHub repository](https://github.com/rundeck/rundeck).
 
 ## Recent Changes
 

--- a/docs/.vuepress/pr-feed.mjs
+++ b/docs/.vuepress/pr-feed.mjs
@@ -350,12 +350,29 @@ function generateMarkdown(prs) {
     };
   });
   
+  // Format lastSaasRelease date if available
+  let lastSaasRelease = null;
+  if (feedConfig && feedConfig.lastSelfHostedRelease && feedConfig.lastSelfHostedRelease.lastSaasRelease) {
+    const saasDateParts = feedConfig.lastSelfHostedRelease.lastSaasRelease.split('-');
+    lastSaasRelease = new Date(Date.UTC(
+      parseInt(saasDateParts[0]), 
+      parseInt(saasDateParts[1]) - 1, 
+      parseInt(saasDateParts[2])
+    )).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'UTC'
+    });
+  }
+  
   // Prepare context for nunjucks
   const context = {
     currentDate: now.toISOString(),
     lastUpdated: dateStr,
     periodDescription,
     releaseInfo,
+    lastSaasRelease,
     prs: prData
   };
   

--- a/docs/.vuepress/pr-feed.mjs
+++ b/docs/.vuepress/pr-feed.mjs
@@ -1,11 +1,11 @@
 /**
- * generate-pr-feed.mjs
+ * pr-feed.mjs
  * 
  * Generates RSS/Atom feeds and markdown pages from recently merged PRs
  * in the private rundeckpro repository. Designed for weekly release updates.
  * 
  * Usage:
- *   node generate-pr-feed.mjs --days=7 [--owner=rundeckpro] [--repo=rundeckpro]
+ *   node pr-feed.mjs --days=7 [--owner=rundeckpro] [--repo=rundeckpro]
  * 
  * Environment Variables:
  *   GH_API_TOKEN - GitHub API token with access to private repos

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,8 +3,49 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-05T22:11:27.846Z</updated>
+  <updated>2025-11-05T22:14:45.623Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
-
+  <entry>
+    <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4429" />
+    <id>rundeck-pr-rundeckpro-4429</id>
+    <updated>2025-10-22T18:28:32.000Z</updated>
+    <content type="text">Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</content>
+  </entry>
+  <entry>
+    <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4441" />
+    <id>rundeck-pr-rundeckpro-4441</id>
+    <updated>2025-10-22T17:07:40.000Z</updated>
+    <content type="text">Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</content>
+  </entry>
+  <entry>
+    <title>Set default runner replica type to manual if not provided in API request</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4428" />
+    <id>rundeck-pr-rundeckpro-4428</id>
+    <updated>2025-10-21T21:46:07.000Z</updated>
+    <content type="text">Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</content>
+  </entry>
+  <entry>
+    <title>Allow Script Arguments on GitHub Run Script plugin</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4403" />
+    <id>rundeck-pr-rundeckpro-4403</id>
+    <updated>2025-10-21T15:46:55.000Z</updated>
+    <content type="text">Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</content>
+  </entry>
+  <entry>
+    <title>Improve the nodehealth check cache refresh</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4424" />
+    <id>rundeck-pr-rundeckpro-4424</id>
+    <updated>2025-10-21T13:12:25.000Z</updated>
+    <content type="text">Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</content>
+  </entry>
+  <entry>
+    <title>Runner Wizard error creating runner linux+ephemeral</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4414" />
+    <id>rundeck-pr-rundeckpro-4414</id>
+    <updated>2025-10-08T15:26:30.000Z</updated>
+    <content type="text">Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</content>
+  </entry>
 </feed>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,49 +3,8 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-05T21:55:10.394Z</updated>
+  <updated>2025-11-05T22:11:27.846Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
-  <entry>
-    <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4429" />
-    <id>rundeck-pr-rundeckpro-4429</id>
-    <updated>2025-10-22T18:28:32.000Z</updated>
-    <content type="text">Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</content>
-  </entry>
-  <entry>
-    <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4441" />
-    <id>rundeck-pr-rundeckpro-4441</id>
-    <updated>2025-10-22T17:07:40.000Z</updated>
-    <content type="text">Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</content>
-  </entry>
-  <entry>
-    <title>Set default runner replica type to manual if not provided in API request</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4428" />
-    <id>rundeck-pr-rundeckpro-4428</id>
-    <updated>2025-10-21T21:46:07.000Z</updated>
-    <content type="text">Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</content>
-  </entry>
-  <entry>
-    <title>Allow Script Arguments on GitHub Run Script plugin</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4403" />
-    <id>rundeck-pr-rundeckpro-4403</id>
-    <updated>2025-10-21T15:46:55.000Z</updated>
-    <content type="text">Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</content>
-  </entry>
-  <entry>
-    <title>Improve the nodehealth check cache refresh</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4424" />
-    <id>rundeck-pr-rundeckpro-4424</id>
-    <updated>2025-10-21T13:12:25.000Z</updated>
-    <content type="text">Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</content>
-  </entry>
-  <entry>
-    <title>Runner Wizard error creating runner linux+ephemeral</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4414" />
-    <id>rundeck-pr-rundeckpro-4414</id>
-    <updated>2025-10-08T15:26:30.000Z</updated>
-    <content type="text">Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</content>
-  </entry>
+
 </feed>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T22:48:38.030Z</updated>
+  <updated>2025-11-06T23:18:49.097Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>
@@ -19,61 +19,5 @@
     <id>rundeck-pr-rundeckpro-4453</id>
     <updated>2025-10-29T15:28:47.000Z</updated>
     <content type="text">Update nimbusJose for CVE-2025-53864 (Merged: Oct 29, 2025)</content>
-  </entry>
-  <entry>
-    <title>Bouncy Castle 1.79 for CVE-2025-8916</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4443</id>
-    <updated>2025-10-23T16:54:27.000Z</updated>
-    <content type="text">Bouncy Castle 1.79 for CVE-2025-8916 (Merged: Oct 23, 2025)</content>
-  </entry>
-  <entry>
-    <title>SSM cannot run job for more than 1 hour</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4444</id>
-    <updated>2025-10-23T16:31:42.000Z</updated>
-    <content type="text">SSM cannot run job for more than 1 hour (Merged: Oct 23, 2025)</content>
-  </entry>
-  <entry>
-    <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4429</id>
-    <updated>2025-10-22T18:28:32.000Z</updated>
-    <content type="text">Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</content>
-  </entry>
-  <entry>
-    <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4441</id>
-    <updated>2025-10-22T17:07:40.000Z</updated>
-    <content type="text">Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</content>
-  </entry>
-  <entry>
-    <title>Set default runner replica type to manual if not provided in API request</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4428</id>
-    <updated>2025-10-21T21:46:07.000Z</updated>
-    <content type="text">Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</content>
-  </entry>
-  <entry>
-    <title>Allow Script Arguments on GitHub Run Script plugin</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4403</id>
-    <updated>2025-10-21T15:46:55.000Z</updated>
-    <content type="text">Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</content>
-  </entry>
-  <entry>
-    <title>Improve the nodehealth check cache refresh</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4424</id>
-    <updated>2025-10-21T13:12:25.000Z</updated>
-    <content type="text">Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</content>
-  </entry>
-  <entry>
-    <title>Runner Wizard error creating runner linux+ephemeral</title>
-    <link href="https://docs.rundeck.com/docs/history/updates/" />
-    <id>rundeck-pr-rundeckpro-4414</id>
-    <updated>2025-10-08T15:26:30.000Z</updated>
-    <content type="text">Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</content>
   </entry>
 </feed>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,47 +3,47 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-05T22:14:45.623Z</updated>
+  <updated>2025-11-06T00:00:39.687Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>
     <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4429" />
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
     <id>rundeck-pr-rundeckpro-4429</id>
     <updated>2025-10-22T18:28:32.000Z</updated>
     <content type="text">Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</content>
   </entry>
   <entry>
     <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4441" />
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
     <id>rundeck-pr-rundeckpro-4441</id>
     <updated>2025-10-22T17:07:40.000Z</updated>
     <content type="text">Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</content>
   </entry>
   <entry>
     <title>Set default runner replica type to manual if not provided in API request</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4428" />
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
     <id>rundeck-pr-rundeckpro-4428</id>
     <updated>2025-10-21T21:46:07.000Z</updated>
     <content type="text">Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</content>
   </entry>
   <entry>
     <title>Allow Script Arguments on GitHub Run Script plugin</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4403" />
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
     <id>rundeck-pr-rundeckpro-4403</id>
     <updated>2025-10-21T15:46:55.000Z</updated>
     <content type="text">Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</content>
   </entry>
   <entry>
     <title>Improve the nodehealth check cache refresh</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4424" />
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
     <id>rundeck-pr-rundeckpro-4424</id>
     <updated>2025-10-21T13:12:25.000Z</updated>
     <content type="text">Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</content>
   </entry>
   <entry>
     <title>Runner Wizard error creating runner linux+ephemeral</title>
-    <link href="https://github.com/rundeckpro/rundeckpro/pull/4414" />
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
     <id>rundeck-pr-rundeckpro-4414</id>
     <updated>2025-10-08T15:26:30.000Z</updated>
     <content type="text">Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</content>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T17:33:26.051Z</updated>
+  <updated>2025-11-06T18:28:35.112Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-07T00:17:56.079Z</updated>
+  <updated>2025-11-07T00:29:20.934Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T00:00:39.687Z</updated>
+  <updated>2025-11-06T00:10:01.198Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T15:33:13.931Z</updated>
+  <updated>2025-11-06T17:33:26.051Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T23:18:49.097Z</updated>
+  <updated>2025-11-06T23:24:06.921Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,9 +3,30 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T00:10:01.198Z</updated>
+  <updated>2025-11-06T15:33:13.931Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
+  <entry>
+    <title>Update nimbusJose for CVE-2025-53864</title>
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
+    <id>rundeck-pr-rundeckpro-4453</id>
+    <updated>2025-10-29T15:28:47.000Z</updated>
+    <content type="text">Update nimbusJose for CVE-2025-53864 (Merged: Oct 29, 2025)</content>
+  </entry>
+  <entry>
+    <title>Bouncy Castle 1.79 for CVE-2025-8916</title>
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
+    <id>rundeck-pr-rundeckpro-4443</id>
+    <updated>2025-10-23T16:54:27.000Z</updated>
+    <content type="text">Bouncy Castle 1.79 for CVE-2025-8916 (Merged: Oct 23, 2025)</content>
+  </entry>
+  <entry>
+    <title>SSM cannot run job for more than 1 hour</title>
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
+    <id>rundeck-pr-rundeckpro-4444</id>
+    <updated>2025-10-23T16:31:42.000Z</updated>
+    <content type="text">SSM cannot run job for more than 1 hour (Merged: Oct 23, 2025)</content>
+  </entry>
   <entry>
     <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
     <link href="https://docs.rundeck.com/docs/history/updates/" />

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Rundeck Development Updates</title>
+  <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
+  <link href="https://docs.rundeck.com/docs" />
+  <updated>2025-11-05T21:55:10.394Z</updated>
+  <id>https://docs.rundeck.com/feeds/development</id>
+  <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
+  <entry>
+    <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4429" />
+    <id>rundeck-pr-rundeckpro-4429</id>
+    <updated>2025-10-22T18:28:32.000Z</updated>
+    <content type="text">Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</content>
+  </entry>
+  <entry>
+    <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4441" />
+    <id>rundeck-pr-rundeckpro-4441</id>
+    <updated>2025-10-22T17:07:40.000Z</updated>
+    <content type="text">Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</content>
+  </entry>
+  <entry>
+    <title>Set default runner replica type to manual if not provided in API request</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4428" />
+    <id>rundeck-pr-rundeckpro-4428</id>
+    <updated>2025-10-21T21:46:07.000Z</updated>
+    <content type="text">Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</content>
+  </entry>
+  <entry>
+    <title>Allow Script Arguments on GitHub Run Script plugin</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4403" />
+    <id>rundeck-pr-rundeckpro-4403</id>
+    <updated>2025-10-21T15:46:55.000Z</updated>
+    <content type="text">Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</content>
+  </entry>
+  <entry>
+    <title>Improve the nodehealth check cache refresh</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4424" />
+    <id>rundeck-pr-rundeckpro-4424</id>
+    <updated>2025-10-21T13:12:25.000Z</updated>
+    <content type="text">Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</content>
+  </entry>
+  <entry>
+    <title>Runner Wizard error creating runner linux+ephemeral</title>
+    <link href="https://github.com/rundeckpro/rundeckpro/pull/4414" />
+    <id>rundeck-pr-rundeckpro-4414</id>
+    <updated>2025-10-08T15:26:30.000Z</updated>
+    <content type="text">Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</content>
+  </entry>
+</feed>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T22:20:13.419Z</updated>
+  <updated>2025-11-06T22:48:38.030Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,9 +3,16 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T18:28:35.112Z</updated>
+  <updated>2025-11-06T22:20:13.419Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
+  <entry>
+    <title>Multiline Job Options (Beta)</title>
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
+    <id>rundeck-pr-rundeck-9822</id>
+    <updated>2025-11-04T23:56:21.000Z</updated>
+    <content type="text">Multiline Job Options (Beta) (Merged: Nov 4, 2025)</content>
+  </entry>
   <entry>
     <title>Update nimbusJose for CVE-2025-53864</title>
     <link href="https://docs.rundeck.com/docs/history/updates/" />

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-07T00:05:10.672Z</updated>
+  <updated>2025-11-07T00:17:56.079Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>

--- a/docs/.vuepress/public/feeds/development-atom.xml
+++ b/docs/.vuepress/public/feeds/development-atom.xml
@@ -3,7 +3,7 @@
   <title>Rundeck Development Updates</title>
   <link href="https://docs.rundeck.com/feeds/development.xml" rel="self" />
   <link href="https://docs.rundeck.com/docs" />
-  <updated>2025-11-06T23:24:06.921Z</updated>
+  <updated>2025-11-07T00:05:10.672Z</updated>
   <id>https://docs.rundeck.com/feeds/development</id>
   <subtitle>Recent merged pull requests and development updates from Rundeck</subtitle>
   <entry>
@@ -19,5 +19,19 @@
     <id>rundeck-pr-rundeckpro-4453</id>
     <updated>2025-10-29T15:28:47.000Z</updated>
     <content type="text">Update nimbusJose for CVE-2025-53864 (Merged: Oct 29, 2025)</content>
+  </entry>
+  <entry>
+    <title>Bouncy Castle 1.79 for CVE-2025-8916</title>
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
+    <id>rundeck-pr-rundeckpro-4443</id>
+    <updated>2025-10-23T16:54:27.000Z</updated>
+    <content type="text">Bouncy Castle 1.79 for CVE-2025-8916 (Merged: Oct 23, 2025)</content>
+  </entry>
+  <entry>
+    <title>SSM cannot run job for more than 1 hour</title>
+    <link href="https://docs.rundeck.com/docs/history/updates/" />
+    <id>rundeck-pr-rundeckpro-4444</id>
+    <updated>2025-10-23T16:31:42.000Z</updated>
+    <content type="text">SSM cannot run job for more than 1 hour (Merged: Oct 23, 2025)</content>
   </entry>
 </feed>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Fri, 07 Nov 2025 00:17:56 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 07 Nov 2025 00:29:20 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Multiline Job Options (Beta)</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Fri, 07 Nov 2025 00:05:10 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 07 Nov 2025 00:17:56 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Multiline Job Options (Beta)</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 15:33:13 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 17:33:26 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Update nimbusJose for CVE-2025-53864</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,8 +5,15 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 18:28:35 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 22:20:13 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Multiline Job Options (Beta)</title>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
+      <description>Multiline Job Options (Beta) (Merged: Nov 4, 2025)</description>
+      <pubDate>Tue, 04 Nov 2025 23:56:21 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeck-9822</guid>
+    </item>
     <item>
       <title>Update nimbusJose for CVE-2025-53864</title>
       <link>https://docs.rundeck.com/docs/history/updates/</link>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Rundeck Development Updates</title>
+    <link>https://docs.rundeck.com/docs</link>
+    <description>Recent merged pull requests and development updates from Rundeck</description>
+    <language>en-us</language>
+    <lastBuildDate>Wed, 05 Nov 2025 21:55:10 GMT</lastBuildDate>
+    <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4429</link>
+      <description>Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</description>
+      <pubDate>Wed, 22 Oct 2025 18:28:32 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4429</guid>
+    </item>
+    <item>
+      <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4441</link>
+      <description>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</description>
+      <pubDate>Wed, 22 Oct 2025 17:07:40 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4441</guid>
+    </item>
+    <item>
+      <title>Set default runner replica type to manual if not provided in API request</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4428</link>
+      <description>Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</description>
+      <pubDate>Tue, 21 Oct 2025 21:46:07 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4428</guid>
+    </item>
+    <item>
+      <title>Allow Script Arguments on GitHub Run Script plugin</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4403</link>
+      <description>Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</description>
+      <pubDate>Tue, 21 Oct 2025 15:46:55 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4403</guid>
+    </item>
+    <item>
+      <title>Improve the nodehealth check cache refresh</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4424</link>
+      <description>Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</description>
+      <pubDate>Tue, 21 Oct 2025 13:12:25 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4424</guid>
+    </item>
+    <item>
+      <title>Runner Wizard error creating runner linux+ephemeral</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4414</link>
+      <description>Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</description>
+      <pubDate>Wed, 08 Oct 2025 15:26:30 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4414</guid>
+    </item>
+  </channel>
+</rss>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 23:18:49 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 23:24:06 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Multiline Job Options (Beta)</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 23:24:06 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 07 Nov 2025 00:05:10 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Multiline Job Options (Beta)</title>
@@ -20,6 +20,20 @@
       <description>Update nimbusJose for CVE-2025-53864 (Merged: Oct 29, 2025)</description>
       <pubDate>Wed, 29 Oct 2025 15:28:47 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4453</guid>
+    </item>
+    <item>
+      <title>Bouncy Castle 1.79 for CVE-2025-8916</title>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
+      <description>Bouncy Castle 1.79 for CVE-2025-8916 (Merged: Oct 23, 2025)</description>
+      <pubDate>Thu, 23 Oct 2025 16:54:27 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4443</guid>
+    </item>
+    <item>
+      <title>SSM cannot run job for more than 1 hour</title>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
+      <description>SSM cannot run job for more than 1 hour (Merged: Oct 23, 2025)</description>
+      <pubDate>Thu, 23 Oct 2025 16:31:42 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4444</guid>
     </item>
   </channel>
 </rss>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 17:33:26 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 18:28:35 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Update nimbusJose for CVE-2025-53864</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 22:20:13 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 22:48:38 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Multiline Job Options (Beta)</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 22:48:38 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 23:18:49 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Multiline Job Options (Beta)</title>
@@ -20,62 +20,6 @@
       <description>Update nimbusJose for CVE-2025-53864 (Merged: Oct 29, 2025)</description>
       <pubDate>Wed, 29 Oct 2025 15:28:47 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4453</guid>
-    </item>
-    <item>
-      <title>Bouncy Castle 1.79 for CVE-2025-8916</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Bouncy Castle 1.79 for CVE-2025-8916 (Merged: Oct 23, 2025)</description>
-      <pubDate>Thu, 23 Oct 2025 16:54:27 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4443</guid>
-    </item>
-    <item>
-      <title>SSM cannot run job for more than 1 hour</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>SSM cannot run job for more than 1 hour (Merged: Oct 23, 2025)</description>
-      <pubDate>Thu, 23 Oct 2025 16:31:42 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4444</guid>
-    </item>
-    <item>
-      <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</description>
-      <pubDate>Wed, 22 Oct 2025 18:28:32 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4429</guid>
-    </item>
-    <item>
-      <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</description>
-      <pubDate>Wed, 22 Oct 2025 17:07:40 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4441</guid>
-    </item>
-    <item>
-      <title>Set default runner replica type to manual if not provided in API request</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</description>
-      <pubDate>Tue, 21 Oct 2025 21:46:07 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4428</guid>
-    </item>
-    <item>
-      <title>Allow Script Arguments on GitHub Run Script plugin</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</description>
-      <pubDate>Tue, 21 Oct 2025 15:46:55 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4403</guid>
-    </item>
-    <item>
-      <title>Improve the nodehealth check cache refresh</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</description>
-      <pubDate>Tue, 21 Oct 2025 13:12:25 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4424</guid>
-    </item>
-    <item>
-      <title>Runner Wizard error creating runner linux+ephemeral</title>
-      <link>https://docs.rundeck.com/docs/history/updates/</link>
-      <description>Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</description>
-      <pubDate>Wed, 08 Oct 2025 15:26:30 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4414</guid>
     </item>
   </channel>
 </rss>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,46 +5,46 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 05 Nov 2025 22:14:45 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 00:00:39 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4429</link>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
       <description>Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</description>
       <pubDate>Wed, 22 Oct 2025 18:28:32 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4429</guid>
     </item>
     <item>
       <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4441</link>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
       <description>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</description>
       <pubDate>Wed, 22 Oct 2025 17:07:40 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4441</guid>
     </item>
     <item>
       <title>Set default runner replica type to manual if not provided in API request</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4428</link>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
       <description>Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</description>
       <pubDate>Tue, 21 Oct 2025 21:46:07 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4428</guid>
     </item>
     <item>
       <title>Allow Script Arguments on GitHub Run Script plugin</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4403</link>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
       <description>Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</description>
       <pubDate>Tue, 21 Oct 2025 15:46:55 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4403</guid>
     </item>
     <item>
       <title>Improve the nodehealth check cache refresh</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4424</link>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
       <description>Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</description>
       <pubDate>Tue, 21 Oct 2025 13:12:25 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4424</guid>
     </item>
     <item>
       <title>Runner Wizard error creating runner linux+ephemeral</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4414</link>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
       <description>Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</description>
       <pubDate>Wed, 08 Oct 2025 15:26:30 GMT</pubDate>
       <guid isPermaLink="false">rundeck-pr-rundeckpro-4414</guid>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,49 +5,8 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 05 Nov 2025 21:55:10 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 05 Nov 2025 22:11:27 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
-    <item>
-      <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4429</link>
-      <description>Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</description>
-      <pubDate>Wed, 22 Oct 2025 18:28:32 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4429</guid>
-    </item>
-    <item>
-      <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4441</link>
-      <description>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</description>
-      <pubDate>Wed, 22 Oct 2025 17:07:40 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4441</guid>
-    </item>
-    <item>
-      <title>Set default runner replica type to manual if not provided in API request</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4428</link>
-      <description>Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</description>
-      <pubDate>Tue, 21 Oct 2025 21:46:07 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4428</guid>
-    </item>
-    <item>
-      <title>Allow Script Arguments on GitHub Run Script plugin</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4403</link>
-      <description>Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</description>
-      <pubDate>Tue, 21 Oct 2025 15:46:55 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4403</guid>
-    </item>
-    <item>
-      <title>Improve the nodehealth check cache refresh</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4424</link>
-      <description>Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</description>
-      <pubDate>Tue, 21 Oct 2025 13:12:25 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4424</guid>
-    </item>
-    <item>
-      <title>Runner Wizard error creating runner linux+ephemeral</title>
-      <link>https://github.com/rundeckpro/rundeckpro/pull/4414</link>
-      <description>Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</description>
-      <pubDate>Wed, 08 Oct 2025 15:26:30 GMT</pubDate>
-      <guid isPermaLink="false">rundeck-pr-rundeckpro-4414</guid>
-    </item>
+
   </channel>
 </rss>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,8 +5,49 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 05 Nov 2025 22:11:27 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 05 Nov 2025 22:14:45 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
-
+    <item>
+      <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4429</link>
+      <description>Improvement in the create runner endpoint to validate assignedProjects prop format (Merged: Oct 22, 2025)</description>
+      <pubDate>Wed, 22 Oct 2025 18:28:32 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4429</guid>
+    </item>
+    <item>
+      <title>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4441</link>
+      <description>Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds (Merged: Oct 22, 2025)</description>
+      <pubDate>Wed, 22 Oct 2025 17:07:40 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4441</guid>
+    </item>
+    <item>
+      <title>Set default runner replica type to manual if not provided in API request</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4428</link>
+      <description>Set default runner replica type to manual if not provided in API request (Merged: Oct 21, 2025)</description>
+      <pubDate>Tue, 21 Oct 2025 21:46:07 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4428</guid>
+    </item>
+    <item>
+      <title>Allow Script Arguments on GitHub Run Script plugin</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4403</link>
+      <description>Allow Script Arguments on GitHub Run Script plugin (Merged: Oct 21, 2025)</description>
+      <pubDate>Tue, 21 Oct 2025 15:46:55 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4403</guid>
+    </item>
+    <item>
+      <title>Improve the nodehealth check cache refresh</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4424</link>
+      <description>Improve the nodehealth check cache refresh (Merged: Oct 21, 2025)</description>
+      <pubDate>Tue, 21 Oct 2025 13:12:25 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4424</guid>
+    </item>
+    <item>
+      <title>Runner Wizard error creating runner linux+ephemeral</title>
+      <link>https://github.com/rundeckpro/rundeckpro/pull/4414</link>
+      <description>Runner Wizard error creating runner linux+ephemeral (Merged: Oct 8, 2025)</description>
+      <pubDate>Wed, 08 Oct 2025 15:26:30 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4414</guid>
+    </item>
   </channel>
 </rss>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,7 +5,7 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 00:00:39 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 00:10:01 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>

--- a/docs/.vuepress/public/feeds/development.xml
+++ b/docs/.vuepress/public/feeds/development.xml
@@ -5,8 +5,29 @@
     <link>https://docs.rundeck.com/docs</link>
     <description>Recent merged pull requests and development updates from Rundeck</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 06 Nov 2025 00:10:01 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Nov 2025 15:33:13 GMT</lastBuildDate>
     <atom:link href="https://docs.rundeck.com/feeds/development.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Update nimbusJose for CVE-2025-53864</title>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
+      <description>Update nimbusJose for CVE-2025-53864 (Merged: Oct 29, 2025)</description>
+      <pubDate>Wed, 29 Oct 2025 15:28:47 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4453</guid>
+    </item>
+    <item>
+      <title>Bouncy Castle 1.79 for CVE-2025-8916</title>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
+      <description>Bouncy Castle 1.79 for CVE-2025-8916 (Merged: Oct 23, 2025)</description>
+      <pubDate>Thu, 23 Oct 2025 16:54:27 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4443</guid>
+    </item>
+    <item>
+      <title>SSM cannot run job for more than 1 hour</title>
+      <link>https://docs.rundeck.com/docs/history/updates/</link>
+      <description>SSM cannot run job for more than 1 hour (Merged: Oct 23, 2025)</description>
+      <pubDate>Thu, 23 Oct 2025 16:31:42 GMT</pubDate>
+      <guid isPermaLink="false">rundeck-pr-rundeckpro-4444</guid>
+    </item>
     <item>
       <title>Improvement in the create runner endpoint to validate assignedProjects prop format</title>
       <link>https://docs.rundeck.com/docs/history/updates/</link>

--- a/docs/.vuepress/sidebar-menus/history.ts
+++ b/docs/.vuepress/sidebar-menus/history.ts
@@ -10,6 +10,11 @@ export default [
     children: [
       ...getHistory('docs/history/'),
       {
+        text: 'Recent Changes',
+        collapsible: true,
+        link: '/history/updates/'
+      },
+      {
         text: '5.x',
         collapsible: true,
         link: '/history/',

--- a/docs/.vuepress/sidebar-menus/history.ts
+++ b/docs/.vuepress/sidebar-menus/history.ts
@@ -3,17 +3,21 @@ import getChildren from '../getChildren'
 
 export default [
   {
-    text: 'Release Notes',
+    text: 'Latest Release',
     collapsible: false,
+    link: '/history/5_x/version-5.17.0.md',
+  },
+  {
+    text: 'Recent Changes',
+    collapsible: true,
+    link: '/history/updates/'
+  },
+  {
+    text: 'Release Notes',
+    collapsible: true,
     link: '/history/',
     headerDepth: 1,
     children: [
-      ...getHistory('docs/history/'),
-      {
-        text: 'Recent Changes',
-        collapsible: true,
-        link: '/history/updates/'
-      },
       {
         text: '5.x',
         collapsible: true,
@@ -61,324 +65,323 @@ export default [
         link: '/history/',
         children: getChildren('docs/history/', '1_x'),
       },
+    ]
+  },
+  {
+    text: "Security Advisories",
+    collapsible: true,
+    link: '/history/cves/',
+    children: getChildren('docs/history/', 'cves'),
+  },
+  {
+    text: "Previous Version Docs",
+    collapsible: true,
+    children: [
       {
-        text: "Security Advisories",
-        collapsible: true,
-        link: '/history/cves/',
-        children: getChildren('docs/history/', 'cves'),
-      },
-      {
-        text: "Previous Version Docs",
+        text: 'Version 5.x',
         collapsible: true,
         children: [
           {
-            text: 'Version 5.x',
-            collapsible: true,
-            children: [
-              {
-                text: "5.17.0",
-                link: "https://docs.rundeck.com/5.17.0/"
-              },
+            text: "5.17.0",
+            link: "https://docs.rundeck.com/5.17.0/"
+          },
 
-              {
-                text: "5.16.0",
-                link: "https://docs.rundeck.com/5.16.0/"
-              },
-              {
-                text: "5.15.0",
-                link: "https://docs.rundeck.com/5.15.0/"
-              },
-              {
-                text: "5.14.1",
-                link: "https://docs.rundeck.com/5.14.1/"
-              },
-              {
-                text: "5.14.0",
-                link: "https://docs.rundeck.com/5.14.0/"
-              },
-              {
-                text: "5.13.0",
-                link: "https://docs.rundeck.com/5.13.0/"
-              },
-              {
-                text: "5.12.0",
-                link: "https://docs.rundeck.com/5.12.0/"
-              },
-              {
-                text: "5.11.1",
-                link: "https://docs.rundeck.com/5.11.1/"
-              },
-              {
-                text: "5.10.1",
-                link: "https://docs.rundeck.com/5.10.1/"
-              },
-              {
-                text: "5.9.0",
-                link: "https://docs.rundeck.com/5.9.0/"
-              },
-              {
-                text: "5.8.0",
-                link: "https://docs.rundeck.com/5.8.0/"
-              },
-              {
-                text: "5.7.0",
-                link: "https://docs.rundeck.com/5.7.0/"
-              },
-              {
-                text: "5.6.1",
-                link: "https://docs.rundeck.com/5.6.1/"
-              },
-              {
-                text: "5.6.0",
-                link: "https://docs.rundeck.com/5.6.0/"
-              },
-              {
-                text: "5.5.0",
-                link: "https://docs.rundeck.com/5.5.0/"
-              },
-              {
-                text: "5.4.0",
-                link: "https://docs.rundeck.com/5.4.0/"
-              },
-              {
-                text: "5.3.0",
-                link: "https://docs.rundeck.com/5.3.0/"
-              },
-              {
-                text: "5.2.0",
-                link: "https://docs.rundeck.com/5.2.0/"
-              },
-              {
-                text: "5.1.2",
-                link: "https://docs.rundeck.com/5.1.2/"
-              },
-              {
-                text: "5.1.1",
-                link: "https://docs.rundeck.com/5.1.1/"
-              },
-              {
-                text: "5.1.0",
-                link: "https://docs.rundeck.com/5.1.0/"
-              },
-              {
-                text: "5.0.2",
-                link: "https://docs.rundeck.com/5.0.2/"
-              },
-              {
-                text: "5.0.1",
-                link: "https://docs.rundeck.com/5.0.1/"
-              },
-              {
-                text: "5.0.0",
-                link: "https://docs.rundeck.com/5.0.0/"
-              }
-            ]
+          {
+            text: "5.16.0",
+            link: "https://docs.rundeck.com/5.16.0/"
           },
           {
-            text: 'Version 4.x',
-            collapsible: true,
-            children: [
-              {
-                text: "4.17.6",
-                link: "https://docs.rundeck.com/4.17.6/"
-              },
-              {
-                text: "4.17.5",
-                link: "https://docs.rundeck.com/4.17.5/"
-              },
-              {
-                text: "4.17.4",
-                link: "https://docs.rundeck.com/4.17.4/"
-              },
-              {
-                text: "4.17.3",
-                link: "https://docs.rundeck.com/4.17.3/"
-              },
-              {
-                text: "4.17.2",
-                link: "https://docs.rundeck.com/4.17.2/"
-              },
-              {
-                text: "4.17.1",
-                link: "https://docs.rundeck.com/4.17.1/"
-              },
-              {
-                text: "4.17.0",
-                link: "https://docs.rundeck.com/4.17.0/"
-              },
-              {
-                text: "4.16.0",
-                link: "https://docs.rundeck.com/4.16.0/"
-              },
-              {
-                text: "4.15.0",
-                link: "https://docs.rundeck.com/4.15.0/"
-              },
-              {
-                text: "4.14.2",
-                link: "https://docs.rundeck.com/4.14.2/"
-              },
-              {
-                text: "4.14.1",
-                link: "https://docs.rundeck.com/4.14.1/"
-              },
-              {
-                text: "4.14.0",
-                link: "https://docs.rundeck.com/4.14.0/"
-              },
-              {
-                text: "4.13.0",
-                link: "https://docs.rundeck.com/4.13.0/"
-              },
-              {
-                text: "4.12.1",
-                link: "https://docs.rundeck.com/4.12.1/"
-              },
-              {
-                text: "4.12.0",
-                link: "https://docs.rundeck.com/4.12.0/"
-              },
-              {
-                text: "4.11.0",
-                link: "https://docs.rundeck.com/4.11.0/"
-              },
-              {
-                text: "4.10.2",
-                link: "https://docs.rundeck.com/4.10.2/"
-              },
-              {
-                text: "4.10.1",
-                link: "https://docs.rundeck.com/4.10.1/"
-              },
-              {
-                text: "4.10.0",
-                link: "https://docs.rundeck.com/4.10.0/"
-              },
-              {
-                text: "4.9.0",
-                link: "https://docs.rundeck.com/4.9.0/"
-              },
-              {
-                text: "4.8.0",
-                link: "https://docs.rundeck.com/4.8.0/"
-              },
-              {
-                text: "4.7.0",
-                link: "https://docs.rundeck.com/4.7.0/"
-              },
-              {
-                text: "4.6.1",
-                link: "https://docs.rundeck.com/4.6.1/"
-              },
-              {
-                text: "4.5.0",
-                link: "https://docs.rundeck.com/4.5.0/"
-              },
-              {
-                text: "4.4.0",
-                link: "https://docs.rundeck.com/4.4.0/"
-              },
-              {
-                text: "4.3.0",
-                link: "https://docs.rundeck.com/4.3.0/"
-              },
-              {
-                text: "4.2.0",
-                link: "https://docs.rundeck.com/4.2.0/"
-              },
-              {
-                text: "4.1.0",
-                link: "https://docs.rundeck.com/4.1.0/"
-              },
-              {
-                text: "4.0.0",
-                link: "https://docs.rundeck.com/4.0.0/"
-              }
-            ]
+            text: "5.15.0",
+            link: "https://docs.rundeck.com/5.15.0/"
           },
           {
-            text: 'Version 3.x',
-            collapsible: true,
-            children: [
-              {
-                text: "3.4.10",
-                link: "https://docs.rundeck.com/3.4.10/"
-              },
-              {
-                text: "3.3.9",
-                link: "https://docs.rundeck.com/3.3.9/"
-              },
-              {
-                text: "3.2.9",
-                link: "https://docs.rundeck.com/3.2.9/"
-              },
-              {
-                text: "3.1.3",
-                link: "https://docs.rundeck.com/3.1.3/"
-              },
-              {
-                text: "3.0.27",
-                link: "https://docs.rundeck.com/3.0.27/"
-              }
-            ]
+            text: "5.14.1",
+            link: "https://docs.rundeck.com/5.14.1/"
           },
           {
-            text: 'Version 2.x',
-            collapsible: true,
-            children: [
-              {
-                text: "2.11.14",
-                link: "https://docs.rundeck.com/2.11.14/"
-              },
-              {
-                text: "2.10.8",
-                link: "https://docs.rundeck.com/2.10.8/"
-              },
-              {
-                text: "2.9.2",
-                link: "https://docs.rundeck.com/2.9.2/"
-              },
-              {
-                text: "2.8.4",
-                link: "https://docs.rundeck.com/2.8.4/"
-              },
-              {
-                text: "2.7.3",
-                link: "https://docs.rundeck.com/2.7.3/"
-              },
-              {
-                text: "2.6.11",
-                link: "https://docs.rundeck.com/2.6.11/"
-              },
-              {
-                text: "2.5.3",
-                link: "https://docs.rundeck.com/2.5.3/"
-              },
-              {
-                text: "2.4.2",
-                link: "https://docs.rundeck.com/2.4.2/"
-              },
-              {
-                text: "2.3.2",
-                link: "https://docs.rundeck.com/2.3.2/"
-              },
-              {
-                text: "2.2.3",
-                link: "https://docs.rundeck.com/2.2.3/"
-              },
-              {
-                text: "2.1.3",
-                link: "https://docs.rundeck.com/2.1.3/"
-              },
-              {
-                text: "2.0.4",
-                link: "https://docs.rundeck.com/2.0.4/"
-              }
-            ]
+            text: "5.14.0",
+            link: "https://docs.rundeck.com/5.14.0/"
+          },
+          {
+            text: "5.13.0",
+            link: "https://docs.rundeck.com/5.13.0/"
+          },
+          {
+            text: "5.12.0",
+            link: "https://docs.rundeck.com/5.12.0/"
+          },
+          {
+            text: "5.11.1",
+            link: "https://docs.rundeck.com/5.11.1/"
+          },
+          {
+            text: "5.10.1",
+            link: "https://docs.rundeck.com/5.10.1/"
+          },
+          {
+            text: "5.9.0",
+            link: "https://docs.rundeck.com/5.9.0/"
+          },
+          {
+            text: "5.8.0",
+            link: "https://docs.rundeck.com/5.8.0/"
+          },
+          {
+            text: "5.7.0",
+            link: "https://docs.rundeck.com/5.7.0/"
+          },
+          {
+            text: "5.6.1",
+            link: "https://docs.rundeck.com/5.6.1/"
+          },
+          {
+            text: "5.6.0",
+            link: "https://docs.rundeck.com/5.6.0/"
+          },
+          {
+            text: "5.5.0",
+            link: "https://docs.rundeck.com/5.5.0/"
+          },
+          {
+            text: "5.4.0",
+            link: "https://docs.rundeck.com/5.4.0/"
+          },
+          {
+            text: "5.3.0",
+            link: "https://docs.rundeck.com/5.3.0/"
+          },
+          {
+            text: "5.2.0",
+            link: "https://docs.rundeck.com/5.2.0/"
+          },
+          {
+            text: "5.1.2",
+            link: "https://docs.rundeck.com/5.1.2/"
+          },
+          {
+            text: "5.1.1",
+            link: "https://docs.rundeck.com/5.1.1/"
+          },
+          {
+            text: "5.1.0",
+            link: "https://docs.rundeck.com/5.1.0/"
+          },
+          {
+            text: "5.0.2",
+            link: "https://docs.rundeck.com/5.0.2/"
+          },
+          {
+            text: "5.0.1",
+            link: "https://docs.rundeck.com/5.0.1/"
+          },
+          {
+            text: "5.0.0",
+            link: "https://docs.rundeck.com/5.0.0/"
+          }
+        ]
+      },
+      {
+        text: 'Version 4.x',
+        collapsible: true,
+        children: [
+          {
+            text: "4.17.6",
+            link: "https://docs.rundeck.com/4.17.6/"
+          },
+          {
+            text: "4.17.5",
+            link: "https://docs.rundeck.com/4.17.5/"
+          },
+          {
+            text: "4.17.4",
+            link: "https://docs.rundeck.com/4.17.4/"
+          },
+          {
+            text: "4.17.3",
+            link: "https://docs.rundeck.com/4.17.3/"
+          },
+          {
+            text: "4.17.2",
+            link: "https://docs.rundeck.com/4.17.2/"
+          },
+          {
+            text: "4.17.1",
+            link: "https://docs.rundeck.com/4.17.1/"
+          },
+          {
+            text: "4.17.0",
+            link: "https://docs.rundeck.com/4.17.0/"
+          },
+          {
+            text: "4.16.0",
+            link: "https://docs.rundeck.com/4.16.0/"
+          },
+          {
+            text: "4.15.0",
+            link: "https://docs.rundeck.com/4.15.0/"
+          },
+          {
+            text: "4.14.2",
+            link: "https://docs.rundeck.com/4.14.2/"
+          },
+          {
+            text: "4.14.1",
+            link: "https://docs.rundeck.com/4.14.1/"
+          },
+          {
+            text: "4.14.0",
+            link: "https://docs.rundeck.com/4.14.0/"
+          },
+          {
+            text: "4.13.0",
+            link: "https://docs.rundeck.com/4.13.0/"
+          },
+          {
+            text: "4.12.1",
+            link: "https://docs.rundeck.com/4.12.1/"
+          },
+          {
+            text: "4.12.0",
+            link: "https://docs.rundeck.com/4.12.0/"
+          },
+          {
+            text: "4.11.0",
+            link: "https://docs.rundeck.com/4.11.0/"
+          },
+          {
+            text: "4.10.2",
+            link: "https://docs.rundeck.com/4.10.2/"
+          },
+          {
+            text: "4.10.1",
+            link: "https://docs.rundeck.com/4.10.1/"
+          },
+          {
+            text: "4.10.0",
+            link: "https://docs.rundeck.com/4.10.0/"
+          },
+          {
+            text: "4.9.0",
+            link: "https://docs.rundeck.com/4.9.0/"
+          },
+          {
+            text: "4.8.0",
+            link: "https://docs.rundeck.com/4.8.0/"
+          },
+          {
+            text: "4.7.0",
+            link: "https://docs.rundeck.com/4.7.0/"
+          },
+          {
+            text: "4.6.1",
+            link: "https://docs.rundeck.com/4.6.1/"
+          },
+          {
+            text: "4.5.0",
+            link: "https://docs.rundeck.com/4.5.0/"
+          },
+          {
+            text: "4.4.0",
+            link: "https://docs.rundeck.com/4.4.0/"
+          },
+          {
+            text: "4.3.0",
+            link: "https://docs.rundeck.com/4.3.0/"
+          },
+          {
+            text: "4.2.0",
+            link: "https://docs.rundeck.com/4.2.0/"
+          },
+          {
+            text: "4.1.0",
+            link: "https://docs.rundeck.com/4.1.0/"
+          },
+          {
+            text: "4.0.0",
+            link: "https://docs.rundeck.com/4.0.0/"
+          }
+        ]
+      },
+      {
+        text: 'Version 3.x',
+        collapsible: true,
+        children: [
+          {
+            text: "3.4.10",
+            link: "https://docs.rundeck.com/3.4.10/"
+          },
+          {
+            text: "3.3.9",
+            link: "https://docs.rundeck.com/3.3.9/"
+          },
+          {
+            text: "3.2.9",
+            link: "https://docs.rundeck.com/3.2.9/"
+          },
+          {
+            text: "3.1.3",
+            link: "https://docs.rundeck.com/3.1.3/"
+          },
+          {
+            text: "3.0.27",
+            link: "https://docs.rundeck.com/3.0.27/"
+          }
+        ]
+      },
+      {
+        text: 'Version 2.x',
+        collapsible: true,
+        children: [
+          {
+            text: "2.11.14",
+            link: "https://docs.rundeck.com/2.11.14/"
+          },
+          {
+            text: "2.10.8",
+            link: "https://docs.rundeck.com/2.10.8/"
+          },
+          {
+            text: "2.9.2",
+            link: "https://docs.rundeck.com/2.9.2/"
+          },
+          {
+            text: "2.8.4",
+            link: "https://docs.rundeck.com/2.8.4/"
+          },
+          {
+            text: "2.7.3",
+            link: "https://docs.rundeck.com/2.7.3/"
+          },
+          {
+            text: "2.6.11",
+            link: "https://docs.rundeck.com/2.6.11/"
+          },
+          {
+            text: "2.5.3",
+            link: "https://docs.rundeck.com/2.5.3/"
+          },
+          {
+            text: "2.4.2",
+            link: "https://docs.rundeck.com/2.4.2/"
+          },
+          {
+            text: "2.3.2",
+            link: "https://docs.rundeck.com/2.3.2/"
+          },
+          {
+            text: "2.2.3",
+            link: "https://docs.rundeck.com/2.2.3/"
+          },
+          {
+            text: "2.1.3",
+            link: "https://docs.rundeck.com/2.1.3/"
+          },
+          {
+            text: "2.0.4",
+            link: "https://docs.rundeck.com/2.0.4/"
           }
         ]
       }
-    ],
-  },
-
+    ]
+  }
 ]

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -96,7 +96,6 @@ Release Date: November 3rd, 2025
 
 Submit your own Pull Requests to get recognition here!
 
-*  ([jayas006](https://github.com/jayas006))
 * Lucas Migliorini ([luqpy](https://github.com/luqpy))
 
 

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -24,7 +24,7 @@ We have recently introduced a new, [beta method for viewing our API](/api/api_ba
 
 ##### ::circle-dot:: Improvement in the create runner endpoint to validate assignedProjects prop format
   
-Fixed an issue to avoid creating a runner via API with a wrong format to the assginedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
+Fixed an issue to avoid creating a runner via API with a wrong format to the assignedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
 
 ##### ::circle-dot:: Set default runner replica type to manual if not provided in API request
 

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -45,7 +45,7 @@ Adds support for passing custom arguments to scripts executed by the GitHubScrip
 
 #####  ::circle-dot:: [OpenAPI doc improvements](https://github.com/rundeck/rundeck/pull/9852)
   
-We working on a dynamically generated OpenAPI spec file that is hosted on our documentation site at [https://docs.rundeck.com/docs/api/](https://docs.rundeck.com/docs/api/).  Currently this functionality is Beta, but the output can be viewed their in two different viewers.  Going forward there will continue to be improvements to these specs.  For more information check out our release notes stream on the release notes page for 5.17.0.
+We are working on a dynamically generated OpenAPI spec file that is hosted on our documentation site at [https://docs.rundeck.com/docs/api/](https://docs.rundeck.com/docs/api/).  Currently this functionality is Beta, but the output can be viewed there in two different viewers.  Going forward there will continue to be improvements to these specs.  For more information check out our release notes stream on the release notes page for 5.17.0.
 
 #####  ::circle-dot:: [Execution view shows local timezone](https://github.com/rundeck/rundeck/pull/9848)
   

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -1,9 +1,9 @@
 ---
 
 title: "5.17.0 Release Notes"
-date: 2025-11-03
+date: 2025-11-06
 image: /images/chevron-logo-red-on-white.png
-description: "Rundeck | Runbook Automation Releases 5.17.0 - Runner management enhancements, improved node health checks, API updates, and expanded plugin flexibility."
+description: "Rundeck | Runbook Automation Releases 5.17.0 - <DESCRIPTION>"
 feed:
  enable: true
  description: ""
@@ -16,50 +16,58 @@ feed:
 
 <!-- <VidStack src="youtube/REPLACE" poster="https://img.youtube.com/vi/REPLACE/maxresdefault.jpg"/> -->
 
-This release introduces several key enhancements to Rundeck’s automation and runner management capabilities. The create runner endpoint now validates the assignedProjects property format, ensuring more reliable runner assignments. Default runner replica types are set to manual when not specified, simplifying API requests. Node health check cache refreshes have been improved for better system monitoring, and errors related to runner creation in the wizard (especially for Linux ephemeral runners) have been addressed. Additionally, the GitHub Run Script plugin now supports script arguments, expanding its flexibility for automation workflows.
-
-We have recently introduced a new, [beta method for viewing our API](/api/api_basics.md#openapi-views): the OpenAPI specification file is now automatically generated from our code base, helping ensure documentation remains current. As this feature is still in beta, we are continuing to refine the official spec file over the next few releases. We welcome your feedback and encourage you to report any issues you encounter.
-
 ## Runbook Automation Updates
 
-> Also includes all Open Source updates from below
+##### ::circle-dot:: Improvement in the create runner endpoint to validate assignedProjects prop format
+  
+Fixed an issue to avoid creating a runner via API with a wrong format to the assginedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
 
-* Improvement in the create runner endpoint to validate assignedProjects prop format
-* Set default runner replica type to manual if not provided in API request
-* Improve the nodehealth check cache refresh
-* Runner Wizard error creating runner linux+ephemeral
-* Allow Script Arguments on GitHub Run Script plugin
+##### ::circle-dot:: Set default runner replica type to manual if not provided in API request
+
+##### ::circle-dot:: Improve the nodehealth check cache refresh
+  
+Removes the automatic 30-second cache refresh mechanism for node health checks and replaces it with a GUI-based refresh approach. The change eliminates forced periodic cache reloads that occurred every 30 seconds, improving performance by relying on user-initiated refreshes instead.
+
+##### ::circle-dot:: Runner Wizard error creating runner linux+ephemeral
+  
+Fixes a Runner Wizard error when creating a Linux ephemeral runner by ensuring proper state management and artifact naming.
+
+##### ::circle-dot:: Allow Script Arguments on GitHub Run Script plugin
+  
+Adds support for passing custom arguments to scripts executed by the GitHubScriptPlugin, allowing users to specify script arguments with shell-like quoting and escaping functionality.
 
 
 ## Rundeck Open Source Product Updates
 
-* [OpenAPI doc improvements](https://github.com/rundeck/rundeck/pull/9852)
-* [Fix example value in set-project-config documentation](https://github.com/rundeck/rundeck/pull/9851)
-* [Clean up println statements from JobAuditApiSpec](https://github.com/rundeck/rundeck/pull/9850)
-* [Execution view shows local timezone](https://github.com/rundeck/rundeck/pull/9848)
-* [change exec cleanup to hql](https://github.com/rundeck/rundeck/pull/9845)
-* [Fix valuelistdelimiter issue when using a | as separator](https://github.com/rundeck/rundeck/pull/9843)
-* [Feature/Add Job Creation Date And Last Modified User Audit Tracking To Job Metadata](https://github.com/rundeck/rundeck/pull/9839)
-* [Remediate CVE-2025-59952](https://github.com/rundeck/rundeck/pull/9837)
-* [Fix CVE-2020-25638](https://github.com/rundeck/rundeck/pull/9824)
-* [Add option based filter for jobs activity  ](https://github.com/rundeck/rundeck/pull/9823)
-* [Yaml exported job delimiter issue](https://github.com/rundeck/rundeck/pull/9821)
-* [Update log4j2.properties.template to add Pre authentication logs](https://github.com/rundeck/rundeck/pull/9820)
-* [Fix error on project export using the UI](https://github.com/rundeck/rundeck/pull/9818)
-* [Fix button to select deselect all on project export ](https://github.com/rundeck/rundeck/pull/9817)
-* [force to load the orchestrator values in the execution object in Job Notification](https://github.com/rundeck/rundeck/pull/9811)
-* [Error Saving config: Undefined immediately after adding Node Source](https://github.com/rundeck/rundeck/pull/9797)
-* [Convert Job File Upload form to Vue](https://github.com/rundeck/rundeck/pull/9791)
-* [Job Import: skip duplicate option causes 500 error](https://github.com/rundeck/rundeck/pull/9790)
-* [Enh/Add logger.cleanup on Remco log4j template](https://github.com/rundeck/rundeck/pull/9770)
-* [Add index for retry_execution_id in the execution table](https://github.com/rundeck/rundeck/pull/9750)
-* [Add preauthentication logging configs](https://github.com/rundeck/rundeck/pull/9091)
+#####  ::circle-dot:: [OpenAPI doc improvements](https://github.com/rundeck/rundeck/pull/9852)
+
+#####  ::circle-dot:: [Execution view shows local timezone](https://github.com/rundeck/rundeck/pull/9848)
+  
+Improves time display formatting across the UI consistent timezone-aware time formatting for execution start/end dates and log entries.
+
+#####  ::circle-dot:: [Feature/Add Job Creation Date And Last Modified User Audit Tracking To Job Metadata](https://github.com/rundeck/rundeck/pull/9839)
+  
+This helps teams see who owns each job and when it was last changed. When importing jobs, the tracking information is protected so it doesn&#39;t get overwritten.
+
+#####  ::circle-dot:: [Remediate CVE-2025-59952](https://github.com/rundeck/rundeck/pull/9837)
+
+#####  ::circle-dot:: [Remediate CVE-2020-25638](https://github.com/rundeck/rundeck/pull/9824)
+
+#####  ::circle-dot:: [Update log4j2.properties.template to add Pre authentication logs](https://github.com/rundeck/rundeck/pull/9820)
+
+#####  ::circle-dot:: [Fix button to select/deselect all on project export ](https://github.com/rundeck/rundeck/pull/9817)
+
+#####  ::circle-dot:: [Add index for retry_execution_id in the execution table](https://github.com/rundeck/rundeck/pull/9750)
+  
+Adds a database index on the retry_execution_id column in the execution table to improve performance during execution cleanup operations and reduce Oracle database deadlock issues.
+
+#####  ::circle-dot:: [Enh/Add logger.cleanup on Remco log4j template](https://github.com/rundeck/rundeck/pull/9716)
+  
+Adds logger configuration for the ExecutionsCleanUp job in the Remco log4j2 template for Docker images. The change enables proper logging visibility for cleanup execution history operations without requiring global log level modifications.
 
 
 [Here is a link to the full list of public PRs](https://github.com/rundeck/rundeck/pulls?q=is%3Apr+milestone%3A5.17.0+is%3Aclosed)
 
-## Ansible Plugin Updates
-* [CVE Fixes](https://github.com/rundeck-plugins/ansible-plugin/pull/418)
 
 
 
@@ -75,15 +83,15 @@ We have recently introduced a new, [beta method for viewing our API](/api/api_ba
 
 Name: <span style="color: sandybrown"><span class="glyphicon glyphicon-flag"></span> "Mont Blanc sandybrown flag"</span>
 
-Release Date: November 3rd, 2025
+Release Date: November 6th, 2025
 
 
 ## Community Contributors
 
 Submit your own Pull Requests to get recognition here!
 
-* J. Casalino ([thedoc31](https://github.com/thedoc31))
-* Takafumi Noguchi ([tknog-pd](https://github.com/tknog-pd))
+*  ([jayas006](https://github.com/jayas006))
+* Lucas Migliorini ([luqpy](https://github.com/luqpy))
 
 
 ## Staff Contributors
@@ -92,9 +100,9 @@ Submit your own Pull Requests to get recognition here!
 * Carlos Eduardo ([carlosrfranco](https://github.com/carlosrfranco))
 * Eduardo Baltra ([edbaltra](https://github.com/edbaltra))
 * Forrest Evans ([fdevans](https://github.com/fdevans))
+* Jaime Tobar ([jtobard](https://github.com/jtobard))
 * Jake Cohen ([jsboak](https://github.com/jsboak))
 * Jaya Singh ([jayas006](https://github.com/jayas006))
-* Jason Brooks ([jbrookspd](https://github.com/jbrookspd))
 * Jesus Osuna ([Jesus-Osuna-M](https://github.com/Jesus-Osuna-M))
 * José Vásquez ([hiawvp](https://github.com/hiawvp))
 * Luis Toledo ([ltamaster](https://github.com/ltamaster))

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -3,10 +3,10 @@
 title: "5.17.0 Release Notes"
 date: 2025-11-06
 image: /images/chevron-logo-red-on-white.png
-description: "Rundeck | Runbook Automation Releases 5.17.0 - <DESCRIPTION>"
+description: "Rundeck | Runbook Automation Releases 5.17.0 - Open API Spec Beta, and lots of bug fixes."
 feed:
  enable: true
- description: ""
+ description: "Open API Spec Beta, and lots of bug fixes"
 
 ---
 
@@ -14,7 +14,11 @@ feed:
 
 ## Overview
 
-<!-- <VidStack src="youtube/REPLACE" poster="https://img.youtube.com/vi/REPLACE/maxresdefault.jpg"/> -->
+<VidStack src="youtube/GTK71H-S0R4" poster="https://img.youtube.com/vi/GTK71H-S0R4/maxresdefault.jpg"/>
+
+This release introduces several key enhancements to Rundeck’s automation and runner management capabilities. The create runner endpoint now validates the assignedProjects property format, ensuring more reliable runner assignments. Default runner replica types are set to manual when not specified, simplifying API requests. Node health check cache refreshes have been improved for better system monitoring, and errors related to runner creation in the wizard (especially for Linux ephemeral runners) have been addressed. Additionally, the GitHub Run Script plugin now supports script arguments, expanding its flexibility for automation workflows.
+
+We have recently introduced a new, [beta method for viewing our API](/api/api_basics.md#openapi-views): the OpenAPI specification file is now automatically generated from our code base, helping ensure documentation remains current. As this feature is still in beta, we are continuing to refine the official spec file over the next few releases. We welcome your feedback and encourage you to report any issues you encounter.
 
 ## Runbook Automation Updates
 
@@ -40,6 +44,8 @@ Adds support for passing custom arguments to scripts executed by the GitHubScrip
 ## Rundeck Open Source Product Updates
 
 #####  ::circle-dot:: [OpenAPI doc improvements](https://github.com/rundeck/rundeck/pull/9852)
+  
+We working on a dynamically generated OpenAPI spec file that is hosted on our documentation site at [https://docs.rundeck.com/docs/api/](https://docs.rundeck.com/docs/api/).  Currently this functionality is Beta, but the output can be viewed their in two different viewers.  Going forward there will continue to be improvements to these specs.  For more information check out our release notes stream on the release notes page for 5.17.0.
 
 #####  ::circle-dot:: [Execution view shows local timezone](https://github.com/rundeck/rundeck/pull/9848)
   

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -1,7 +1,7 @@
 ---
 
 title: "5.17.0 Release Notes"
-date: 2025-11-06
+date: 2025-11-03
 image: /images/chevron-logo-red-on-white.png
 description: "Rundeck | Runbook Automation Releases 5.17.0 - Open API Spec Beta, and lots of bug fixes."
 feed:
@@ -89,7 +89,7 @@ Adds logger configuration for the ExecutionsCleanUp job in the Remco log4j2 temp
 
 Name: <span style="color: sandybrown"><span class="glyphicon glyphicon-flag"></span> "Mont Blanc sandybrown flag"</span>
 
-Release Date: November 6th, 2025
+Release Date: November 3rd, 2025
 
 
 ## Community Contributors

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -49,7 +49,7 @@ We are working on a dynamically generated OpenAPI spec file that is hosted on ou
 
 #####  ::circle-dot:: [Execution view shows local timezone](https://github.com/rundeck/rundeck/pull/9848)
   
-Improves time display formatting across the UI consistent timezone-aware time formatting for execution start/end dates and log entries.
+Improves time display formatting across the UI with consistent timezone-aware time formatting for execution start/end dates and log entries.
 
 #####  ::circle-dot:: [Feature/Add Job Creation Date And Last Modified User Audit Tracking To Job Metadata](https://github.com/rundeck/rundeck/pull/9839)
   

--- a/docs/history/index.md
+++ b/docs/history/index.md
@@ -1,4 +1,4 @@
-# Rundeck Release Highlights
+# Release History
 
 ## Most Recent Release Notes
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T17:33:26.026Z
+date: 2025-11-06T18:28:35.090Z
 feed: true
 index: true
 ---
@@ -55,7 +55,11 @@ The development updates are automatically generated from our private development
 
 #### ::circle-check:: Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
 
+  Adds support for passing custom arguments to scripts executed by the GitHubScriptPlugin, allowing users to specify script arguments with shell-like quoting and escaping functionality.
+
 #### ::circle-check:: Improve the nodehealth check cache refresh _(Oct 21, 2025)_
+
+  Removes the automatic 30-second cache refresh mechanism for node health checks and replaces it with a GUI-based refresh approach. The change eliminates forced periodic cache reloads that occurred every 30 seconds, improving performance by relying on user-initiated refreshes instead.
 
 #### ::circle-check:: Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-07T00:05:10.636Z
+date: 2025-11-07T00:17:56.059Z
 feed: true
 index: true
 ---
@@ -10,27 +10,7 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 23, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
-
-## Subscribe to Updates
-
-Stay informed about Rundeck development by subscribing to a feed:
-
-- [RSS Feed](/feeds/development.xml)
-- [Atom Feed](/feeds/development-atom.xml)
-
-These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight changes that may not be available in our Self Hosted Releases yet.
-
-## About These Updates
-
-
-The development updates are automatically generated from both our private repository for the commercial product and the public open source repository to provide complete visibility into changes deployed to the SaaS platform. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
-
-**Note**: These updates only reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
-
----
-
-**List Last updated:** 2025-11-07
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 23, 2025.
 
 ## Recent Changes
 
@@ -51,5 +31,27 @@ The development updates are automatically generated from both our private reposi
 
   Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.
 
+
+
+
+## Subscribe to Updates
+
+Stay informed about Rundeck development by subscribing to a feed:
+
+- [RSS Feed](/feeds/development.xml)
+- [Atom Feed](/feeds/development-atom.xml)
+
+These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight changes that may not be available in our Self Hosted Releases yet.
+
+## About These Updates
+
+
+The development updates are automatically generated from both our private repository for the commercial product and the public open source repository to provide complete visibility into changes deployed to the SaaS platform. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
+
+**Note**: These updates only reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
+
+---
+
+**List Last updated:** 2025-11-07
 
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,0 +1,52 @@
+---
+title: Recent Development Updates
+description: Latest merged changes from the Rundeck development team
+date: 2025-11-05T21:55:10.371Z
+feed: true
+index: true
+---
+
+# Recent Development Updates
+
+Stay up to date with the latest changes and improvements from the Runbook Automation development team.
+
+## Subscribe to Updates
+
+Stay informed about Rundeck development by subscribing to our feeds:
+
+- [RSS Feed](/feeds/development.xml)
+- [Atom Feed](/feeds/development-atom.xml)
+
+These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight important changes that may not be available in our Self Hosted Releases yet.
+
+## About These Updates
+
+The development updates are automatically generated from our private development repository and filtered to show customer-visible changes. They provide insight into active development features available in the Runbook Automation SaaS solution.
+
+**Note**: These updates reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
+
+---
+
+**Last updated:** 2025-11-05
+
+This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 5, 2025.
+
+## Recent Changes
+
+
+#### Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
+
+#### Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
+
+  This PR fixes a parsing error that occurs when processing RSS feeds that use Z as the timezone indicator instead of standard abbreviations like GMT or UTC.
+
+#### Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
+
+#### Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
+
+#### Improve the nodehealth check cache refresh _(Oct 21, 2025)_
+
+#### Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
+
+
+

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T22:20:13.397Z
+date: 2025-11-06T22:48:38.007Z
 feed: true
 index: true
 ---
@@ -10,7 +10,7 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 3, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.18.0](/history/5_x/version-5.18.0.md) on October 6, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
 
 ## Subscribe to Updates
 
@@ -35,46 +35,46 @@ The development updates are automatically generated from both our private reposi
 ## Recent Changes
 
 
-#### ::circle-check:: Multiline Job Options (Beta) _(Nov 4, 2025)_ [PR #9822](https://github.com/rundeck/rundeck/pull/9822)
+#### ::circle-dot:: Multiline Job Options (Beta) _(Nov 4, 2025)_ [PR #9822](https://github.com/rundeck/rundeck/pull/9822)
 
 
   Adds support for Multiline Job Options as a new choice in the &quot;Option Type&quot; dropdown. This allows users to create job options that can accept multi-line text input instead of being limited to single-line text fields.
 
-#### ::circle-check:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
+#### ::circle-dot:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
 
 
-#### ::circle-check:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
+#### ::circle-dot:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
 
 
-#### ::circle-check:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
+#### ::circle-dot:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
 
 
   Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.
 
-#### ::circle-check:: Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
+#### ::circle-dot:: Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
 
 
   Fixed an issue to avoid creating a runner via API with a wrong format to the assginedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
 
-#### ::circle-check:: Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
+#### ::circle-dot:: Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
 
 
   Error that occurs when processing RSS feeds that use Z as the timezone indicator instead of standard abbreviations like GMT or UTC.
 
-#### ::circle-check:: Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
+#### ::circle-dot:: Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
 
 
-#### ::circle-check:: Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
+#### ::circle-dot:: Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
 
 
   Adds support for passing custom arguments to scripts executed by the GitHubScriptPlugin, allowing users to specify script arguments with shell-like quoting and escaping functionality.
 
-#### ::circle-check:: Improve the nodehealth check cache refresh _(Oct 21, 2025)_
+#### ::circle-dot:: Improve the nodehealth check cache refresh _(Oct 21, 2025)_
 
 
   Removes the automatic 30-second cache refresh mechanism for node health checks and replaces it with a GUI-based refresh approach. The change eliminates forced periodic cache reloads that occurred every 30 seconds, improving performance by relying on user-initiated refreshes instead.
 
-#### ::circle-check:: Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
+#### ::circle-dot:: Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
 
 
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-07T00:17:56.059Z
+date: 2025-11-07T00:29:20.912Z
 feed: true
 index: true
 ---
@@ -12,21 +12,25 @@ Stay up to date with the latest changes and improvements from the Runbook Automa
 
 This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 23, 2025.
 
+
+**Last SaaS Deployment:** November 4, 2025
+
+
 ## Recent Changes
 
 
-#### ::circle-dot:: Multiline Job Options (Beta) _(Nov 4, 2025)_ [PR #9822](https://github.com/rundeck/rundeck/pull/9822)
+#### ::circle-dot:: Multiline Job Options (Beta)  [PR #9822](https://github.com/rundeck/rundeck/pull/9822)
 
 
   Adds support for Multiline Job Options as a new choice in the &quot;Option Type&quot; dropdown. This allows users to create job options that can accept multi-line text input instead of being limited to single-line text fields.
 
-#### ::circle-dot:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
+#### ::circle-dot:: Update nimbusJose for CVE-2025-53864 
 
 
-#### ::circle-dot:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
+#### ::circle-dot:: Bouncy Castle 1.79 for CVE-2025-8916 
 
 
-#### ::circle-dot:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
+#### ::circle-dot:: SSM cannot run job for more than 1 hour 
 
 
   Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T23:18:49.073Z
+date: 2025-11-06T23:24:06.905Z
 feed: true
 index: true
 ---

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,35 +1,36 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T15:33:13.906Z
+date: 2025-11-06T17:33:26.026Z
 feed: true
 index: true
 ---
 
 # Recent Development Updates
 
-Stay up to date with the latest changes and improvements from the Runbook Automation development team.
+Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
+
+This page shows recently merged pull requests from the Runbook Automation product repository merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 6, 2025. These changes are specific to the commercial Runbook Automation product, which is built on top of the open source Rundeck project. For updates to the open source Rundeck code, visit the [Rundeck GitHub repository](https://github.com/rundeck/rundeck).
 
 ## Subscribe to Updates
 
-Stay informed about Rundeck development by subscribing to our feeds:
+Stay informed about Rundeck development by subscribing to a feed:
 
 - [RSS Feed](/feeds/development.xml)
 - [Atom Feed](/feeds/development-atom.xml)
 
-These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight important changes that may not be available in our Self Hosted Releases yet.
+These feeds are updated after each deployment to our production Runbook Automation SaaS solution. They highlight changes that may not be available in our Self Hosted Releases yet.
 
 ## About These Updates
 
-The development updates are automatically generated from our private development repository and filtered to show customer-visible changes. They provide insight into active development features available in the Runbook Automation SaaS solution.
 
-**Note**: These updates reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
+The development updates are automatically generated from our private development repository to highlight key changes happening in the SaaS solution. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
+
+**Note**: These updates only reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
 
 ---
 
 **List Last updated:** 2025-11-06
-
-This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 6, 2025.
 
 ## Recent Changes
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T18:28:35.090Z
+date: 2025-11-06T22:20:13.397Z
 feed: true
 index: true
 ---
@@ -10,7 +10,7 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from the Runbook Automation product repository merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 6, 2025. These changes are specific to the commercial Runbook Automation product, which is built on top of the open source Rundeck project. For updates to the open source Rundeck code, visit the [Rundeck GitHub repository](https://github.com/rundeck/rundeck).
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 3, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
 
 ## Subscribe to Updates
 
@@ -24,7 +24,7 @@ These feeds are updated after each deployment to our production Runbook Automati
 ## About These Updates
 
 
-The development updates are automatically generated from our private development repository to highlight key changes happening in the SaaS solution. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
+The development updates are automatically generated from both our private repository for the commercial product and the public open source repository to provide complete visibility into changes deployed to the SaaS platform. They provide insight into active development features available in the Runbook Automation SaaS solution and will be released with the next Self Hosted release.
 
 **Note**: These updates only reflect changes deployed to our SaaS platform. Self-hosted customers should refer to the [Release Notes](/history/) section for version-specific updates applicable to their installation.
 
@@ -35,33 +35,47 @@ The development updates are automatically generated from our private development
 ## Recent Changes
 
 
+#### ::circle-check:: Multiline Job Options (Beta) _(Nov 4, 2025)_ [PR #9822](https://github.com/rundeck/rundeck/pull/9822)
+
+
+  Adds support for Multiline Job Options as a new choice in the &quot;Option Type&quot; dropdown. This allows users to create job options that can accept multi-line text input instead of being limited to single-line text fields.
+
 #### ::circle-check:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
+
 
 #### ::circle-check:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
 
+
 #### ::circle-check:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
+
 
   Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.
 
 #### ::circle-check:: Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
 
+
   Fixed an issue to avoid creating a runner via API with a wrong format to the assginedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
 
 #### ::circle-check:: Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
+
 
   Error that occurs when processing RSS feeds that use Z as the timezone indicator instead of standard abbreviations like GMT or UTC.
 
 #### ::circle-check:: Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
 
+
 #### ::circle-check:: Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
+
 
   Adds support for passing custom arguments to scripts executed by the GitHubScriptPlugin, allowing users to specify script arguments with shell-like quoting and escaping functionality.
 
 #### ::circle-check:: Improve the nodehealth check cache refresh _(Oct 21, 2025)_
 
+
   Removes the automatic 30-second cache refresh mechanism for node health checks and replaces it with a GUI-based refresh approach. The change eliminates forced periodic cache reloads that occurred every 30 seconds, improving performance by relying on user-initiated refreshes instead.
 
 #### ::circle-check:: Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
+
 
 
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T00:10:01.173Z
+date: 2025-11-06T15:33:13.906Z
 feed: true
 index: true
 ---
@@ -34,7 +34,17 @@ This page shows recently merged pull requests from the Rundeck development team 
 ## Recent Changes
 
 
+#### ::circle-check:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
+
+#### ::circle-check:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
+
+#### ::circle-check:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
+
+  Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.
+
 #### ::circle-check:: Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
+
+  Fixed an issue to avoid creating a runner via API with a wrong format to the assginedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
 
 #### ::circle-check:: Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T00:00:39.650Z
+date: 2025-11-06T00:10:01.173Z
 feed: true
 index: true
 ---
@@ -29,7 +29,7 @@ The development updates are automatically generated from our private development
 
 **List Last updated:** 2025-11-06
 
-This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 5, 2025.
+This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 6, 2025.
 
 ## Recent Changes
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T22:48:38.007Z
+date: 2025-11-06T23:18:49.073Z
 feed: true
 index: true
 ---
@@ -10,7 +10,7 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.18.0](/history/5_x/version-5.18.0.md) on October 6, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 27, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
 
 ## Subscribe to Updates
 
@@ -41,40 +41,6 @@ The development updates are automatically generated from both our private reposi
   Adds support for Multiline Job Options as a new choice in the &quot;Option Type&quot; dropdown. This allows users to create job options that can accept multi-line text input instead of being limited to single-line text fields.
 
 #### ::circle-dot:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
-
-
-#### ::circle-dot:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
-
-
-#### ::circle-dot:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
-
-
-  Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.
-
-#### ::circle-dot:: Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
-
-
-  Fixed an issue to avoid creating a runner via API with a wrong format to the assginedProject property. Currently, the runner is being created even if this property is not correct and it causes an error when listing runner from the GUI or via API
-
-#### ::circle-dot:: Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
-
-
-  Error that occurs when processing RSS feeds that use Z as the timezone indicator instead of standard abbreviations like GMT or UTC.
-
-#### ::circle-dot:: Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
-
-
-#### ::circle-dot:: Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
-
-
-  Adds support for passing custom arguments to scripts executed by the GitHubScriptPlugin, allowing users to specify script arguments with shell-like quoting and escaping functionality.
-
-#### ::circle-dot:: Improve the nodehealth check cache refresh _(Oct 21, 2025)_
-
-
-  Removes the automatic 30-second cache refresh mechanism for node health checks and replaces it with a GUI-based refresh approach. The change eliminates forced periodic cache reloads that occurred every 30 seconds, improving performance by relying on user-initiated refreshes instead.
-
-#### ::circle-dot:: Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
 
 
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-05T22:11:27.823Z
+date: 2025-11-05T22:14:45.598Z
 feed: true
 index: true
 ---
@@ -29,10 +29,24 @@ The development updates are automatically generated from our private development
 
 **List Last updated:** 2025-11-05
 
-This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on November 2, 2025.
+This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 5, 2025.
 
 ## Recent Changes
 
 
-*No new updates to report since the last release.*
+#### ::circle-check:: Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
+
+#### ::circle-check:: Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
+
+  Error that occurs when processing RSS feeds that use Z as the timezone indicator instead of standard abbreviations like GMT or UTC.
+
+#### ::circle-check:: Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
+
+#### ::circle-check:: Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
+
+#### ::circle-check:: Improve the nodehealth check cache refresh _(Oct 21, 2025)_
+
+#### ::circle-check:: Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
+
+
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-05T22:14:45.598Z
+date: 2025-11-06T00:00:39.650Z
 feed: true
 index: true
 ---
@@ -27,7 +27,7 @@ The development updates are automatically generated from our private development
 
 ---
 
-**List Last updated:** 2025-11-05
+**List Last updated:** 2025-11-06
 
 This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 5, 2025.
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-06T23:24:06.905Z
+date: 2025-11-07T00:05:10.636Z
 feed: true
 index: true
 ---
@@ -10,7 +10,7 @@ index: true
 
 Stay up to date with the latest changes and improvements from the Runbook Automation development team.  
 
-This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 27, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
+This page shows recently merged pull requests from both the Runbook Automation product repository and the open source Rundeck repository merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on October 23, 2025. These updates reflect changes deployed to our Runbook Automation SaaS platform, combining both private product enhancements and public open source improvements.
 
 ## Subscribe to Updates
 
@@ -30,7 +30,7 @@ The development updates are automatically generated from both our private reposi
 
 ---
 
-**List Last updated:** 2025-11-06
+**List Last updated:** 2025-11-07
 
 ## Recent Changes
 
@@ -42,6 +42,14 @@ The development updates are automatically generated from both our private reposi
 
 #### ::circle-dot:: Update nimbusJose for CVE-2025-53864 _(Oct 29, 2025)_
 
+
+#### ::circle-dot:: Bouncy Castle 1.79 for CVE-2025-8916 _(Oct 23, 2025)_
+
+
+#### ::circle-dot:: SSM cannot run job for more than 1 hour _(Oct 23, 2025)_
+
+
+  Adds configurable SSM execution timeout functionality to allow AWS SSM jobs to run beyond the default 1-hour limit. The changes introduce a new ssm-execution-timeout configuration property that defaults to 3600 seconds (1 hour) but can be adjusted as needed.
 
 
 

--- a/docs/history/updates/index.md
+++ b/docs/history/updates/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recent Development Updates
 description: Latest merged changes from the Rundeck development team
-date: 2025-11-05T21:55:10.371Z
+date: 2025-11-05T22:11:27.823Z
 feed: true
 index: true
 ---
@@ -27,26 +27,12 @@ The development updates are automatically generated from our private development
 
 ---
 
-**Last updated:** 2025-11-05
+**List Last updated:** 2025-11-05
 
-This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.16.0](/history/5_x/version-5.16.0.md) on October 5, 2025.
+This page shows recently merged pull requests from the Rundeck development team merged since the last self-hosted release of [5.17.0](/history/5_x/version-5.17.0.md) on November 2, 2025.
 
 ## Recent Changes
 
 
-#### Improvement in the create runner endpoint to validate assignedProjects prop format _(Oct 22, 2025)_
-
-#### Fix RSS Feeds plugin not recognizing Dates on Microsoft RSS Feeds _(Oct 22, 2025)_
-
-  This PR fixes a parsing error that occurs when processing RSS feeds that use Z as the timezone indicator instead of standard abbreviations like GMT or UTC.
-
-#### Set default runner replica type to manual if not provided in API request _(Oct 21, 2025)_
-
-#### Allow Script Arguments on GitHub Run Script plugin _(Oct 21, 2025)_
-
-#### Improve the nodehealth check cache refresh _(Oct 21, 2025)_
-
-#### Runner Wizard error creating runner linux+ephemeral _(Oct 8, 2025)_
-
-
+*No new updates to report since the last release.*
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "docs:no-cache": "vuepress dev docs --no-cache",
     "deploy:github": "npm run docs:build; push-dir --dir=docs/.vuepress/dist --branch=gh-pages --cleanup",
     "notes": "node ./docs/.vuepress/notes.mjs",
+    "pr-feed": "node ./docs/.vuepress/generate-pr-feed.mjs --include-section=\"Release Notes\"",
     "docs:clean-dev": "vuepress dev docs --clean-cache",
     "docs:update-package": "npx vp-update"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "docs:no-cache": "vuepress dev docs --no-cache",
     "deploy:github": "npm run docs:build; push-dir --dir=docs/.vuepress/dist --branch=gh-pages --cleanup",
     "notes": "node ./docs/.vuepress/notes.mjs",
-    "pr-feed": "node ./docs/.vuepress/generate-pr-feed.mjs --include-section=\"Release Notes\"",
+    "pr-feed": "node ./docs/.vuepress/pr-feed.mjs --include-section=\"Release Notes\"",
     "docs:clean-dev": "vuepress dev docs --clean-cache",
     "docs:update-package": "npx vp-update"
   },


### PR DESCRIPTION
## Add Automated PR Feed Generator for SaaS Development Updates

**!! Note: Before merge we need to update the config file to the latest release.  Current setting is intentionally old so we see entries since 5.16.0.**

### Summary
Implements an automated system to generate customer-facing documentation of changes deployed to the Runbook Automation SaaS platform. This addresses the visibility gap for private repository changes that aren't yet available in self-hosted releases.

### Problem
When we deploy to SaaS (typically weekly), customers only see updates from the public `rundeck` repository. Changes from our private `rundeckpro` repository remain invisible until the next self-hosted release, leaving customers unaware of improvements and fixes they're already using.

### Solution
Created `generate-pr-feed.mjs` - a script that:
- Fetches merged PRs from the private `rundeckpro` repository
- Filters for customer-relevant changes (via `release-notes/include` label)
- Generates a documentation page at `/history/updates/`
- Produces RSS/Atom feeds for automated notifications
- Tracks changes since the last self-hosted release automatically

### Key Features
- **Automatic Baseline Tracking**: Integrated with existing `notes.mjs` workflow - when you generate release notes, the PR feed baseline automatically updates
- **Template-Based**: Uses Nunjucks templates (matching `notes.mjs` pattern) for easy content customization
- **Clean Output**: Removes internal ticket prefixes (RUN-XXXX) from PR titles for customer readability
- **Optional Sections**: Can extract specific sections from PR bodies (e.g., "Release Notes") for additional context
- **Consistent Patterns**: Follows established project conventions for maintainability

### Files Added
- `docs/.vuepress/generate-pr-feed.mjs` - Main script
- `docs/.vuepress/pr-feed.md.nj` - Editable Nunjucks template
- `docs/.vuepress/pr-feed-config.json` - Release baseline tracker
- `docs/history/updates/index.md` - Generated output page
- `PR-FEED-README.md` - Comprehensive documentation

### Files Modified
- `docs/.vuepress/notes.mjs` - Auto-updates PR feed config on release
- `package.json` - Added `pr-feed` npm script
- `README.md` - Added reference to PR feed docs

### Usage
```bash
# Weekly SaaS release process:
npm run pr-feed
git add docs/history/updates/ docs/.vuepress/public/feeds/
git commit -m "Update SaaS deployment feed"
```

### Documentation
See `PR-FEED-README.md` for complete setup instructions, workflow integration, and best practices.
