### PR TITLE
Implement cookie consent for Analytics

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -50,7 +50,14 @@ export default defineClientConfig({
         initializeAnalytics();
         // Track initial page view
         trackPageView(router.currentRoute.value.path);
-      }, { once: true });
+      });
+      
+      // Listen for consent revoked event (when user changes from Accept to Reject)
+      window.addEventListener('ga-consent-revoked', () => {
+        // Clear any existing analytics state if needed
+        // Note: We don't uninitialize GA4 as it's already loaded
+        console.log('Analytics consent revoked - no new events will be tracked');
+      });
 
       // Track page views on route changes
       router.afterEach((to) => {

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -2,6 +2,8 @@ import { defineClientConfig } from '@vuepress/client'
 import '@docsearch/css'
 import Layout from "./layouts/Layout.vue";
 import NotFound from "./layouts/NotFound.vue";
+import CookieConsent from "./components/CookieConsent.vue";
+import { loadGA4, trackPageView, setupAutoTracking, setupVideoTracking, hasConsent } from "./utils/analytics";
 
 declare const VERSION: string;
 declare const VERSION_FULL: string;
@@ -27,6 +29,33 @@ export default defineClientConfig({
       $apiVersion: { get: () => API_VERSION },
       $cliVersion: { get: () => CLI_VERSION },
     });
+
+    // Google Analytics 4 with Cookie Consent
+    if (typeof window !== 'undefined') {
+      // Check if user already gave consent
+      if (hasConsent()) {
+        loadGA4();
+        setupAutoTracking();
+        setupVideoTracking();
+      }
+
+      // Listen for consent granted event
+      window.addEventListener('ga-consent-granted', () => {
+        loadGA4();
+        setupAutoTracking();
+        setupVideoTracking();
+        // Track initial page view
+        trackPageView(router.currentRoute.value.path);
+      });
+
+      // Track page views on route changes
+      router.afterEach((to) => {
+        // Small delay to ensure page title is updated
+        setTimeout(() => {
+          trackPageView(to.path);
+        }, 100);
+      });
+    }
     
     // The section below is used to properly format the Search results on the docs site.
     if (typeof window !== 'undefined') {
@@ -96,5 +125,5 @@ export default defineClientConfig({
     }
   },
   setup() { },
-  rootComponents: [],
+  rootComponents: [CookieConsent],
 })

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -1,4 +1,5 @@
 import { defineClientConfig } from '@vuepress/client'
+import { nextTick } from 'vue'
 import '@docsearch/css'
 import Layout from "./layouts/Layout.vue";
 import NotFound from "./layouts/NotFound.vue";
@@ -50,10 +51,10 @@ export default defineClientConfig({
 
       // Track page views on route changes
       router.afterEach((to) => {
-        // Small delay to ensure page title is updated
-        setTimeout(() => {
+        // Wait for DOM updates to complete
+        nextTick(() => {
           trackPageView(to.path);
-        }, 100);
+        });
       });
     }
     

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -5,6 +5,7 @@ import Layout from "./layouts/Layout.vue";
 import NotFound from "./layouts/NotFound.vue";
 import CookieConsent from "./components/CookieConsent.vue";
 import { loadGA4, trackPageView, setupAutoTracking, setupVideoTracking, hasConsent } from "./utils/analytics";
+import { CONSENT_GRANTED_EVENT, CONSENT_REVOKED_EVENT, CONSENT_DENIED_EVENT } from "./utils/constants";
 
 declare const VERSION: string;
 declare const VERSION_FULL: string;
@@ -46,17 +47,22 @@ export default defineClientConfig({
       }
 
       // Listen for consent granted event
-      window.addEventListener('ga-consent-granted', () => {
+      window.addEventListener(CONSENT_GRANTED_EVENT, () => {
         initializeAnalytics();
         // Track initial page view
         trackPageView(router.currentRoute.value.path);
       });
       
       // Listen for consent revoked event (when user changes from Accept to Reject)
-      window.addEventListener('ga-consent-revoked', () => {
+      window.addEventListener(CONSENT_REVOKED_EVENT, () => {
         // Clear any existing analytics state if needed
         // Note: We don't uninitialize GA4 as it's already loaded
         console.log('Analytics consent revoked - no new events will be tracked');
+      });
+      
+      // Listen for consent denied event (when user initially rejects)
+      window.addEventListener(CONSENT_DENIED_EVENT, () => {
+        console.log('Analytics consent denied - tracking not enabled');
       });
 
       // Track page views on route changes

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -33,24 +33,28 @@ export default defineClientConfig({
 
     // Google Analytics 4 with Cookie Consent
     if (typeof window !== 'undefined') {
-      // Check if user already gave consent
-      if (hasConsent()) {
+      // Helper to initialize analytics
+      const initializeAnalytics = () => {
         loadGA4();
         setupAutoTracking();
         setupVideoTracking();
+      };
+
+      // Check if user already gave consent
+      if (hasConsent()) {
+        initializeAnalytics();
       }
 
       // Listen for consent granted event
       window.addEventListener('ga-consent-granted', () => {
-        loadGA4();
-        setupAutoTracking();
-        setupVideoTracking();
+        initializeAnalytics();
         // Track initial page view
         trackPageView(router.currentRoute.value.path);
-      });
+      }, { once: true });
 
       // Track page views on route changes
       router.afterEach((to) => {
+        if (!hasConsent()) return;
         // Wait for DOM updates to complete
         nextTick(() => {
           trackPageView(to.path);

--- a/docs/.vuepress/components/CookieConsent.vue
+++ b/docs/.vuepress/components/CookieConsent.vue
@@ -73,6 +73,9 @@ const rejectCookies = () => {
       
       // Move focus to main content
       const mainContent = document.querySelector('main') || document.body;
+      if (mainContent && !(mainContent as HTMLElement).hasAttribute('tabindex')) {
+        (mainContent as HTMLElement).setAttribute('tabindex', '-1');
+      }
       (mainContent as HTMLElement)?.focus();
     } catch (error) {
       console.error('Failed to save consent preference:', error);

--- a/docs/.vuepress/components/CookieConsent.vue
+++ b/docs/.vuepress/components/CookieConsent.vue
@@ -28,6 +28,16 @@ import { CONSENT_KEY } from '../utils/constants';
 
 const showBanner = ref(false);
 
+// Expose function to reopen banner (for Cookie Settings)
+const reopenBanner = () => {
+  showBanner.value = true;
+};
+
+// Make it accessible globally for Cookie Settings link
+if (typeof window !== 'undefined') {
+  (window as any).reopenCookieBanner = reopenBanner;
+}
+
 onMounted(() => {
   // Only show banner if user hasn't made a choice yet
   if (typeof window !== 'undefined') {
@@ -47,15 +57,21 @@ onMounted(() => {
 const acceptCookies = () => {
   if (typeof window !== 'undefined') {
     try {
+      const previousConsent = localStorage.getItem(CONSENT_KEY);
       localStorage.setItem(CONSENT_KEY, 'true');
       showBanner.value = false;
       
       // Move focus to main content
       const mainContent = document.querySelector('main') || document.body;
+      if (mainContent && !(mainContent as HTMLElement).hasAttribute('tabindex')) {
+        (mainContent as HTMLElement).setAttribute('tabindex', '-1');
+      }
       (mainContent as HTMLElement)?.focus();
       
-      // Emit custom event that GA4 should be loaded
-      window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+      // Only emit event if this is a new acceptance (not already accepted)
+      if (previousConsent !== 'true') {
+        window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+      }
     } catch (error) {
       console.error('Failed to save consent preference:', error);
       // Still hide banner and dispatch event even if storage fails
@@ -68,6 +84,7 @@ const acceptCookies = () => {
 const rejectCookies = () => {
   if (typeof window !== 'undefined') {
     try {
+      const previousConsent = localStorage.getItem(CONSENT_KEY);
       localStorage.setItem(CONSENT_KEY, 'false');
       showBanner.value = false;
       
@@ -77,6 +94,11 @@ const rejectCookies = () => {
         (mainContent as HTMLElement).setAttribute('tabindex', '-1');
       }
       (mainContent as HTMLElement)?.focus();
+      
+      // Emit revoked event if user changed from Accept to Reject
+      if (previousConsent === 'true') {
+        window.dispatchEvent(new CustomEvent('ga-consent-revoked'));
+      }
     } catch (error) {
       console.error('Failed to save consent preference:', error);
       // Still hide banner even if storage fails

--- a/docs/.vuepress/components/CookieConsent.vue
+++ b/docs/.vuepress/components/CookieConsent.vue
@@ -1,0 +1,207 @@
+<template>
+  <Transition name="cookie-banner-fade">
+    <div v-if="showBanner" class="cookie-consent-banner" role="dialog" aria-labelledby="cookie-consent-title" aria-describedby="cookie-consent-description">
+      <div class="cookie-consent-content">
+        <div class="cookie-consent-text">
+          <h3 id="cookie-consent-title" class="cookie-consent-title">Cookie Notice</h3>
+          <p id="cookie-consent-description">
+            We use cookies to improve your experience. By accepting, you consent to our use of analytics cookies.
+            <a href="https://www.pagerduty.com/privacy-policy/" target="_blank" rel="noopener noreferrer" class="cookie-consent-link">Privacy Policy</a>
+          </p>
+        </div>
+        <div class="cookie-consent-actions">
+          <button @click="rejectCookies" class="cookie-btn cookie-btn-reject" aria-label="Reject cookies">
+            Reject
+          </button>
+          <button @click="acceptCookies" class="cookie-btn cookie-btn-accept" aria-label="Accept cookies">
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+const CONSENT_KEY = 'ga_consent_given';
+const showBanner = ref(false);
+
+onMounted(() => {
+  // Only show banner if user hasn't made a choice yet
+  if (typeof window !== 'undefined') {
+    const existingConsent = localStorage.getItem(CONSENT_KEY);
+    if (existingConsent === null) {
+      showBanner.value = true;
+    }
+  }
+});
+
+const acceptCookies = () => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(CONSENT_KEY, 'true');
+    showBanner.value = false;
+    
+    // Emit custom event that GA4 should be loaded
+    window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+  }
+};
+
+const rejectCookies = () => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(CONSENT_KEY, 'false');
+    showBanner.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.cookie-consent-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--vp-c-bg, #ffffff);
+  border-top: 2px solid var(--vp-c-brand, #3eaf7c);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  z-index: 9999;
+  padding: 1.5rem;
+}
+
+.cookie-consent-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.cookie-consent-text {
+  flex: 1;
+  min-width: 280px;
+}
+
+.cookie-consent-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1, #2c3e50);
+}
+
+.cookie-consent-text p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2, #476582);
+}
+
+.cookie-consent-link {
+  color: var(--vp-c-brand, #3eaf7c);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.cookie-consent-link:hover {
+  color: var(--vp-c-brand-dark, #2d8659);
+}
+
+.cookie-consent-actions {
+  display: flex;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+.cookie-btn {
+  padding: 0.6rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.cookie-btn-accept {
+  background: var(--vp-c-brand, #3eaf7c);
+  color: #ffffff;
+}
+
+.cookie-btn-accept:hover {
+  background: var(--vp-c-brand-dark, #2d8659);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(62, 175, 124, 0.3);
+}
+
+.cookie-btn-reject {
+  background: transparent;
+  color: var(--vp-c-text-2, #476582);
+  border: 1px solid var(--vp-c-divider, #e2e8f0);
+}
+
+.cookie-btn-reject:hover {
+  background: var(--vp-c-bg-soft, #f6f8fa);
+  border-color: var(--vp-c-text-2, #476582);
+}
+
+/* Transition effects */
+.cookie-banner-fade-enter-active,
+.cookie-banner-fade-leave-active {
+  transition: all 0.3s ease;
+}
+
+.cookie-banner-fade-enter-from {
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+.cookie-banner-fade-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+/* Dark mode support */
+html.dark .cookie-consent-banner {
+  background: var(--vp-c-bg, #1e1e1e);
+  border-top-color: var(--vp-c-brand, #3eaf7c);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.5);
+}
+
+html.dark .cookie-consent-title {
+  color: var(--vp-c-text-1, #e0e0e0);
+}
+
+html.dark .cookie-consent-text p {
+  color: var(--vp-c-text-2, #a0a0a0);
+}
+
+html.dark .cookie-btn-reject {
+  color: var(--vp-c-text-2, #a0a0a0);
+  border-color: var(--vp-c-divider, #3a3a3a);
+}
+
+html.dark .cookie-btn-reject:hover {
+  background: var(--vp-c-bg-soft, #2a2a2a);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .cookie-consent-content {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .cookie-consent-actions {
+    width: 100%;
+    flex-direction: row;
+  }
+
+  .cookie-btn {
+    flex: 1;
+  }
+}
+</style>
+

--- a/docs/.vuepress/components/CookieConsent.vue
+++ b/docs/.vuepress/components/CookieConsent.vue
@@ -24,7 +24,13 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { CONSENT_KEY } from '../utils/constants';
+import { 
+  CONSENT_KEY, 
+  CONSENT_GRANTED_EVENT, 
+  CONSENT_REVOKED_EVENT, 
+  CONSENT_DENIED_EVENT,
+  CONSENT_EXPIRY_MONTHS 
+} from '../utils/constants';
 
 const showBanner = ref(false);
 
@@ -38,13 +44,44 @@ if (typeof window !== 'undefined') {
   (window as any).reopenCookieBanner = reopenBanner;
 }
 
+/**
+ * Check if consent has expired (GDPR compliance)
+ */
+const isConsentExpired = (consentData: any): boolean => {
+  if (!consentData.timestamp) return true; // Old format, expired
+  
+  const monthsSinceConsent = (Date.now() - consentData.timestamp) / (1000 * 60 * 60 * 24 * 30);
+  return monthsSinceConsent > CONSENT_EXPIRY_MONTHS;
+};
+
 onMounted(() => {
-  // Only show banner if user hasn't made a choice yet
+  // Only show banner if user hasn't made a choice yet or consent expired
   if (typeof window !== 'undefined') {
     try {
-      const existingConsent = localStorage.getItem(CONSENT_KEY);
-      if (existingConsent === null) {
+      const existingConsentStr = localStorage.getItem(CONSENT_KEY);
+      
+      if (existingConsentStr === null) {
+        // No consent stored yet
         showBanner.value = true;
+      } else {
+        // Check if it's old format (just 'true'/'false') or new format with timestamp
+        try {
+          const consentData = JSON.parse(existingConsentStr);
+          
+          // Check if consent has expired
+          if (consentData.consent === true && isConsentExpired(consentData)) {
+            // Consent expired, show banner again
+            showBanner.value = true;
+          }
+          // If consent === false (rejected), don't show banner
+        } catch {
+          // Old format (just 'true' or 'false' string), migrate and check
+          if (existingConsentStr === 'true') {
+            // Treat old 'true' as expired - show banner to get fresh consent
+            showBanner.value = true;
+          }
+          // If old 'false', keep it as rejected, don't show banner
+        }
       }
     } catch (error) {
       // If localStorage is unavailable (e.g., private browsing), show the banner
@@ -57,8 +94,27 @@ onMounted(() => {
 const acceptCookies = () => {
   if (typeof window !== 'undefined') {
     try {
-      const previousConsent = localStorage.getItem(CONSENT_KEY);
-      localStorage.setItem(CONSENT_KEY, 'true');
+      const previousConsentStr = localStorage.getItem(CONSENT_KEY);
+      let previousConsent = false;
+      
+      // Check previous consent status
+      try {
+        if (previousConsentStr) {
+          const parsed = JSON.parse(previousConsentStr);
+          previousConsent = parsed.consent === true;
+        }
+      } catch {
+        // Old format
+        previousConsent = previousConsentStr === 'true';
+      }
+      
+      // Store consent with timestamp
+      const consentData = {
+        consent: true,
+        timestamp: Date.now(),
+        version: 1
+      };
+      localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
       showBanner.value = false;
       
       // Move focus to main content
@@ -69,14 +125,14 @@ const acceptCookies = () => {
       (mainContent as HTMLElement)?.focus();
       
       // Only emit event if this is a new acceptance (not already accepted)
-      if (previousConsent !== 'true') {
-        window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+      if (!previousConsent) {
+        window.dispatchEvent(new CustomEvent(CONSENT_GRANTED_EVENT));
       }
     } catch (error) {
       console.error('Failed to save consent preference:', error);
       // Still hide banner and dispatch event even if storage fails
       showBanner.value = false;
-      window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+      window.dispatchEvent(new CustomEvent(CONSENT_GRANTED_EVENT));
     }
   }
 };
@@ -84,8 +140,27 @@ const acceptCookies = () => {
 const rejectCookies = () => {
   if (typeof window !== 'undefined') {
     try {
-      const previousConsent = localStorage.getItem(CONSENT_KEY);
-      localStorage.setItem(CONSENT_KEY, 'false');
+      const previousConsentStr = localStorage.getItem(CONSENT_KEY);
+      let previousConsent = false;
+      
+      // Check previous consent status
+      try {
+        if (previousConsentStr) {
+          const parsed = JSON.parse(previousConsentStr);
+          previousConsent = parsed.consent === true;
+        }
+      } catch {
+        // Old format
+        previousConsent = previousConsentStr === 'true';
+      }
+      
+      // Store rejection with timestamp
+      const consentData = {
+        consent: false,
+        timestamp: Date.now(),
+        version: 1
+      };
+      localStorage.setItem(CONSENT_KEY, JSON.stringify(consentData));
       showBanner.value = false;
       
       // Move focus to main content
@@ -95,9 +170,13 @@ const rejectCookies = () => {
       }
       (mainContent as HTMLElement)?.focus();
       
-      // Emit revoked event if user changed from Accept to Reject
-      if (previousConsent === 'true') {
-        window.dispatchEvent(new CustomEvent('ga-consent-revoked'));
+      // Emit appropriate event
+      if (previousConsent) {
+        // User changed from Accept to Reject
+        window.dispatchEvent(new CustomEvent(CONSENT_REVOKED_EVENT));
+      } else {
+        // Initial rejection
+        window.dispatchEvent(new CustomEvent(CONSENT_DENIED_EVENT));
       }
     } catch (error) {
       console.error('Failed to save consent preference:', error);

--- a/docs/.vuepress/components/CookieConsent.vue
+++ b/docs/.vuepress/components/CookieConsent.vue
@@ -1,6 +1,6 @@
 <template>
   <Transition name="cookie-banner-fade">
-    <div v-if="showBanner" class="cookie-consent-banner" role="dialog" aria-labelledby="cookie-consent-title" aria-describedby="cookie-consent-description">
+    <div v-if="showBanner" class="cookie-consent-banner" role="dialog" aria-modal="true" aria-labelledby="cookie-consent-title" aria-describedby="cookie-consent-description">
       <div class="cookie-consent-content">
         <div class="cookie-consent-text">
           <h3 id="cookie-consent-title" class="cookie-consent-title">Cookie Notice</h3>
@@ -24,15 +24,21 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
+import { CONSENT_KEY } from '../utils/constants';
 
-const CONSENT_KEY = 'ga_consent_given';
 const showBanner = ref(false);
 
 onMounted(() => {
   // Only show banner if user hasn't made a choice yet
   if (typeof window !== 'undefined') {
-    const existingConsent = localStorage.getItem(CONSENT_KEY);
-    if (existingConsent === null) {
+    try {
+      const existingConsent = localStorage.getItem(CONSENT_KEY);
+      if (existingConsent === null) {
+        showBanner.value = true;
+      }
+    } catch (error) {
+      // If localStorage is unavailable (e.g., private browsing), show the banner
+      console.warn('localStorage unavailable:', error);
       showBanner.value = true;
     }
   }
@@ -40,18 +46,39 @@ onMounted(() => {
 
 const acceptCookies = () => {
   if (typeof window !== 'undefined') {
-    localStorage.setItem(CONSENT_KEY, 'true');
-    showBanner.value = false;
-    
-    // Emit custom event that GA4 should be loaded
-    window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+    try {
+      localStorage.setItem(CONSENT_KEY, 'true');
+      showBanner.value = false;
+      
+      // Move focus to main content
+      const mainContent = document.querySelector('main') || document.body;
+      (mainContent as HTMLElement)?.focus();
+      
+      // Emit custom event that GA4 should be loaded
+      window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+    } catch (error) {
+      console.error('Failed to save consent preference:', error);
+      // Still hide banner and dispatch event even if storage fails
+      showBanner.value = false;
+      window.dispatchEvent(new CustomEvent('ga-consent-granted'));
+    }
   }
 };
 
 const rejectCookies = () => {
   if (typeof window !== 'undefined') {
-    localStorage.setItem(CONSENT_KEY, 'false');
-    showBanner.value = false;
+    try {
+      localStorage.setItem(CONSENT_KEY, 'false');
+      showBanner.value = false;
+      
+      // Move focus to main content
+      const mainContent = document.querySelector('main') || document.body;
+      (mainContent as HTMLElement)?.focus();
+    } catch (error) {
+      console.error('Failed to save consent preference:', error);
+      // Still hide banner even if storage fails
+      showBanner.value = false;
+    }
   }
 };
 </script>

--- a/docs/.vuepress/components/CookieSettings.vue
+++ b/docs/.vuepress/components/CookieSettings.vue
@@ -1,0 +1,41 @@
+<template>
+  <button 
+    class="cookie-settings-link"
+    @click="openCookieSettings"
+    aria-label="Cookie Settings"
+  >
+    Cookie Settings
+  </button>
+</template>
+
+<script setup lang="ts">
+const openCookieSettings = () => {
+  if (typeof window !== 'undefined' && (window as any).reopenCookieBanner) {
+    (window as any).reopenCookieBanner();
+  }
+};
+</script>
+
+<style scoped>
+.cookie-settings-link {
+  background: none;
+  border: none;
+  color: var(--theme-color, #3eaf7c);
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+  font-family: inherit;
+  transition: opacity 0.2s;
+}
+
+.cookie-settings-link:hover {
+  opacity: 0.7;
+}
+
+/* Dark mode */
+html.dark .cookie-settings-link {
+  color: var(--theme-color, #3eaf7c);
+}
+</style>
+

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -7,7 +7,6 @@ import { getDirname, path } from '@vuepress/utils';
 import { openGraphPlugin } from 'vuepress-plugin-open-graph';
 import { registerComponentsPlugin } from '@vuepress/plugin-register-components';
 import { dateSorter } from "@vuepress/helper";
-import { googleAnalyticsPlugin } from '@vuepress/plugin-google-analytics';
 import { removePwaPlugin } from '@vuepress/plugin-remove-pwa';
 
 // sidebars
@@ -150,6 +149,7 @@ export default defineUserConfig({
       },
       redirect: {
         config: {
+          '/privacy-policy.html': 'https://www.pagerduty.com/privacy-policy/',
           '/history/cves/2025-06-05-runnersecurity.html' : '/history/cves/2025-06-runner-security.html',
           '/manual/01-introduction.html': '/introduction/introduction.html',
           '/manual/03-getting-started.html': '/learning/index.html',
@@ -339,9 +339,6 @@ export default defineUserConfig({
         RundeckSwaggerUi: path.resolve(__dirname, './components/RundeckSwaggerUI.vue'),
         OpenApiExplorer: path.resolve(__dirname, './components/OpenApiExplorer.vue')
       },
-    }),
-    googleAnalyticsPlugin({
-      id: 'G-05XJ24KPYH',
     }),
     openGraphPlugin({
       host: 'https://docs.rundeck.com',

--- a/docs/.vuepress/layouts/Layout.vue
+++ b/docs/.vuepress/layouts/Layout.vue
@@ -2,6 +2,7 @@
 import { Layout } from "vuepress-theme-hope/client";
 import { usePageData } from "@vuepress/client";
 import { computed } from "vue";
+import CookieSettings from "../components/CookieSettings.vue";
 
 const pageData = usePageData();
 const isHomePage = computed(() => pageData.value.frontmatter.home === true);
@@ -26,5 +27,48 @@ const isHomePage = computed(() => pageData.value.frontmatter.home === true);
         </p>
       </div>
     </template>
+
+    <!-- Add footer links for Privacy Policy and Cookie Settings after page content -->
+    <template #pageBottom>
+      <div class="custom-footer-links">
+        <a href="https://www.pagerduty.com/privacy-policy/" target="_blank" rel="noopener noreferrer">
+          Privacy Policy
+        </a>
+        <span class="footer-separator">|</span>
+        <CookieSettings />
+      </div>
+    </template>
   </Layout>
 </template>
+
+<style scoped>
+.custom-footer-links {
+  text-align: center;
+  padding: 1rem 0;
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2, #476582);
+}
+
+.custom-footer-links a {
+  color: var(--theme-color, #3eaf7c);
+  text-decoration: none;
+}
+
+.custom-footer-links a:hover {
+  text-decoration: underline;
+}
+
+.footer-separator {
+  margin: 0 0.5rem;
+  color: var(--vp-c-divider, #e2e8f0);
+}
+
+/* Dark mode */
+html.dark .custom-footer-links {
+  color: var(--vp-c-text-2, #a0a0a0);
+}
+
+html.dark .footer-separator {
+  color: var(--vp-c-divider, #3a3a3a);
+}
+</style>

--- a/docs/.vuepress/utils/analytics.ts
+++ b/docs/.vuepress/utils/analytics.ts
@@ -5,7 +5,7 @@
  * after explicit user consent. No tracking occurs before consent is granted.
  */
 
-import { GA_MEASUREMENT_ID, CONSENT_KEY } from './constants';
+import { GA_MEASUREMENT_ID, CONSENT_KEY, CONSENT_EXPIRY_MONTHS } from './constants';
 
 declare global {
   interface Window {
@@ -20,7 +20,27 @@ declare global {
 export function hasConsent(): boolean {
   if (typeof window === 'undefined') return false;
   try {
-    return localStorage.getItem(CONSENT_KEY) === 'true';
+    const consentStr = localStorage.getItem(CONSENT_KEY);
+    if (!consentStr) return false;
+    
+    try {
+      // New format with timestamp
+      const consentData = JSON.parse(consentStr);
+      
+      // Check if consent is true and not expired
+      if (consentData.consent !== true) return false;
+      
+      // Check expiration
+      if (!consentData.timestamp) return false;
+      const monthsSinceConsent = (Date.now() - consentData.timestamp) / (1000 * 60 * 60 * 24 * 30);
+      if (monthsSinceConsent > CONSENT_EXPIRY_MONTHS) return false;
+      
+      return true;
+    } catch {
+      // Old format (just 'true' or 'false')
+      // Treat old format as expired for safety
+      return false;
+    }
   } catch {
     return false;
   }

--- a/docs/.vuepress/utils/analytics.ts
+++ b/docs/.vuepress/utils/analytics.ts
@@ -5,8 +5,7 @@
  * after explicit user consent. No tracking occurs before consent is granted.
  */
 
-const GA_MEASUREMENT_ID = 'G-05XJ24KPYH';
-const CONSENT_KEY = 'ga_consent_given';
+import { GA_MEASUREMENT_ID, CONSENT_KEY } from './constants';
 
 declare global {
   interface Window {
@@ -31,10 +30,7 @@ export function loadGA4(): void {
   if (typeof window === 'undefined') return;
   
   // Check if already loaded
-  if (window.gtag) {
-    console.log('Analytics already loaded');
-    return;
-  }
+  if (window.gtag) return;
 
   // Initialize dataLayer and gtag stub
   window.dataLayer = window.dataLayer || [];
@@ -159,12 +155,17 @@ export function trackVideoComplete(videoId: string, videoTitle?: string): void {
   });
 }
 
+// Guards to prevent duplicate initialization
+let autoTrackingInitialized = false;
+let videoTrackingInitialized = false;
+
 /**
  * Set up automatic tracking for outbound links and downloads
  * Call this once when the app initializes
  */
 export function setupAutoTracking(): void {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || autoTrackingInitialized) return;
+  autoTrackingInitialized = true;
 
   // Track outbound links
   document.addEventListener('click', (e) => {
@@ -178,13 +179,15 @@ export function setupAutoTracking(): void {
 
     // Check if it's an outbound link
     if (href.startsWith('http') && !href.includes(window.location.hostname)) {
-      trackOutboundLink(href, target.textContent || undefined);
+      const sanitizedText = (target.textContent || '').substring(0, 200).trim();
+      trackOutboundLink(href, sanitizedText || undefined);
     }
 
     // Check if it's a file download
     const downloadExtensions = ['.pdf', '.zip', '.tar', '.gz', '.dmg', '.exe', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'];
     if (downloadExtensions.some(ext => href.toLowerCase().endsWith(ext))) {
-      trackDownload(href, target.textContent || href.split('/').pop());
+      const sanitizedText = (target.textContent || '').substring(0, 200).trim();
+      trackDownload(href, sanitizedText || href.split('/').pop());
     }
   });
 }
@@ -194,7 +197,8 @@ export function setupAutoTracking(): void {
  * Monitors all VidStack video players on the page and tracks engagement
  */
 export function setupVideoTracking(): void {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || videoTrackingInitialized) return;
+  videoTrackingInitialized = true;
 
   const trackedVideos = new Map<string, {
     milestones: Set<number>;
@@ -293,10 +297,22 @@ export function setupVideoTracking(): void {
 
   // Watch for dynamically added videos (for SPA navigation)
   const observer = new MutationObserver((mutations) => {
+    let hasRelevantChanges = false;
     for (const mutation of mutations) {
-      if (mutation.addedNodes.length > 0) {
-        trackAllVideos();
+      for (const node of mutation.addedNodes) {
+        if (
+          node instanceof Element &&
+          (node.matches('media-player') ||
+            node.querySelector('media-player'))
+        ) {
+          hasRelevantChanges = true;
+          break;
+        }
       }
+      if (hasRelevantChanges) break;
+    }
+    if (hasRelevantChanges) {
+      trackAllVideos();
     }
   });
 

--- a/docs/.vuepress/utils/analytics.ts
+++ b/docs/.vuepress/utils/analytics.ts
@@ -126,6 +126,7 @@ export function trackDownload(url: string, fileName?: string): void {
 export function trackVideoStart(videoId: string, videoTitle?: string, pagePath?: string): void {
   if (!hasConsent() || !window.gtag) return;
 
+  console.log('📹 Video Start:', videoId);
   window.gtag('event', 'video_start', {
     video_id: videoId,
     video_title: videoTitle || document.title,
@@ -142,6 +143,7 @@ export function trackVideoStart(videoId: string, videoTitle?: string, pagePath?:
 export function trackVideoProgress(videoId: string, progress: number, videoTitle?: string): void {
   if (!hasConsent() || !window.gtag) return;
 
+  console.log(`📊 Video Progress: ${progress}% - ${videoId}`);
   window.gtag('event', 'video_progress', {
     video_id: videoId,
     video_progress: progress,
@@ -158,6 +160,7 @@ export function trackVideoProgress(videoId: string, progress: number, videoTitle
 export function trackVideoComplete(videoId: string, videoTitle?: string): void {
   if (!hasConsent() || !window.gtag) return;
 
+  console.log('✅ Video Complete:', videoId);
   window.gtag('event', 'video_complete', {
     video_id: videoId,
     video_title: videoTitle || document.title,
@@ -208,23 +211,32 @@ export function setupVideoTracking(): void {
   }>();
 
   /**
-   * Extract YouTube video ID from VidStack src attribute
+   * Extract YouTube video ID from media-player element
    */
-  function extractVideoId(vidStackElement: Element): string | null {
-    const src = vidStackElement.getAttribute('src');
+  function extractVideoId(mediaPlayer: Element): string | null {
+    // Look for the YouTube iframe inside the media-player
+    const youtubeIframe = mediaPlayer.querySelector('iframe.vds-youtube');
+    if (!youtubeIframe) return null;
+    
+    const src = youtubeIframe.getAttribute('src');
     if (!src) return null;
     
-    // Handle format: youtube/VIDEO_ID
-    const match = src.match(/youtube\/([a-zA-Z0-9_-]+)/);
+    // Extract video ID from YouTube embed URL
+    // Format: https://www.youtube-nocookie.com/embed/VIDEO_ID?...
+    const match = src.match(/embed\/([a-zA-Z0-9_-]+)/);
     return match ? match[1] : null;
   }
 
   /**
    * Initialize tracking for a single video player
    */
-  function initVideoTracking(vidStackElement: Element): void {
-    const videoId = extractVideoId(vidStackElement);
+  function initVideoTracking(mediaPlayer: Element): void {
+    const videoId = extractVideoId(mediaPlayer);
     if (!videoId) return;
+
+    // Check if already tracking this player instance
+    if (mediaPlayer.hasAttribute('data-ga-tracked')) return;
+    mediaPlayer.setAttribute('data-ga-tracked', 'true');
 
     // Initialize tracking state for this video
     if (!trackedVideos.has(videoId)) {
@@ -236,63 +248,53 @@ export function setupVideoTracking(): void {
 
     const trackingState = trackedVideos.get(videoId)!;
 
-    // Wait for the media player to be ready
-    const checkForPlayer = setInterval(() => {
-      const mediaPlayer = vidStackElement.querySelector('media-player');
-      if (!mediaPlayer) return;
+    // Track video start
+    mediaPlayer.addEventListener('play', () => {
+      if (!hasConsent()) return;
+      if (!trackingState.started) {
+        trackVideoStart(videoId, document.title, window.location.pathname);
+        trackingState.started = true;
+      }
+    });
 
-      clearInterval(checkForPlayer);
+    // Track progress milestones
+    mediaPlayer.addEventListener('time-update', (event: any) => {
+      if (!hasConsent()) return;
+      
+      const detail = event.detail;
+      if (!detail) return;
 
-      // Track video start
-      mediaPlayer.addEventListener('play', () => {
-        if (!hasConsent()) return;
-        if (!trackingState.started) {
-          trackVideoStart(videoId, document.title, window.location.pathname);
-          trackingState.started = true;
+      const currentTime = detail.currentTime || 0;
+      // Get duration from the player element itself, not from event
+      const duration = (mediaPlayer as any).duration || 0;
+      
+      if (duration === 0 || currentTime === 0) return;
+
+      const progress = (currentTime / duration) * 100;
+
+      // Track milestones: 25%, 50%, 75%, 100%
+      const milestones = [25, 50, 75, 100];
+      for (const milestone of milestones) {
+        if (progress >= milestone && !trackingState.milestones.has(milestone)) {
+          trackingState.milestones.add(milestone);
+          trackVideoProgress(videoId, milestone, document.title);
         }
-      });
+      }
+    });
 
-      // Track progress milestones
-      mediaPlayer.addEventListener('time-update', (event: any) => {
-        if (!hasConsent()) return;
-        
-        const detail = event.detail;
-        if (!detail) return;
-
-        const currentTime = detail.currentTime || 0;
-        const duration = detail.duration || 0;
-        
-        if (duration === 0) return;
-
-        const progress = (currentTime / duration) * 100;
-
-        // Track milestones: 25%, 50%, 75%, 100%
-        const milestones = [25, 50, 75, 100];
-        for (const milestone of milestones) {
-          if (progress >= milestone && !trackingState.milestones.has(milestone)) {
-            trackingState.milestones.add(milestone);
-            trackVideoProgress(videoId, milestone, document.title);
-          }
-        }
-      });
-
-      // Track video completion
-      mediaPlayer.addEventListener('ended', () => {
-        if (!hasConsent()) return;
-        trackVideoComplete(videoId, document.title);
-      });
-    }, 100);
-
-    // Clean up after 10 seconds if player never loads
-    setTimeout(() => clearInterval(checkForPlayer), 10000);
+    // Track video completion
+    mediaPlayer.addEventListener('ended', () => {
+      if (!hasConsent()) return;
+      trackVideoComplete(videoId, document.title);
+    });
   }
 
   /**
-   * Find and track all VidStack elements on the page
+   * Find and track all media-player elements on the page
    */
   function trackAllVideos(): void {
-    const vidStackElements = document.querySelectorAll('VidStack, [class*="vidstack"]');
-    vidStackElements.forEach(initVideoTracking);
+    const mediaPlayers = document.querySelectorAll('media-player');
+    mediaPlayers.forEach(initVideoTracking);
   }
 
   // Initial tracking

--- a/docs/.vuepress/utils/analytics.ts
+++ b/docs/.vuepress/utils/analytics.ts
@@ -19,7 +19,11 @@ declare global {
  */
 export function hasConsent(): boolean {
   if (typeof window === 'undefined') return false;
-  return localStorage.getItem(CONSENT_KEY) === 'true';
+  try {
+    return localStorage.getItem(CONSENT_KEY) === 'true';
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -35,7 +39,7 @@ export function loadGA4(): void {
   // Initialize dataLayer and gtag stub
   window.dataLayer = window.dataLayer || [];
   window.gtag = function gtag(...args: any[]) {
-    window.dataLayer!.push(arguments);
+    window.dataLayer!.push(args);
   };
   window.gtag('js', new Date());
   window.gtag('config', GA_MEASUREMENT_ID, {
@@ -109,7 +113,7 @@ export function trackDownload(url: string, fileName?: string): void {
 
 /**
  * Track video start
- * @param videoId - YouTube video ID
+ * @param videoId - Video ID (e.g., YouTube video ID when using YouTube provider)
  * @param videoTitle - Title/description of the video
  * @param pagePath - Path of the page containing the video
  */
@@ -125,7 +129,7 @@ export function trackVideoStart(videoId: string, videoTitle?: string, pagePath?:
 
 /**
  * Track video progress milestones
- * @param videoId - YouTube video ID
+ * @param videoId - Video ID (e.g., YouTube video ID when using YouTube provider)
  * @param progress - Progress percentage (25, 50, 75, 100)
  * @param videoTitle - Title/description of the video
  */
@@ -142,7 +146,7 @@ export function trackVideoProgress(videoId: string, progress: number, videoTitle
 
 /**
  * Track video completion
- * @param videoId - YouTube video ID
+ * @param videoId - Video ID (e.g., YouTube video ID when using YouTube provider)
  * @param videoTitle - Title/description of the video
  */
 export function trackVideoComplete(videoId: string, videoTitle?: string): void {
@@ -158,6 +162,9 @@ export function trackVideoComplete(videoId: string, videoTitle?: string): void {
 // Guards to prevent duplicate initialization
 let autoTrackingInitialized = false;
 let videoTrackingInitialized = false;
+
+// Video progress milestones to track
+const VIDEO_MILESTONES = [25, 50, 75, 100] as const;
 
 /**
  * Set up automatic tracking for outbound links and downloads
@@ -179,14 +186,14 @@ export function setupAutoTracking(): void {
 
     // Check if it's an outbound link
     if (href.startsWith('http') && !href.includes(window.location.hostname)) {
-      const sanitizedText = (target.textContent || '').substring(0, 200).trim();
+      const sanitizedText = (target.textContent || '').substring(0, 200).trim().replace(/[\n\r\t]/g, ' ');
       trackOutboundLink(href, sanitizedText || undefined);
     }
 
     // Check if it's a file download
     const downloadExtensions = ['.pdf', '.zip', '.tar', '.gz', '.dmg', '.exe', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'];
     if (downloadExtensions.some(ext => href.toLowerCase().endsWith(ext))) {
-      const sanitizedText = (target.textContent || '').substring(0, 200).trim();
+      const sanitizedText = (target.textContent || '').substring(0, 200).trim().replace(/[\n\r\t]/g, ' ');
       trackDownload(href, sanitizedText || href.split('/').pop());
     }
   });
@@ -261,15 +268,14 @@ export function setupVideoTracking(): void {
 
       const currentTime = detail.currentTime || 0;
       // Get duration from the player element itself, not from event
-      const duration = (mediaPlayer as any).duration || 0;
+      const duration = 'duration' in mediaPlayer ? (mediaPlayer as any).duration : 0;
       
       if (duration === 0 || currentTime === 0) return;
 
       const progress = (currentTime / duration) * 100;
 
-      // Track milestones: 25%, 50%, 75%, 100%
-      const milestones = [25, 50, 75, 100];
-      for (const milestone of milestones) {
+      // Track milestones
+      for (const milestone of VIDEO_MILESTONES) {
         if (progress >= milestone && !trackingState.milestones.has(milestone)) {
           trackingState.milestones.add(milestone);
           trackVideoProgress(videoId, milestone, document.title);

--- a/docs/.vuepress/utils/analytics.ts
+++ b/docs/.vuepress/utils/analytics.ts
@@ -36,19 +36,15 @@ export function loadGA4(): void {
     return;
   }
 
-  // Initialize dataLayer
+  // Initialize dataLayer and gtag stub
   window.dataLayer = window.dataLayer || [];
   window.gtag = function gtag(...args: any[]) {
-    window.dataLayer!.push(args);
+    window.dataLayer!.push(arguments);
   };
-
-  // Set initial timestamp
   window.gtag('js', new Date());
-
-  // Configure analytics with measurement ID
   window.gtag('config', GA_MEASUREMENT_ID, {
-    send_page_view: false, // We'll manually track page views
-    anonymize_ip: true, // Privacy-friendly
+    send_page_view: false,
+    anonymize_ip: true,
   });
 
   // Inject the analytics script
@@ -56,8 +52,6 @@ export function loadGA4(): void {
   script.async = true;
   script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
   document.head.appendChild(script);
-
-  console.log('Analytics loaded with consent');
 }
 
 /**
@@ -126,7 +120,6 @@ export function trackDownload(url: string, fileName?: string): void {
 export function trackVideoStart(videoId: string, videoTitle?: string, pagePath?: string): void {
   if (!hasConsent() || !window.gtag) return;
 
-  console.log('📹 Video Start:', videoId);
   window.gtag('event', 'video_start', {
     video_id: videoId,
     video_title: videoTitle || document.title,
@@ -143,7 +136,6 @@ export function trackVideoStart(videoId: string, videoTitle?: string, pagePath?:
 export function trackVideoProgress(videoId: string, progress: number, videoTitle?: string): void {
   if (!hasConsent() || !window.gtag) return;
 
-  console.log(`📊 Video Progress: ${progress}% - ${videoId}`);
   window.gtag('event', 'video_progress', {
     video_id: videoId,
     video_progress: progress,
@@ -160,7 +152,6 @@ export function trackVideoProgress(videoId: string, progress: number, videoTitle
 export function trackVideoComplete(videoId: string, videoTitle?: string): void {
   if (!hasConsent() || !window.gtag) return;
 
-  console.log('✅ Video Complete:', videoId);
   window.gtag('event', 'video_complete', {
     video_id: videoId,
     video_title: videoTitle || document.title,

--- a/docs/.vuepress/utils/analytics.ts
+++ b/docs/.vuepress/utils/analytics.ts
@@ -1,0 +1,315 @@
+/**
+ * GDPR/CCPA Compliant Analytics Implementation
+ * 
+ * This module provides manual analytics loading and tracking that only fires
+ * after explicit user consent. No tracking occurs before consent is granted.
+ */
+
+const GA_MEASUREMENT_ID = 'G-05XJ24KPYH';
+const CONSENT_KEY = 'ga_consent_given';
+
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+    dataLayer?: any[];
+  }
+}
+
+/**
+ * Check if user has given consent for analytics
+ */
+export function hasConsent(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(CONSENT_KEY) === 'true';
+}
+
+/**
+ * Manually inject analytics script into the page
+ * Only called AFTER user consent is granted
+ */
+export function loadGA4(): void {
+  if (typeof window === 'undefined') return;
+  
+  // Check if already loaded
+  if (window.gtag) {
+    console.log('Analytics already loaded');
+    return;
+  }
+
+  // Initialize dataLayer
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag(...args: any[]) {
+    window.dataLayer!.push(args);
+  };
+
+  // Set initial timestamp
+  window.gtag('js', new Date());
+
+  // Configure analytics with measurement ID
+  window.gtag('config', GA_MEASUREMENT_ID, {
+    send_page_view: false, // We'll manually track page views
+    anonymize_ip: true, // Privacy-friendly
+  });
+
+  // Inject the analytics script
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+  document.head.appendChild(script);
+
+  console.log('Analytics loaded with consent');
+}
+
+/**
+ * Track a page view
+ * @param path - The page path to track
+ * @param title - The page title
+ */
+export function trackPageView(path: string, title?: string): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', 'page_view', {
+    page_path: path,
+    page_title: title || document.title,
+    page_location: window.location.href,
+  });
+}
+
+/**
+ * Track a custom event
+ * @param eventName - Name of the event
+ * @param parameters - Additional event parameters
+ */
+export function trackEvent(eventName: string, parameters?: Record<string, any>): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', eventName, parameters);
+}
+
+/**
+ * Track outbound link clicks
+ * @param url - The external URL being clicked
+ * @param linkText - The text of the link
+ */
+export function trackOutboundLink(url: string, linkText?: string): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', 'click', {
+    event_category: 'outbound',
+    event_label: url,
+    link_text: linkText,
+    value: 1,
+  });
+}
+
+/**
+ * Track file downloads
+ * @param url - The file URL
+ * @param fileName - The name of the file
+ */
+export function trackDownload(url: string, fileName?: string): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', 'file_download', {
+    file_name: fileName || url.split('/').pop(),
+    file_url: url,
+    link_text: fileName,
+  });
+}
+
+/**
+ * Track video start
+ * @param videoId - YouTube video ID
+ * @param videoTitle - Title/description of the video
+ * @param pagePath - Path of the page containing the video
+ */
+export function trackVideoStart(videoId: string, videoTitle?: string, pagePath?: string): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', 'video_start', {
+    video_id: videoId,
+    video_title: videoTitle || document.title,
+    page_path: pagePath || window.location.pathname,
+  });
+}
+
+/**
+ * Track video progress milestones
+ * @param videoId - YouTube video ID
+ * @param progress - Progress percentage (25, 50, 75, 100)
+ * @param videoTitle - Title/description of the video
+ */
+export function trackVideoProgress(videoId: string, progress: number, videoTitle?: string): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', 'video_progress', {
+    video_id: videoId,
+    video_progress: progress,
+    video_title: videoTitle || document.title,
+    page_path: window.location.pathname,
+  });
+}
+
+/**
+ * Track video completion
+ * @param videoId - YouTube video ID
+ * @param videoTitle - Title/description of the video
+ */
+export function trackVideoComplete(videoId: string, videoTitle?: string): void {
+  if (!hasConsent() || !window.gtag) return;
+
+  window.gtag('event', 'video_complete', {
+    video_id: videoId,
+    video_title: videoTitle || document.title,
+    page_path: window.location.pathname,
+  });
+}
+
+/**
+ * Set up automatic tracking for outbound links and downloads
+ * Call this once when the app initializes
+ */
+export function setupAutoTracking(): void {
+  if (typeof window === 'undefined') return;
+
+  // Track outbound links
+  document.addEventListener('click', (e) => {
+    if (!hasConsent()) return;
+
+    const target = (e.target as HTMLElement).closest('a');
+    if (!target) return;
+
+    const href = target.getAttribute('href');
+    if (!href) return;
+
+    // Check if it's an outbound link
+    if (href.startsWith('http') && !href.includes(window.location.hostname)) {
+      trackOutboundLink(href, target.textContent || undefined);
+    }
+
+    // Check if it's a file download
+    const downloadExtensions = ['.pdf', '.zip', '.tar', '.gz', '.dmg', '.exe', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx'];
+    if (downloadExtensions.some(ext => href.toLowerCase().endsWith(ext))) {
+      trackDownload(href, target.textContent || href.split('/').pop());
+    }
+  });
+}
+
+/**
+ * Set up VidStack video tracking
+ * Monitors all VidStack video players on the page and tracks engagement
+ */
+export function setupVideoTracking(): void {
+  if (typeof window === 'undefined') return;
+
+  const trackedVideos = new Map<string, {
+    milestones: Set<number>;
+    started: boolean;
+  }>();
+
+  /**
+   * Extract YouTube video ID from VidStack src attribute
+   */
+  function extractVideoId(vidStackElement: Element): string | null {
+    const src = vidStackElement.getAttribute('src');
+    if (!src) return null;
+    
+    // Handle format: youtube/VIDEO_ID
+    const match = src.match(/youtube\/([a-zA-Z0-9_-]+)/);
+    return match ? match[1] : null;
+  }
+
+  /**
+   * Initialize tracking for a single video player
+   */
+  function initVideoTracking(vidStackElement: Element): void {
+    const videoId = extractVideoId(vidStackElement);
+    if (!videoId) return;
+
+    // Initialize tracking state for this video
+    if (!trackedVideos.has(videoId)) {
+      trackedVideos.set(videoId, {
+        milestones: new Set(),
+        started: false,
+      });
+    }
+
+    const trackingState = trackedVideos.get(videoId)!;
+
+    // Wait for the media player to be ready
+    const checkForPlayer = setInterval(() => {
+      const mediaPlayer = vidStackElement.querySelector('media-player');
+      if (!mediaPlayer) return;
+
+      clearInterval(checkForPlayer);
+
+      // Track video start
+      mediaPlayer.addEventListener('play', () => {
+        if (!hasConsent()) return;
+        if (!trackingState.started) {
+          trackVideoStart(videoId, document.title, window.location.pathname);
+          trackingState.started = true;
+        }
+      });
+
+      // Track progress milestones
+      mediaPlayer.addEventListener('time-update', (event: any) => {
+        if (!hasConsent()) return;
+        
+        const detail = event.detail;
+        if (!detail) return;
+
+        const currentTime = detail.currentTime || 0;
+        const duration = detail.duration || 0;
+        
+        if (duration === 0) return;
+
+        const progress = (currentTime / duration) * 100;
+
+        // Track milestones: 25%, 50%, 75%, 100%
+        const milestones = [25, 50, 75, 100];
+        for (const milestone of milestones) {
+          if (progress >= milestone && !trackingState.milestones.has(milestone)) {
+            trackingState.milestones.add(milestone);
+            trackVideoProgress(videoId, milestone, document.title);
+          }
+        }
+      });
+
+      // Track video completion
+      mediaPlayer.addEventListener('ended', () => {
+        if (!hasConsent()) return;
+        trackVideoComplete(videoId, document.title);
+      });
+    }, 100);
+
+    // Clean up after 10 seconds if player never loads
+    setTimeout(() => clearInterval(checkForPlayer), 10000);
+  }
+
+  /**
+   * Find and track all VidStack elements on the page
+   */
+  function trackAllVideos(): void {
+    const vidStackElements = document.querySelectorAll('VidStack, [class*="vidstack"]');
+    vidStackElements.forEach(initVideoTracking);
+  }
+
+  // Initial tracking
+  trackAllVideos();
+
+  // Watch for dynamically added videos (for SPA navigation)
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.addedNodes.length > 0) {
+        trackAllVideos();
+      }
+    }
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+}
+

--- a/docs/.vuepress/utils/constants.ts
+++ b/docs/.vuepress/utils/constants.ts
@@ -5,3 +5,16 @@
 export const GA_MEASUREMENT_ID = 'G-05XJ24KPYH';
 export const CONSENT_KEY = 'ga_consent_given';
 
+/**
+ * Custom event names for consent management
+ */
+export const CONSENT_GRANTED_EVENT = 'ga-consent-granted';
+export const CONSENT_REVOKED_EVENT = 'ga-consent-revoked';
+export const CONSENT_DENIED_EVENT = 'ga-consent-denied';
+
+/**
+ * Consent expiration period in months (GDPR compliance)
+ * Set to 6 months to comply with strictest regulations
+ */
+export const CONSENT_EXPIRY_MONTHS = 6;
+

--- a/docs/.vuepress/utils/constants.ts
+++ b/docs/.vuepress/utils/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared constants for analytics implementation
+ */
+
+export const GA_MEASUREMENT_ID = 'G-05XJ24KPYH';
+export const CONSENT_KEY = 'ga_consent_given';
+


### PR DESCRIPTION
- Remove auto-loading analytics plugin from config
- Add CookieConsent component with bottom banner design
- Implement manual analytics loading only after user consent
- Add comprehensive tracking: page views, downloads, outbound links, video engagement
- Track VidStack video interactions (start, progress milestones, completion)
- Redirect privacy policy to PagerDuty main privacy policy
- All tracking checks consent before firing (verifiable in Network tab)