### PR TITLE
RUN-3794: Document Job Audit Tracking Feature

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2680,6 +2680,14 @@ In Cluster mode, additional information about what server UUID is the schedule o
 * `serverNodeUUID` UUID of the schedule owner server for this job
 * `serverOwner` boolean value whether the target server is the owner, `true/false`.
 
+**Since v56**:
+
+Job audit tracking fields are included in the response:
+
+* `createdBy` - Username of the user who created the job (may be null for jobs created before v5.17.0)
+* `lastModifiedBy` - Username of the user who last modified the job (may be null for jobs created before v5.17.0)
+* `created` - ISO-8601 timestamp when the job was created (may be null for jobs created before v5.17.0)
+* `lastModified` - ISO-8601 timestamp when the job was last modified (may be null for jobs created before v5.17.0)
 
 ``` json
 [
@@ -2695,7 +2703,11 @@ In Cluster mode, additional information about what server UUID is the schedule o
     "scheduleEnabled": true/false,
     "enabled": true/false,
     "serverNodeUUID": "[UUID]",
-    "serverOwner": true/false
+    "serverOwner": true/false,
+    "createdBy": "username",
+    "lastModifiedBy": "username",
+    "created": "2024-01-15T10:30:00Z",
+    "lastModified": "2024-12-10T14:22:00Z"
   }
 ]
 ```
@@ -2822,6 +2834,8 @@ Depending on the requested format:
 * YAML: [job-yaml](/manual/document-format-reference/job-yaml-v12.md) format
 * JSON: [job-json](/manual/document-format-reference/job-json-v44.md) format (API v44+)
 
+**Since v56**: Exported job definitions include audit tracking fields (`user`, `createdBy`, `lastModifiedBy`, `created`, `lastModified`) that indicate who created and last modified the job, along with timestamps. See the job definition format documentation for details.
+
 
 ### Importing Jobs ###
 
@@ -2849,6 +2863,15 @@ Optional parameters:
 * `uuidOption`: Whether to preserve or remove UUIDs from the imported jobs. Allowed values (**since V9**):
     *  `preserve`: Preserve the UUIDs in imported jobs.  This may cause the import to fail if the UUID is already used. (Default value).
     *  `remove`: Remove the UUIDs from imported jobs. Allows update/create to succeed without conflict on UUID.
+
+**Audit Field Handling (since v56)**:
+
+Job audit tracking fields (`user`, `createdBy`, `lastModifiedBy`, `created`, `lastModified`) are protected during import and will not be overwritten. These fields are system-managed to maintain accurate audit history:
+
+* When importing a job with audit fields, those fields are ignored and the existing audit information is preserved
+* When creating a new job via import, the current user and timestamp are recorded as the creator
+* When updating an existing job via import, the current user and timestamp are recorded as the last modifier
+* Jobs imported from older Rundeck versions (before 5.17.0) without audit fields will have these fields populated on first modification
 
 **Response:**
 
@@ -3173,9 +3196,20 @@ A single object:
     "scheduled": true/false,
     "scheduleEnabled": true/false,
     "enabled": true/false,
-    "averageDuration": long (milliseconds)
+    "averageDuration": long (milliseconds),
+    "createdBy": "username",
+    "lastModifiedBy": "username",
+    "created": "2024-01-15T10:30:00Z",
+    "lastModified": "2024-12-10T14:22:00Z"
 }
 ```
+
+**Since v56**: The response includes job audit tracking fields:
+
+* `createdBy` - Username of the user who created the job (may be null for jobs created before v5.17.0)
+* `lastModifiedBy` - Username of the user who last modified the job (may be null for jobs created before v5.17.0)
+* `created` - ISO-8601 timestamp when the job was created (may be null for jobs created before v5.17.0)
+* `lastModified` - ISO-8601 timestamp when the job was last modified (may be null for jobs created before v5.17.0)
 
 ### Upload a File for a Job Option
 

--- a/docs/api/rundeck-api-versions.md
+++ b/docs/api/rundeck-api-versions.md
@@ -35,6 +35,16 @@ Changes introduced by API Version number:
 API versions below `{{$apiDepVersion}}` are *deprecated*.  Clients using earlier versions should upgrade to use `{{$apiDepVersion}}` as the minimum version before release `{{ $apiDepRelease }}` to avoid errors.
 :::
 
+### Version 56
+
+* Updated Endpoints:
+  * [`GET /api/V/project/[PROJECT]/jobs`][/api/V/project/\[PROJECT\]/jobs] - Job listing responses now include audit tracking fields: `createdBy` (job creator username), `lastModifiedBy` (last modifier username), `created` (creation timestamp), and `lastModified` (last modification timestamp)
+  * [`GET /api/18/job/[ID]/info`][/api/V/job/\[ID\]/info] - Job metadata response now includes audit tracking fields
+  * Job Export endpoints now include audit tracking fields in exported job definitions
+
+* Job Import Behavior:
+  * Audit tracking fields (`user`, `createdBy`, `lastModifiedBy`, `created`, `lastModified`) are now protected during job import operations and will not be overwritten. These fields are managed by the system to maintain accurate audit history.
+
 ### Version 55
 
 * New Endpoints:

--- a/docs/history/5_x/version-5.17.0.md
+++ b/docs/history/5_x/version-5.17.0.md
@@ -61,9 +61,16 @@ We are working on a dynamically generated OpenAPI spec file that is hosted on ou
   
 Improves time display formatting across the UI with consistent timezone-aware time formatting for execution start/end dates and log entries.
 
-#####  ::circle-dot:: [Feature/Add Job Creation Date And Last Modified User Audit Tracking To Job Metadata](https://github.com/rundeck/rundeck/pull/9839)
+#####  ::circle-dot:: [Job Audit Tracking: Track Job Creator and Modification History](https://github.com/rundeck/rundeck/pull/9839)
   
-This helps teams see who owns each job and when it was last changed. When importing jobs, the tracking information is protected so it doesn&#39;t get overwritten.
+Rundeck now automatically tracks comprehensive audit information for every job, making it easier to manage job ownership and understand change history. Each job now records:
+
+- **Job Creator** (`createdBy`): The username of who originally created the job
+- **Last Modifier** (`lastModifiedBy`): The username of who last changed the job  
+- **Creation Date** (`created`): When the job was first created
+- **Last Modified Date** (`lastModified`): When the job was last changed
+
+This audit information is visible through the API (v56+) and appears in exported job definitions (YAML/JSON/XML). The tracking fields are system-managed and protected during job import operations to maintain accurate audit history - when you import or promote jobs between environments, the audit trail is preserved rather than being overwritten. This helps teams answer questions like "Who created this job?", "When was it last modified?", and "Who made the most recent changes?" - essential for compliance, troubleshooting, and job lifecycle management.
 
 #####  ::circle-dot:: [Remediate CVE-2025-59952](https://github.com/rundeck/rundeck/pull/9837)
 

--- a/docs/manual/document-format-reference/job-json-v44.md
+++ b/docs/manual/document-format-reference/job-json-v44.md
@@ -115,6 +115,30 @@ In addition, these optional entries can be present:
 
 : Unique UUID
 
+`user`
+
+: Username of the job creator (system-managed, since v5.17.0). This field is automatically populated when a job is created and appears in exported job definitions. When importing jobs, this field is protected and will not overwrite existing audit information.
+
+`createdBy`
+
+: Username of the job creator (system-managed, since v5.17.0). This field is automatically populated and maintained by Rundeck.
+
+`lastModifiedBy`
+
+: Username of the user who last modified the job (system-managed, since v5.17.0). This field is automatically updated whenever the job is modified.
+
+`created`
+
+: ISO-8601 timestamp when the job was created (system-managed, since v5.17.0). Example: `"2024-01-15T10:30:00Z"`
+
+`lastModified`
+
+: ISO-8601 timestamp when the job was last modified (system-managed, since v5.17.0). Example: `"2024-12-10T14:22:00Z"`
+
+::: tip
+The audit tracking fields (`user`, `createdBy`, `lastModifiedBy`, `created`, `lastModified`) are system-managed and should not be manually edited. When importing jobs, these fields are ignored to preserve accurate audit history. Jobs created before Rundeck 5.17.0 may have null values for these fields until they are next modified.
+:::
+
 `group`
 
 : Job group name

--- a/docs/manual/document-format-reference/job-v20.md
+++ b/docs/manual/document-format-reference/job-v20.md
@@ -220,6 +220,50 @@ as unique as possible if you set it manually.
 This identifier is used to uniquely identify jobs when ported between Rundeck
 instances.
 
+## Audit Tracking Fields
+
+The following elements are system-managed audit tracking fields (since v5.17.0). These fields are automatically populated and maintained by Rundeck and appear in exported job definitions. When importing jobs, these fields are protected and will not overwrite existing audit information.
+
+### user
+
+The `user` element contains the username of the job creator.
+
+```xml
+<job>
+    <name>My Job</name>
+    <user>admin</user>
+    ...
+</job>
+```
+
+### createdBy
+
+The `createdBy` element contains the username of the job creator.
+
+### lastModifiedBy
+
+The `lastModifiedBy` element contains the username of the user who last modified the job.
+
+### created
+
+The `created` element contains an ISO-8601 timestamp when the job was created.
+
+```xml
+<created>2024-01-15T10:30:00Z</created>
+```
+
+### lastModified
+
+The `lastModified` element contains an ISO-8601 timestamp when the job was last modified.
+
+```xml
+<lastModified>2024-12-10T14:22:00Z</lastModified>
+```
+
+::: tip
+The audit tracking fields are system-managed and should not be manually edited. When importing jobs, these fields are ignored to preserve accurate audit history. Jobs created before Rundeck 5.17.0 may have null values for these fields until they are next modified.
+:::
+
 ## name
 
 The job name is a sub-element of [job](#job). The combination of 'name'

--- a/docs/manual/document-format-reference/job-yaml-v12.md
+++ b/docs/manual/document-format-reference/job-yaml-v12.md
@@ -108,6 +108,30 @@ In addition, these optional entries can be present:
 
 : Unique UUID
 
+`user`
+
+: Username of the job creator (system-managed, since v5.17.0). This field is automatically populated when a job is created and appears in exported job definitions. When importing jobs, this field is protected and will not overwrite existing audit information.
+
+`createdBy`
+
+: Username of the job creator (system-managed, since v5.17.0). This field is automatically populated and maintained by Rundeck.
+
+`lastModifiedBy`
+
+: Username of the user who last modified the job (system-managed, since v5.17.0). This field is automatically updated whenever the job is modified.
+
+`created`
+
+: ISO-8601 timestamp when the job was created (system-managed, since v5.17.0). Example: `2024-01-15T10:30:00Z`
+
+`lastModified`
+
+: ISO-8601 timestamp when the job was last modified (system-managed, since v5.17.0). Example: `2024-12-10T14:22:00Z`
+
+::: tip
+The audit tracking fields (`user`, `createdBy`, `lastModifiedBy`, `created`, `lastModified`) are system-managed and should not be manually edited. When importing jobs, these fields are ignored to preserve accurate audit history. Jobs created before Rundeck 5.17.0 may have null values for these fields until they are next modified.
+:::
+
 `group`
 
 : Job group name


### PR DESCRIPTION
## Overview

This PR adds comprehensive documentation for the **Job Audit Tracking** feature introduced in Rundeck 5.17.0 (PR rundeck/rundeck#9839).

## What's New

The Job Audit Tracking feature automatically captures and maintains audit information for every job:

- **Job Creator** (`createdBy`): Username of who originally created the job
- **Last Modifier** (`lastModifiedBy`): Username of who last changed the job  
- **Creation Date** (`created`): ISO-8601 timestamp when job was created
- **Last Modified Date** (`lastModified`): ISO-8601 timestamp when job was last changed

## Documentation Changes

### 1. API Version History (`docs/api/rundeck-api-versions.md`)
- Added API v56 section documenting the new audit tracking fields
- Listed updated endpoints that now include these fields
- Explained job import behavior for audit fields

### 2. API Reference Documentation (`docs/api/index.md`)
- **Job Listing Endpoint**: Updated response examples to include audit fields with descriptions
- **Get Job Metadata Endpoint**: Added audit fields to response example  
- **Job Export**: Added note that exported jobs include audit tracking fields
- **Job Import**: Added comprehensive section explaining:
  - Audit fields are protected during import (not overwritten)
  - System-managed behavior
  - How fields are populated for new/updated/legacy jobs

### 3. Job Definition Format Specifications
Updated all three format specifications to document the new audit fields:

- **YAML** (`docs/manual/document-format-reference/job-yaml-v12.md`)
- **JSON** (`docs/manual/document-format-reference/job-json-v44.md`)
- **XML** (`docs/manual/document-format-reference/job-v20.md`)

Each includes:
- Field descriptions with examples
- Documentation that fields are system-managed
- Tip boxes explaining import protection behavior
- Notes about nullability for pre-5.17.0 jobs

### 4. Enhanced Release Notes (`docs/history/5_x/version-5.17.0.md`)
- Rewrote feature description with more detail
- Added bullet points clearly listing tracked information
- Explained value proposition and use cases
- Highlighted field protection during import/promotion

## Key Documentation Points

✅ What fields are tracked (creator, modifier, timestamps)  
✅ API v56 introduction and field descriptions  
✅ Field nullability (may be null for pre-5.17.0 jobs)  
✅ System-managed nature (auto-populated, protected)  
✅ Import behavior (fields are ignored/protected)  
✅ Export behavior (fields appear in exported definitions)  
✅ All three job definition formats (YAML, JSON, XML)  
✅ Use cases and benefits for teams

## Testing

All modified files pass linting with no errors.

## Related

- Rundeck PR: https://github.com/rundeck/rundeck/pull/9839
- Ticket: RUN-3794

## Benefits

This documentation helps users:
- Understand who created and modified jobs
- Track job ownership and lifecycle
- Maintain audit compliance
- Troubleshoot job configuration issues
- Manage jobs across multiple environments with preserved audit history