### PR TITLE
RUN-3969: add information about cve-2025-66021

### DIFF
--- a/docs/history/cves/cve-2025-66021.md
+++ b/docs/history/cves/cve-2025-66021.md
@@ -1,0 +1,11 @@
+# CVE-2025-66021
+
+## Issue with OWASP Java HTML Sanitizer
+
+::: danger FALSE POSITIVE
+ Rundeck and Runbook Automation are not vulnerable to this CVE.
+:::
+
+[CVE-2025-66021](https://nvd.nist.gov/vuln/detail/CVE-2025-66021) describes that only affects the usage of HtmlPolicyBuilder when configured with allowTextIn for the style tag.
+
+After review, we have confirmed that neither Rundeck nor Runbook Automation use HtmlPolicyBuilder with allowTextIn for the style tag, so this vulnerability does not impact our products.

--- a/docs/history/cves/cve-2025-66021.md
+++ b/docs/history/cves/cve-2025-66021.md
@@ -6,6 +6,6 @@
  Rundeck and Runbook Automation are not vulnerable to this CVE.
 :::
 
-[CVE-2025-66021](https://nvd.nist.gov/vuln/detail/CVE-2025-66021) describes that only affects the usage of HtmlPolicyBuilder when configured with allowTextIn for the style tag.
+[CVE-2025-66021](https://nvd.nist.gov/vuln/detail/CVE-2025-66021) describes a vulnerability that only affects the usage of HtmlPolicyBuilder when configured with allowTextIn for the style tag.
 
 After review, we have confirmed that neither Rundeck nor Runbook Automation use HtmlPolicyBuilder with allowTextIn for the style tag, so this vulnerability does not impact our products.

--- a/docs/history/cves/index.md
+++ b/docs/history/cves/index.md
@@ -59,3 +59,4 @@ These are the Security Advisories Rundeck has issued in the past.  It is always 
 * [CVE-2025-41242 Spring Path traversal](cve-2025-41242.md).
 * [CVE-2025-48924 Issue in Apache Commons Lang](cve-2025-48924.md)
 * [CVE-2025-41249 Spring Framework annotation detection mechanism may not correctly resolve annotation](cve-2025-41249.md)
+* [CVE-2025-66021 Issue with OWASP Java HTML Sanitizer](cve-2025-66021.md)

--- a/docs/history/cves/index.md
+++ b/docs/history/cves/index.md
@@ -57,6 +57,6 @@ These are the Security Advisories Rundeck has issued in the past.  It is always 
 * [CVE-2024-38827 Locale-sensitive string case conversion methods](cve-2024-38827.md).
 * [CVE-2024-45338 golang/x/net 0.20.0](cve-2024-38819.md).
 * [CVE-2025-41242 Spring Path traversal](cve-2025-41242.md).
-* [CVE-2025-48924 Issue in Apache Commons Lang](cve-2025-48924.md)
+* [CVE-2025-48924 Issue in Apache Commons Lang](cve-2025-48924.md).
 * [CVE-2025-41249 Spring Framework annotation detection mechanism may not correctly resolve annotation](cve-2025-41249.md).
 * [CVE-2025-66021 Issue with OWASP Java HTML Sanitizer](cve-2025-66021.md).

--- a/docs/history/cves/index.md
+++ b/docs/history/cves/index.md
@@ -58,5 +58,5 @@ These are the Security Advisories Rundeck has issued in the past.  It is always 
 * [CVE-2024-45338 golang/x/net 0.20.0](cve-2024-38819.md).
 * [CVE-2025-41242 Spring Path traversal](cve-2025-41242.md).
 * [CVE-2025-48924 Issue in Apache Commons Lang](cve-2025-48924.md)
-* [CVE-2025-41249 Spring Framework annotation detection mechanism may not correctly resolve annotation](cve-2025-41249.md)
-* [CVE-2025-66021 Issue with OWASP Java HTML Sanitizer](cve-2025-66021.md)
+* [CVE-2025-41249 Spring Framework annotation detection mechanism may not correctly resolve annotation](cve-2025-41249.md).
+* [CVE-2025-66021 Issue with OWASP Java HTML Sanitizer](cve-2025-66021.md).


### PR DESCRIPTION
This pull request adds documentation for CVE-2025-66021, clarifying that Rundeck and Runbook Automation are not affected by this vulnerability related to the OWASP Java HTML Sanitizer.

Security advisory documentation updates:

* Added a new file `cve-2025-66021.md` explaining that Rundeck and Runbook Automation are not vulnerable to CVE-2025-66021, as they do not use `HtmlPolicyBuilder` with `allowTextIn` for the `style` tag.
* Updated the CVE index in `index.md` to include a reference to the new CVE-2025-66021 advisory.