### PR TITLE
RUN-3992 Improve docs about Aws ssm timeout

### DIFF
--- a/docs/learning/howto/cross-account-aws-ssm.md
+++ b/docs/learning/howto/cross-account-aws-ssm.md
@@ -298,6 +298,15 @@ The SSM Node Executor can be set as the **Default Node Executor** - thereby maki
    * If you have more than one remote account, you can leave this blank.
 6. See below for using **CloudWatch Logs** for larger log-output.
 7. Optionally modify the **Log Filter Delay** property to be the number of seconds to wait before retrieving logs.
+
+:::tip Extended Execution Time
+SSM executions support extended timeout configurations:
+- With Assume Role: up to 12 hours
+- Without Assume Role: up to 48 hours
+- Inline Scripts: maximum 8 hours
+
+See the [Execution Timeout Configuration](/manual/projects/node-execution/aws-ssm.md#execution-timeout-configuration) section for complete details and configuration methods.
+:::
    <br>
 
 The SSM File Copier can also be set as the **Default File Copier** for the whole project:

--- a/docs/learning/howto/cross-account-aws-ssm.md
+++ b/docs/learning/howto/cross-account-aws-ssm.md
@@ -301,9 +301,9 @@ The SSM Node Executor can be set as the **Default Node Executor** - thereby maki
 
 :::tip Extended Execution Time
 SSM executions support extended timeout configurations:
-- With Assume Role: up to 12 hours
-- Without Assume Role: up to 48 hours
-- Inline Scripts: maximum 8 hours
+- With Assume Role: up to **12 hours (43200 seconds)**
+- Without Assume Role: up to **48 hours (172800 seconds)**
+- Inline Scripts: maximum **8 hours (28800 seconds)**
 
 See the [Execution Timeout Configuration](/manual/projects/node-execution/aws-ssm.md#execution-timeout-configuration) section for complete details and configuration methods.
 :::

--- a/docs/manual/projects/node-execution/aws-ssm.md
+++ b/docs/manual/projects/node-execution/aws-ssm.md
@@ -199,17 +199,61 @@ Similarly, scripts that are executed using the **Inline Script** Job step will t
 ### Execution Timeout Configuration
 AWS SSM has a default execution timeout of 1 hour (3600 seconds). You can configure a custom timeout value using the **`ssm-execution-timeout`** property to allow longer-running commands and scripts.
 
-To set the execution timeout for all SSM executions in a project:
+#### Maximum Timeout Limits
+
+The maximum execution timeout depends on your authentication method and execution type:
+
+- **With Assume Role**: Up to **12 hours (43200 seconds)**
+  - Applies when using cross-account access with IAM role assumption
+  - Limited by AWS IAM temporary credentials duration
+
+- **Without Assume Role**: Up to **48 hours (172800 seconds)**
+  - Applies when using direct IAM role attachment or access keys
+  - Suitable for very long-running operations
+
+- **Inline Scripts (RBA and RBA-SH)**: Maximum **8 hours (28800 seconds)**
+  - This limit applies specifically to inline script steps in both Runbook Automation (RBA) and Runbook Automation Self-Hosted (RBA-SH)
+  - Applies regardless of assume role usage
+
+:::warning Important
+Ensure your IAM policies and AWS service limits support your configured timeout duration. For assume role configurations, verify the maximum session duration is set appropriately in the IAM role settings.
+:::
+
+:::tip Best Practice: Timeout Configuration
+Configure your `ssm-execution-timeout` to be **longer than your expected job duration**, with a safety margin of a few minutes. For example, if your job typically runs for 2 hours, set the timeout to 2 hours and 5-10 minutes (7500-7800 seconds) to ensure the job completes successfully without timing out. This buffer accounts for variable execution times and system delays.
+:::
+
+#### Configuration Methods
+
+**1. Project-wide Configuration (Default Node Executor)**
 1. Navigate to **Project Settings** -> **Edit Configuration** -> **Default Node Executor**.
-2. In the **AWS / SSM / Node Executor** configuration, add the **Execution Timeout** value in seconds.
+2. Select **AWS / SSM / Node Executor**
+3. Set the **Execution Timeout** value in seconds (e.g., 7200 for 2 hours)
 
-To set the execution timeout on project config file:
-**`project.ssm-execution-timeout=3600`**
+**2. Node Source Level (EC2 Node Source)**
 
-To set the execution timeout at node level, add the following node-attribute to the nodes by using the [Attribute Match](/manual/node-enhancers.md#attribute-match)
-**`ssm-execution-timeout=3600`**
+Using the **Mapping Params** field:
+```
+ssm-execution-timeout.default=7200
+```
+(Example: 2 hours = 7200 seconds)
 
-**Default Value**: If not specified, the execution timeout defaults to **3600 seconds (1 hour)**.
+**3. Project Configuration File**
+
+Add to your project configuration file:
+```
+project.ssm-execution-timeout=7200
+```
+
+**4. Node Level (Individual Nodes)**
+
+Using the [Attribute Match](/manual/node-enhancers.md#attribute-match) node enhancer, add as a node-attribute:
+```
+ssm-execution-timeout=7200
+```
+
+#### Default Value
+If not specified, the execution timeout defaults to **3600 seconds (1 hour)**.
 
 ## Using CloudWatch Logs (Optional)
 The example policies in the prior sections enable Runbook Automation to retrieve logs directly from SSM.  

--- a/docs/manual/projects/node-execution/aws-ssm.md
+++ b/docs/manual/projects/node-execution/aws-ssm.md
@@ -211,7 +211,7 @@ The maximum execution timeout depends on your authentication method and executio
   - Applies when using direct IAM role attachment or access keys
   - Suitable for very long-running operations
 
-- **Inline Scripts (RBA and RBA-SH)**: Maximum **8 hours (28800 seconds)**
+- **Inline Scripts (Runbook Automation/RBA and Runbook Automation Self-Hosted/RBA-SH)**: Maximum **8 hours (28800 seconds)**
   - This limit applies specifically to inline script steps in both Runbook Automation (RBA) and Runbook Automation Self-Hosted (RBA-SH)
   - Applies regardless of assume role usage
 


### PR DESCRIPTION
**Description**
Updates AWS SSM documentation to reflect configurable execution timeout feature https://github.com/rundeckpro/rundeckpro/pull/4537
This PR updates the AWS Systems Manager (SSM) Node Executor documentation to include the new configurable timeout functionality introduced in version 5.18.0.

**Changes Made:**
- Added clarity on different timeout limits based on authentication method
- With Assume Role: up to 12 hours (43200 seconds)
- Without Assume Role: up to 48 hours (172800 seconds)
- Inline Scripts (RBA/RBA-SH): maximum 8 hours (28800 seconds)
- Added best practice guidance for configuring timeouts with safety margins
- Documented all configuration methods: project-wide, node source level, project config file, and node level
- Included important warnings about IAM policies and AWS service limits
- Added cross-reference to extended execution time capabilities
- Linked to detailed timeout configuration documentation
