### PR TITLE
Fixed JSON example

### DIFF
--- a/docs/manual/jobs/job-plugins/workflow-steps/http-request.md
+++ b/docs/manual/jobs/job-plugins/workflow-steps/http-request.md
@@ -20,12 +20,10 @@ This plugin executes an HTTP/S request to a remote endpoint.
     * JSON example:
     * ```json 
       {
-         "name": "User-Agent",
-         "value": "Buddy"
+         "User-Agent": "Buddy"
       },
       {
-         "name": "Content-Type",
-         "value": "application/json"
+         "Content-Type": "application/json",
       }
       ```
 


### PR DESCRIPTION
Fixed wrong JSON example. Using the old example will result in the following HTTP headers:
```
name: Content-Type
value: application/json
```

