### PR TITLE
Add section-based search filtering

### DIFF
--- a/.docsearch/config.json
+++ b/.docsearch/config.json
@@ -3,13 +3,104 @@
   "js_render": false,
   "start_urls": [
     {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/learning/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["Learning"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/manual/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["User Guide"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/api/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["API"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/administration/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["Administration"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/developer/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["Developer"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/history/cves/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["Administration"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/history/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["Release Notes"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/rd-cli/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["User Guide"]
+    },
+    {
+      "url": "https://docs.rundeck.com/(?P<version>.*?)/upgrading/",
+      "variables": {
+        "version": [
+          "docs",
+          "4.0.x"
+        ]
+      },
+      "tags": ["Administration"]
+    },
+    {
       "url": "https://docs.rundeck.com/(?P<version>.*?)/",
       "variables": {
         "version": [
           "docs",
           "4.0.x"
         ]
-      }
+      },
+      "tags": ["General"]
     }
   ],
   "stop_urls": [
@@ -41,7 +132,8 @@
   "custom_settings": {
     "attributesForFaceting": [
       "version",
-      "lang"
+      "lang",
+      "tags"
     ]
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,3 +40,17 @@ You are an AI assistant helping maintain the Rundeck documentation site.
 - Use numbered lists for sequential steps
 - Use bullet points for non-sequential items
 - Tables should have headers and consistent column formatting
+
+## Search Setup
+
+### Architecture
+- **Search Provider**: Algolia DocSearch via `@vuepress/plugin-docsearch`
+- **Index Name**: `prod_rundeck_docs`
+- **Indexing**: Automated via CircleCI using `algolia/docsearch-scraper` Docker image
+- **Configuration Files**:
+  - `.docsearch/config.json` - Algolia scraper configuration (selectors, start URLs, faceting attributes)
+  - `docs/.vuepress/config.ts` - VuePress DocSearch plugin configuration (appId, apiKey, search parameters)
+- **Current Facets**: `version` (filters by docs version like "docs", "4.0.x") and `lang`
+- **Section-Based Filtering**: Uses `tags` attribute to enable filtering by documentation section (learning, manual, api, administration, developer, etc.)
+- **Indexing Strategy**: Tags are applied via URL patterns in `start_urls` to categorize content by documentation section
+- **Custom Implementation**: Section filter checkboxes can be added via custom search UI using Algolia InstantSearch or DocSearch customization

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ git push origin
 ## Documentation Structure
 
 The documentation is organized as follows:
-- `/docs/` - Main documentation content
+- `/docs/` - Main documentation content (published to docs.rundeck.com)
 - `/docs/.vuepress/` - VuePress configuration
 - `/docs/.vuepress/public/assets/img/` - Images Folder
+- `/dev-docs/` - Internal developer documentation (scripts, architecture, workflows)
 
 # How to Create Release Notes
 
@@ -248,7 +249,7 @@ git push
 
 ## SaaS Development Updates Feed
 
-For generating RSS/Atom feeds and markdown pages showing recent PRs deployed to the SaaS platform (but not yet in self-hosted releases), see [PR-FEED-README.md](./PR-FEED-README.md).
+For generating RSS/Atom feeds and markdown pages showing recent PRs deployed to the SaaS platform (but not yet in self-hosted releases), see [dev-docs/PR-FEED-README.md](./dev-docs/PR-FEED-README.md).
 
 This feed automatically tracks changes since the last self-hosted release and is updated after each SaaS deployment:
 

--- a/dev-docs/DOCSEARCH_FILTERS_README.md
+++ b/dev-docs/DOCSEARCH_FILTERS_README.md
@@ -23,31 +23,26 @@ This guide explains how to integrate the section filtering component into your R
 
 ## Integration in Layout
 
-To add the filter button to your navbar, you have two options:
+The filter button is **automatically injected** into the navbar by the client configuration. No manual component placement is needed.
 
-### Option A: Add to Custom Navbar (Recommended)
-Edit your navbar menu file to include the component.
+The `injectDocSearchFiltersIntoNavbar()` function in `client.ts` automatically:
+1. Waits for the DocSearch container to be rendered
+2. Creates a wrapper element next to the search container
+3. Mounts the `DocSearchFilters` component dynamically
 
-### Option B: Add to Layout (Alternative)
-You can add it to a navbar slot in `Layout.vue`:
-
-```vue
-<template #navbarEnd>
-  <DocSearchFilters />
-</template>
-```
-
-Or create a custom navbar that includes the component.
+This ensures the filter component appears right next to the search button without requiring manual template modifications.
 
 ## How It Works
 
 1. **User clicks the filter button** (funnel icon with badge)
 2. **Filter dropdown opens** showing available section tags
 3. **User selects/deselects sections** via checkboxes
-4. **Selections are stored** in localStorage
-5. **Filter state is dispatched** via custom event
-6. **DocSearch monitors** and applies the filter state
-7. **Results are filtered** by Algolia based on selected tags
+4. **Selections are stored** in localStorage for persistence
+5. **Filter state is dispatched** via custom `docsearch-filters-updated` event
+6. **Plugin intercepts Algolia requests** - The `docsearch-filters.ts` plugin patches `fetch` and `XMLHttpRequest` to intercept all Algolia API calls
+7. **Facet filters are injected** - Selected sections are added to the request's `facetFilters` parameter as OR conditions (e.g., `tags:Learning OR tags:API`)
+8. **Results are filtered by Algolia** - Algolia returns only results matching the selected section tags
+9. **Search input is triggered** - An input event is dispatched to refresh the search results with the new filters applied
 
 ## Configuration
 

--- a/dev-docs/PR-FEED-README.md
+++ b/dev-docs/PR-FEED-README.md
@@ -362,7 +362,7 @@ This ensures the exact commits used in the build are compared, guaranteeing accu
 
 ## Related Documentation
 
-- **[README.md](./README.md)** - Main documentation project setup and release notes generation
+- **[README.md](../README.md)** - Main documentation project setup and release notes generation
 - **`notes.mjs`** - Self-hosted release notes generator (uses same shared utilities)
 - **`pr-utils.mjs`** - Shared utility functions used by both scripts
 

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,0 +1,76 @@
+# Developer Documentation
+
+This directory contains internal documentation for developers working on the Rundeck documentation project. These guides cover build processes, automation scripts, and architectural decisions.
+
+## Contents
+
+### 📋 [PR-FEED-README.md](./PR-FEED-README.md)
+**SaaS Development Feed Generator**
+
+Comprehensive guide for generating RSS/Atom feeds and markdown pages from recently merged pull requests in Rundeck repositories. This script is run as part of the SaaS release process to communicate updates deployed to Runbook Automation SaaS.
+
+**Key Topics:**
+- Weekly SaaS release workflow
+- Tag-based PR comparison
+- Configuration management
+- Feed generation (RSS 2.0 and Atom 1.0)
+- Integration with release notes process
+
+**Usage:** `npm run pr-feed`
+
+---
+
+### 🔍 [DOCSEARCH_FILTERS_README.md](./DOCSEARCH_FILTERS_README.md)
+**DocSearch Section Filters Integration**
+
+Technical documentation for the custom DocSearch filter component that allows users to filter documentation search results by section (Learning, API, Administration, etc.).
+
+**Key Topics:**
+- Component architecture (Vue + VuePress)
+- Client-side plugin integration
+- Algolia request interception
+- LocalStorage persistence
+- Automatic navbar injection
+
+**Files Covered:**
+- `docs/.vuepress/components/DocSearchFilters.vue`
+- `docs/.vuepress/plugins/docsearch-filters.ts`
+- `docs/.vuepress/client.ts`
+
+---
+
+## Related Documentation
+
+### Main Project Documentation
+- **[README.md](../README.md)** - Main project README with setup, release notes, and workflow instructions
+- **[.github/copilot-instructions.md](../.github/copilot-instructions.md)** - AI assistant instructions for code generation
+
+### Build Scripts
+- **`notes.mjs`** - Self-hosted release notes generator (tag-based)
+- **`pr-feed.mjs`** - SaaS development feed generator
+- **`pr-utils.mjs`** - Shared utility functions
+
+### Configuration Files
+- **`pr-feed-config.json`** - PR feed baseline configuration
+- **`.docsearch/config.json`** - Algolia DocSearch configuration
+- **`docs/.vuepress/config.ts`** - VuePress site configuration
+
+---
+
+## Contributing
+
+When adding new internal documentation:
+
+1. **Place it in this directory** (`dev-docs/`)
+2. **Update this README** with a description and link
+3. **Reference from main README** if it's a key workflow
+4. **Keep it updated** as the implementation changes
+
+---
+
+## Notes
+
+- This directory is for **internal/developer documentation only**
+- User-facing documentation belongs in `/docs/`
+- These files are **not** published to docs.rundeck.com
+- Complements the Copilot instructions in `.github/`

--- a/docs/.vuepress/DOCSEARCH_FILTERS_README.md
+++ b/docs/.vuepress/DOCSEARCH_FILTERS_README.md
@@ -1,0 +1,114 @@
+# DocSearch Filters Integration
+
+This guide explains how to integrate the section filtering component into your Rundeck documentation search.
+
+## Components Created
+
+### 1. DocSearchFilters.vue
+- Location: `docs/.vuepress/components/DocSearchFilters.vue`
+- A Vue component that provides a filter button with a dropdown panel
+- Shows section checkboxes (Learning, User Guide, API, Administration, Developer, Release Notes, General)
+- Persists filter selections in localStorage
+- Dispatches custom events when filters change
+
+### 2. docsearch-filters.ts Plugin
+- Location: `docs/.vuepress/plugins/docsearch-filters.ts`
+- Client-side plugin that integrates filters with DocSearch
+- Listens for filter update events and applies them to DocSearch
+- Monitors DocSearch modal for filter restoration
+
+### 3. Client Configuration Updates
+- Updated `docs/.vuepress/client.ts` to initialize the filter integration
+- Imports and calls `initializeDocSearchFilters()` on app startup
+
+## Integration in Layout
+
+To add the filter button to your navbar, you have two options:
+
+### Option A: Add to Custom Navbar (Recommended)
+Edit your navbar menu file to include the component.
+
+### Option B: Add to Layout (Alternative)
+You can add it to a navbar slot in `Layout.vue`:
+
+```vue
+<template #navbarEnd>
+  <DocSearchFilters />
+</template>
+```
+
+Or create a custom navbar that includes the component.
+
+## How It Works
+
+1. **User clicks the filter button** (funnel icon with badge)
+2. **Filter dropdown opens** showing available section tags
+3. **User selects/deselects sections** via checkboxes
+4. **Selections are stored** in localStorage
+5. **Filter state is dispatched** via custom event
+6. **DocSearch monitors** and applies the filter state
+7. **Results are filtered** by Algolia based on selected tags
+
+## Configuration
+
+### Available Sections
+The component currently supports these sections (from `config.json` tags):
+- Learning
+- User Guide
+- API
+- Administration
+- Developer
+- Release Notes
+- General
+
+To add new sections:
+1. Update `.docsearch/config.json` to add new `start_urls` with tags
+2. Update the `sections` array in `DocSearchFilters.vue`
+
+### VuePress Configuration
+The DocSearch configuration in `docs/.vuepress/config.ts` includes:
+```typescript
+searchParameters: {
+  hitsPerPage: 100,
+  facetFilters: [`version:${setup.base}`],
+  facets: ['tags']
+}
+```
+
+The `facets: ['tags']` tells Algolia to include tags as filterable attributes.
+
+## Styling
+
+The component uses VuePress theme variables for styling:
+- `--c-brand` - Brand color
+- `--c-border` - Border color
+- `--c-text-secondary` - Secondary text color
+- `--c-bg`, `--c-bg-light` - Background colors
+
+It automatically adapts to dark mode using `html.dark` selector.
+
+## Testing
+
+To test the filters:
+
+1. Build/run the docs: `npm run docs:dev`
+2. Click the filter button in the navbar
+3. Select a section (e.g., "Learning")
+4. Perform a search
+5. Results should only show items tagged with the selected section
+6. Refresh the page - filter selections persist via localStorage
+
+## Troubleshooting
+
+### Filters not appearing in results
+- Ensure Algolia index has been re-scraped with new tags
+- Check that `facets: ['tags']` is in the config
+- Verify the section tags match what's in `config.json`
+
+### localStorage not working
+- Browser privacy mode disables localStorage
+- Clear localStorage and refresh if there are issues
+
+### Component not visible
+- Ensure DocSearchFilters component is imported and placed in the layout
+- Check browser console for Vue component registration errors

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -1,11 +1,13 @@
 import { defineClientConfig } from '@vuepress/client'
-import { nextTick } from 'vue'
+import { nextTick, createApp } from 'vue'
 import '@docsearch/css'
 import Layout from "./layouts/Layout.vue";
 import NotFound from "./layouts/NotFound.vue";
 import CookieConsent from "./components/CookieConsent.vue";
+import DocSearchFilters from "./components/DocSearchFilters.vue";
 import { loadGA4, trackPageView, setupAutoTracking, setupVideoTracking, hasConsent } from "./utils/analytics";
 import { CONSENT_GRANTED_EVENT, CONSENT_REVOKED_EVENT, CONSENT_DENIED_EVENT } from "./utils/constants";
+import { initializeDocSearchFilters } from "./plugins/docsearch-filters";
 
 declare const VERSION: string;
 declare const VERSION_FULL: string;
@@ -73,6 +75,12 @@ export default defineClientConfig({
           trackPageView(to.path);
         });
       });
+
+      // Initialize DocSearch filters integration
+      initializeDocSearchFilters();
+
+      // Inject DocSearch filters into navbar
+      injectDocSearchFiltersIntoNavbar();
     }
     
     // The section below is used to properly format the Search results on the docs site.
@@ -142,6 +150,51 @@ export default defineClientConfig({
       window.XMLHttpRequest = newXHR as any;
     }
   },
-  setup() { },
+  setup() {
+    // Inject DocSearchFilters component into the navbar
+    injectDocSearchFiltersIntoNavbar();
+  },
   rootComponents: [CookieConsent],
 })
+
+/**
+ * Inject DocSearchFilters component into the navbar next to search
+ * Mounts directly after the docsearch-container for tight integration
+ */
+function injectDocSearchFiltersIntoNavbar() {
+  const checkAndInject = () => {
+    // Target the docsearch container directly
+    const docsearchContainer = document.querySelector('#docsearch-container')
+    
+    if (!docsearchContainer) {
+      // Keep trying until docsearch is rendered
+      setTimeout(checkAndInject, 100)
+      return
+    }
+
+    // Check if already injected - look for the wrapper in parent
+    const parent = docsearchContainer.parentElement
+    if (parent?.querySelector('.navbar-filters-wrapper')) {
+      return
+    }
+
+    // Create a container for the filters
+    const filterContainer = document.createElement('div')
+    filterContainer.className = 'navbar-filters-wrapper'
+    filterContainer.style.display = 'flex'
+    filterContainer.style.alignItems = 'center'
+    filterContainer.style.marginLeft = '8px'
+    
+    // Insert right after the docsearch container
+    docsearchContainer.parentElement?.appendChild(filterContainer)
+
+    // Mount the Vue component
+    const app = createApp(DocSearchFilters)
+    app.mount(filterContainer)
+  }
+
+  // Start checking after a brief delay to ensure DOM is ready
+  if (typeof window !== 'undefined') {
+    setTimeout(checkAndInject, 500)
+  }
+}

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -78,9 +78,6 @@ export default defineClientConfig({
 
       // Initialize DocSearch filters integration
       initializeDocSearchFilters();
-
-      // Inject DocSearch filters into navbar
-      injectDocSearchFiltersIntoNavbar();
     }
     
     // The section below is used to properly format the Search results on the docs site.
@@ -157,6 +154,9 @@ export default defineClientConfig({
   rootComponents: [CookieConsent],
 })
 
+// Store Vue app instance to enable cleanup if needed
+let filterAppInstance: ReturnType<typeof createApp> | null = null
+
 /**
  * Inject DocSearchFilters component into the navbar next to search
  * Mounts directly after the docsearch-container for tight integration
@@ -188,9 +188,18 @@ function injectDocSearchFiltersIntoNavbar() {
     // Insert right after the docsearch container
     docsearchContainer.parentElement?.appendChild(filterContainer)
 
-    // Mount the Vue component
-    const app = createApp(DocSearchFilters)
-    app.mount(filterContainer)
+    // Unmount previous instance if it exists
+    if (filterAppInstance) {
+      try {
+        filterAppInstance.unmount()
+      } catch (e) {
+        console.warn('Failed to unmount previous filter app instance:', e)
+      }
+    }
+
+    // Mount the Vue component and store the instance
+    filterAppInstance = createApp(DocSearchFilters)
+    filterAppInstance.mount(filterContainer)
   }
 
   // Start checking after a brief delay to ensure DOM is ready

--- a/docs/.vuepress/components/DocSearchFilters.vue
+++ b/docs/.vuepress/components/DocSearchFilters.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="docsearch-filters-container">
+    <!-- Filter toggle button -->
+    <button 
+      class="filter-toggle-btn"
+      :class="{ active: showFilters }"
+      @click="showFilters = !showFilters"
+      title="Toggle section filters"
+    >
+      <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+      </svg>
+      <span v-if="hasActiveFilters" class="filter-badge">{{ selectedSections.length }}</span>
+    </button>
+
+    <!-- Filter panel -->
+    <div v-if="showFilters" class="docsearch-filters">
+      <div class="filters-header">
+        <span class="filters-label">Filter Search:</span>
+        <button 
+          v-if="hasActiveFilters" 
+          class="clear-filters-btn"
+          @click="clearFilters"
+        >
+          Clear
+        </button>
+      </div>
+      <div class="filters-grid">
+        <label 
+          v-for="section in sections" 
+          :key="section"
+          class="filter-checkbox"
+        >
+          <input 
+            type="checkbox" 
+            :value="section"
+            v-model="selectedSections"
+            @change="updateFilters"
+          />
+          <span>{{ section }}</span>
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, nextTick } from 'vue'
+
+const sections = [
+  'User Guide',
+  'Learning', 
+  'API',
+  'Administration',
+  'Developer',
+  'Release Notes',
+  'General',
+]
+
+const selectedSections = ref<string[]>([])
+const showFilters = ref(false)
+
+const hasActiveFilters = computed(() => selectedSections.value.length > 0)
+
+const updateFilters = () => {
+  // Store selection in localStorage
+  localStorage.setItem('docsearch-section-filters', JSON.stringify(selectedSections.value))
+  
+  // Dispatch event for other components to listen to
+  window.dispatchEvent(new CustomEvent('docsearch-filters-updated', {
+    detail: { selectedSections: selectedSections.value }
+  }))
+  
+  // Trigger re-search if DocSearch is open
+  triggerDocSearchUpdate()
+}
+
+const clearFilters = () => {
+  selectedSections.value = []
+  localStorage.removeItem('docsearch-section-filters')
+  triggerDocSearchUpdate()
+}
+
+const triggerDocSearchUpdate = () => {
+  // Find the DocSearch input and trigger an input event to refresh results
+  const docSearchInput = document.querySelector('.DocSearch-Input') as HTMLInputElement
+  if (docSearchInput) {
+    // Trigger input event to refresh search results with new filters
+    docSearchInput.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+}
+
+// Restore filters from localStorage on mount
+const restoreFilters = () => {
+  const stored = localStorage.getItem('docsearch-section-filters')
+  if (stored) {
+    try {
+      selectedSections.value = JSON.parse(stored)
+    } catch (e) {
+      console.error('Failed to restore search filters:', e)
+    }
+  }
+}
+
+onMounted(() => {
+  restoreFilters()
+  
+  // Close filters panel when clicking outside
+  document.addEventListener('click', (e) => {
+    const container = document.querySelector('.docsearch-filters-container')
+    if (container && !container.contains(e.target as Node)) {
+      showFilters.value = false
+    }
+  })
+})
+</script>
+
+<style scoped>
+.docsearch-filters-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: none;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  color: var(--c-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 13px;
+  position: relative;
+}
+
+.filter-toggle-btn:hover {
+  color: var(--c-brand);
+  border-color: var(--c-brand);
+  background-color: var(--c-bg-light);
+}
+
+.filter-toggle-btn.active {
+  color: var(--c-brand);
+  border-color: var(--c-brand);
+  background-color: var(--c-brand-light);
+}
+
+.filter-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  background-color: var(--c-brand);
+  color: var(--c-text);
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.docsearch-filters {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 8px;
+  padding: 8px 12px;
+  background-color: var(--vp-c-bg);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  min-width: 240px;
+}
+
+html.dark .docsearch-filters {
+  background-color: var(--vp-c-bg-soft);
+  border-color: var(--c-border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+.filters-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0px;
+  padding-bottom: 0px;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.filters-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--c-text-secondary);
+  letter-spacing: 0.5px;
+}
+
+.clear-filters-btn {
+  padding: 2px 6px;
+  font-size: 11px;
+  background: none;
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+  color: var(--c-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.clear-filters-btn:hover {
+  background-color: var(--c-bg-light);
+  border-color: var(--c-brand);
+  color: var(--c-brand);
+}
+
+.filters-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0px;
+}
+
+.filter-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 13px;
+  color: var(--c-text);
+  padding: 0px 0;
+  transition: color 0.2s ease;
+}
+
+.filter-checkbox input[type='checkbox'] {
+  cursor: pointer;
+  margin: 0;
+  width: 18px;
+  height: 18px;
+  accent-color: var(--c-brand);
+  flex-shrink: 0;
+}
+
+.filter-checkbox:hover {
+  color: var(--c-brand);
+}
+
+.filter-checkbox input[type='checkbox']:checked + span {
+  font-weight: 600;
+  color: var(--c-brand);
+}
+
+.filter-checkbox input[type='checkbox']:checked {
+  background-color: var(--c-brand);
+}
+</style>

--- a/docs/.vuepress/components/DocSearchFilters.vue
+++ b/docs/.vuepress/components/DocSearchFilters.vue
@@ -4,7 +4,7 @@
     <button 
       class="filter-toggle-btn"
       :class="{ active: showFilters }"
-      @click="showFilters = !showFilters"
+      @click.stop="showFilters = !showFilters"
       title="Toggle section filters"
     >
       <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/docs/.vuepress/components/DocSearchFilters.vue
+++ b/docs/.vuepress/components/DocSearchFilters.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 const sections = [
   'User Guide',
@@ -64,7 +64,11 @@ const hasActiveFilters = computed(() => selectedSections.value.length > 0)
 
 const updateFilters = () => {
   // Store selection in localStorage
-  localStorage.setItem('docsearch-section-filters', JSON.stringify(selectedSections.value))
+  try {
+    localStorage.setItem('docsearch-section-filters', JSON.stringify(selectedSections.value))
+  } catch (e) {
+    console.error('Failed to save search filters to localStorage:', e)
+  }
   
   // Dispatch event for other components to listen to
   window.dispatchEvent(new CustomEvent('docsearch-filters-updated', {
@@ -77,7 +81,17 @@ const updateFilters = () => {
 
 const clearFilters = () => {
   selectedSections.value = []
-  localStorage.removeItem('docsearch-section-filters')
+  try {
+    localStorage.removeItem('docsearch-section-filters')
+  } catch (e) {
+    console.error('Failed to clear search filters from localStorage:', e)
+  }
+  
+  // Dispatch event to notify other components
+  window.dispatchEvent(new CustomEvent('docsearch-filters-updated', {
+    detail: { selectedSections: selectedSections.value }
+  }))
+  
   triggerDocSearchUpdate()
 }
 
@@ -92,13 +106,21 @@ const triggerDocSearchUpdate = () => {
 
 // Restore filters from localStorage on mount
 const restoreFilters = () => {
-  const stored = localStorage.getItem('docsearch-section-filters')
-  if (stored) {
-    try {
+  try {
+    const stored = localStorage.getItem('docsearch-section-filters')
+    if (stored) {
       selectedSections.value = JSON.parse(stored)
-    } catch (e) {
-      console.error('Failed to restore search filters:', e)
     }
+  } catch (e) {
+    console.error('Failed to restore search filters:', e)
+  }
+}
+
+// Click outside handler
+const handleClickOutside = (e: MouseEvent) => {
+  const container = document.querySelector('.docsearch-filters-container')
+  if (container && !container.contains(e.target as Node)) {
+    showFilters.value = false
   }
 }
 
@@ -106,12 +128,12 @@ onMounted(() => {
   restoreFilters()
   
   // Close filters panel when clicking outside
-  document.addEventListener('click', (e) => {
-    const container = document.querySelector('.docsearch-filters-container')
-    if (container && !container.contains(e.target as Node)) {
-      showFilters.value = false
-    }
-  })
+  document.addEventListener('click', handleClickOutside)
+})
+
+onBeforeUnmount(() => {
+  // Clean up event listener to prevent memory leak
+  document.removeEventListener('click', handleClickOutside)
 })
 </script>
 

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -131,7 +131,8 @@ export default defineUserConfig({
         indexName: 'prod_rundeck_docs',
         searchParameters: {
           hitsPerPage: 100,
-          facetFilters: [`version:${setup.base}`]
+          facetFilters: [`version:${setup.base}`],
+          facets: ['tags']
         },
         locales: {
           '/': {

--- a/docs/.vuepress/plugins/docsearch-filters.ts
+++ b/docs/.vuepress/plugins/docsearch-filters.ts
@@ -6,116 +6,155 @@
 export function setupDocSearchFiltersIntegration() {
   if (typeof window === 'undefined') return
 
+  // Patch fetch and XHR immediately
+  patchAlgoliaRequests()
+
   // Listen for filter updates from the filter component
   window.addEventListener('docsearch-filters-updated', (event: CustomEvent) => {
     const { selectedSections } = event.detail
     applySelectedFilters(selectedSections)
   })
+}
 
-  // Monitor DocSearch input changes and reapply filters
-  const monitorDocSearch = () => {
-    const docSearchButton = document.querySelector('[data-docsearch-button]')
-    if (!docSearchButton) {
-      setTimeout(monitorDocSearch, 100)
-      return
-    }
-
-    docSearchButton.addEventListener('click', () => {
-      setTimeout(() => {
-        const input = document.querySelector('.DocSearch-Input') as HTMLInputElement
-        if (input && !(input as any).__filtersAttached) {
-          ;(input as any).__filtersAttached = true
-
-          // Restore and apply stored filters when modal opens
-          const stored = localStorage.getItem('docsearch-section-filters')
-          if (stored) {
-            try {
-              const filters = JSON.parse(stored)
-              applySelectedFilters(filters)
-            } catch (e) {
-              console.error('Failed to apply stored filters:', e)
-            }
-          }
-
-          // Monitor input changes
-          input.addEventListener('input', () => {
-            const stored = localStorage.getItem('docsearch-section-filters')
-            if (stored) {
+/**
+ * Intercept fetch and XHR requests to Algolia to inject selected filters
+ */
+function patchAlgoliaRequests() {
+  // Patch fetch
+  const originalFetch = window.fetch
+  
+  window.fetch = function(url: string | Request, options?: RequestInit) {
+    // Convert Request object to string if needed
+    let urlStr = typeof url === 'string' ? url : url.url
+    
+    if (urlStr && urlStr.includes('algolia')) {
+      // Intercept Algolia fetch requests
+      let body = options?.body
+      
+      if (body && typeof body === 'string') {
+        try {
+          const parsed = JSON.parse(body)
+          if (parsed.requests && Array.isArray(parsed.requests)) {
+            // Get selected filters from localStorage
+            const storedFilters = localStorage.getItem('docsearch-section-filters')
+            let selectedSections: string[] = []
+            if (storedFilters) {
               try {
-                const filters = JSON.parse(stored)
-                applySelectedFilters(filters)
+                selectedSections = JSON.parse(storedFilters)
               } catch (e) {
                 // Silently fail
               }
             }
-          })
+
+            // Modify each request to include our facet filters
+            parsed.requests.forEach((req: any) => {
+              if (!req.facetFilters) {
+                req.facetFilters = []
+              }
+              
+              // Ensure facetFilters is an array
+              if (!Array.isArray(req.facetFilters)) {
+                req.facetFilters = [req.facetFilters]
+              }
+
+              // Add our section filters if any are selected
+              if (selectedSections.length > 0) {
+                // Build a filter array with OR logic: tags:Learning OR tags:API
+                const tagFilters = selectedSections.map(section => `tags:${section}`)
+                req.facetFilters.push(tagFilters)
+              }
+            })
+
+            // Update the body with modified request
+            if (options) {
+              options.body = JSON.stringify(parsed)
+            }
+          }
+        } catch (e) {
+          // If parsing fails, just continue with original request
         }
-      }, 100)
-    })
+      }
+    }
+
+    return originalFetch.call(this, url, options)
+  } as any
+
+  // Also patch XMLHttpRequest for compatibility
+  const originalOpen = XMLHttpRequest.prototype.open
+  const originalSend = XMLHttpRequest.prototype.send
+
+  XMLHttpRequest.prototype.open = function(method: string, url: string, ...args: any[]) {
+    ;(this as any).__requestUrl = url
+    return originalOpen.apply(this, [method, url, ...args])
   }
 
-  monitorDocSearch()
+  XMLHttpRequest.prototype.send = function(body: any) {
+    // Check if this is an Algolia request
+    const url = (this as any).__requestUrl as string
+    if (url && url.includes('algolia')) {
+      try {
+        // Intercept the request body and add our filters
+        let requestBody = body
+        if (typeof body === 'string') {
+          const parsed = JSON.parse(body)
+          if (parsed.requests && Array.isArray(parsed.requests)) {
+            // Get selected filters from localStorage
+            const storedFilters = localStorage.getItem('docsearch-section-filters')
+            let selectedSections: string[] = []
+            if (storedFilters) {
+              try {
+                selectedSections = JSON.parse(storedFilters)
+              } catch (e) {
+                // Silently fail
+              }
+            }
+
+            // Modify each request to include our facet filters
+            parsed.requests.forEach((req: any) => {
+              if (!req.facetFilters) {
+                req.facetFilters = []
+              }
+              
+              // Ensure facetFilters is an array
+              if (!Array.isArray(req.facetFilters)) {
+                req.facetFilters = [req.facetFilters]
+              }
+
+              // Add our section filters if any are selected
+              if (selectedSections.length > 0) {
+                // Build a filter array with OR logic: tags:Learning OR tags:API
+                const tagFilters = selectedSections.map(section => `tags:${section}`)
+                req.facetFilters.push(tagFilters)
+              }
+            })
+
+            requestBody = JSON.stringify(parsed)
+          }
+        }
+
+        return originalSend.call(this, requestBody)
+      } catch (e) {
+        // If parsing fails, just send original request
+        return originalSend.call(this, body)
+      }
+    }
+
+    return originalSend.call(this, body)
+  }
 }
 
-/**
- * Apply selected section filters by manipulating the DocSearch input
- * and triggering a re-search with the filters applied
- */
 function applySelectedFilters(selectedSections: string[]) {
+  // Trigger a search update by simulating input on the search field
   const input = document.querySelector('.DocSearch-Input') as HTMLInputElement
-
-  if (!input) return
-
-  // Get the current search query
-  const currentQuery = input.value
-
-  // Build the facet filter tags
-  const filterTags = selectedSections.length > 0
-    ? ` (${selectedSections.join(' OR ')})`
-    : ''
-
-  // If there are filters, append them as a metadata hint
-  // Note: Algolia filtering happens server-side via facetFilters
-  // This is just visual feedback
-  const docSearchContainer = document.querySelector('.DocSearch')
-  if (docSearchContainer) {
-    // Mark that filters are applied
-    docSearchContainer.setAttribute('data-filters-applied', selectedSections.join(','))
-  }
-
-  // Trigger a search with filters
-  // The actual filtering is done through Algolia's facetFilters parameter
-  // which we need to patch in the DocSearch instance
-  patchDocSearchInstance(selectedSections)
-}
-
-/**
- * Patch the DocSearch instance to include section filters in searches
- */
-function patchDocSearchInstance(selectedSections: string[]) {
-  // This attempts to patch the DocSearch search parameters
-  // Note: Direct patching of DocSearch internals is fragile and version-dependent
-  // A better approach would be to re-implement search using Algolia's JS client directly
-
-  const docSearchDialog = document.querySelector('[role="dialog"]')
-  if (!docSearchDialog) return
-
-  // Try to trigger a new search with our filters
-  const input = docSearchDialog.querySelector('input') as HTMLInputElement
-  if (input && input.value) {
-    // Force a re-search by simulating input events
-    const event = new Event('input', { bubbles: true })
-    input.dispatchEvent(event)
+  if (input) {
+    // Dispatch an input event to trigger re-search with new filters
+    input.dispatchEvent(new Event('input', { bubbles: true }))
   }
 }
 
 // Export function to initialize the integration
 export function initializeDocSearchFilters() {
-  // Wait for DOM to be ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setupDocSearchFiltersIntegration)
-  } else {
-    setupDocSearchFiltersIntegration()
-  }
+  // Setup immediately - don't wait for DOM
+  setupDocSearchFiltersIntegration()
 }
 

--- a/docs/.vuepress/plugins/docsearch-filters.ts
+++ b/docs/.vuepress/plugins/docsearch-filters.ts
@@ -3,8 +3,15 @@
  * This modifies DocSearch behavior to respect the selected section filters
  */
 
+// Track if integration has been set up to prevent duplicate listeners
+let isIntegrationSetup = false
+
 export function setupDocSearchFiltersIntegration() {
   if (typeof window === 'undefined') return
+  
+  // Prevent duplicate setup
+  if (isIntegrationSetup) return
+  isIntegrationSetup = true
 
   // Patch fetch and XHR immediately
   patchAlgoliaRequests()

--- a/docs/.vuepress/plugins/docsearch-filters.ts
+++ b/docs/.vuepress/plugins/docsearch-filters.ts
@@ -1,0 +1,121 @@
+/**
+ * Client-side plugin to integrate custom section filters with DocSearch
+ * This modifies DocSearch behavior to respect the selected section filters
+ */
+
+export function setupDocSearchFiltersIntegration() {
+  if (typeof window === 'undefined') return
+
+  // Listen for filter updates from the filter component
+  window.addEventListener('docsearch-filters-updated', (event: CustomEvent) => {
+    const { selectedSections } = event.detail
+    applySelectedFilters(selectedSections)
+  })
+
+  // Monitor DocSearch input changes and reapply filters
+  const monitorDocSearch = () => {
+    const docSearchButton = document.querySelector('[data-docsearch-button]')
+    if (!docSearchButton) {
+      setTimeout(monitorDocSearch, 100)
+      return
+    }
+
+    docSearchButton.addEventListener('click', () => {
+      setTimeout(() => {
+        const input = document.querySelector('.DocSearch-Input') as HTMLInputElement
+        if (input && !(input as any).__filtersAttached) {
+          ;(input as any).__filtersAttached = true
+
+          // Restore and apply stored filters when modal opens
+          const stored = localStorage.getItem('docsearch-section-filters')
+          if (stored) {
+            try {
+              const filters = JSON.parse(stored)
+              applySelectedFilters(filters)
+            } catch (e) {
+              console.error('Failed to apply stored filters:', e)
+            }
+          }
+
+          // Monitor input changes
+          input.addEventListener('input', () => {
+            const stored = localStorage.getItem('docsearch-section-filters')
+            if (stored) {
+              try {
+                const filters = JSON.parse(stored)
+                applySelectedFilters(filters)
+              } catch (e) {
+                // Silently fail
+              }
+            }
+          })
+        }
+      }, 100)
+    })
+  }
+
+  monitorDocSearch()
+}
+
+/**
+ * Apply selected section filters by manipulating the DocSearch input
+ * and triggering a re-search with the filters applied
+ */
+function applySelectedFilters(selectedSections: string[]) {
+  const input = document.querySelector('.DocSearch-Input') as HTMLInputElement
+
+  if (!input) return
+
+  // Get the current search query
+  const currentQuery = input.value
+
+  // Build the facet filter tags
+  const filterTags = selectedSections.length > 0
+    ? ` (${selectedSections.join(' OR ')})`
+    : ''
+
+  // If there are filters, append them as a metadata hint
+  // Note: Algolia filtering happens server-side via facetFilters
+  // This is just visual feedback
+  const docSearchContainer = document.querySelector('.DocSearch')
+  if (docSearchContainer) {
+    // Mark that filters are applied
+    docSearchContainer.setAttribute('data-filters-applied', selectedSections.join(','))
+  }
+
+  // Trigger a search with filters
+  // The actual filtering is done through Algolia's facetFilters parameter
+  // which we need to patch in the DocSearch instance
+  patchDocSearchInstance(selectedSections)
+}
+
+/**
+ * Patch the DocSearch instance to include section filters in searches
+ */
+function patchDocSearchInstance(selectedSections: string[]) {
+  // This attempts to patch the DocSearch search parameters
+  // Note: Direct patching of DocSearch internals is fragile and version-dependent
+  // A better approach would be to re-implement search using Algolia's JS client directly
+
+  const docSearchDialog = document.querySelector('[role="dialog"]')
+  if (!docSearchDialog) return
+
+  // Try to trigger a new search with our filters
+  const input = docSearchDialog.querySelector('input') as HTMLInputElement
+  if (input && input.value) {
+    // Force a re-search by simulating input events
+    const event = new Event('input', { bubbles: true })
+    input.dispatchEvent(event)
+  }
+}
+
+// Export function to initialize the integration
+export function initializeDocSearchFilters() {
+  // Wait for DOM to be ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupDocSearchFiltersIntegration)
+  } else {
+    setupDocSearchFiltersIntegration()
+  }
+}
+


### PR DESCRIPTION
- Configure Algolia with section tags (Learning, User Guide, API, Administration, Developer, Release Notes, General)
- Add DocSearchFilters Vue component with filter dropdown UI
- Integrate filter component into navbar via client.ts
- Update docsearch config to include facets for tags
- Add client plugin to handle filter state and localStorage
- Update copilot instructions with search architecture details
- Filter selections persist via localStorage and integrate with Algolia faceted search


In order to test this locally there are only a few "tagged" records.  Full tagging will happen once merged to main.
Configure filter for "Administration" and search for "runner" or "acl".  There should be one record for each search.