### PR TITLE
RUN-4081: Document Health Checks compatibility with Enterprise Runners (5.18.0+)

### DIFF
--- a/docs/administration/runner/runner-faq.md
+++ b/docs/administration/runner/runner-faq.md
@@ -22,4 +22,4 @@ Yes, multiple runners can be configured with the same tags. At this time only on
 
 ## Does this work with Health Checks?
 
-As of the current product version Health Checks via the Runner are not yet supported.
+Yes, Health Checks are fully compatible with Enterprise Runners as of version 5.18.0. Health Checks will continue to work correctly when Runners are enabled and assigned to projects.

--- a/docs/administration/runner/runner-plugins/runner-plugins.md
+++ b/docs/administration/runner/runner-plugins/runner-plugins.md
@@ -117,6 +117,6 @@ The following plugins are available in the next generation Runners:
 - vault-storage
 :::
 
-:::warning Health Checks Limitation
-The Health Checks feature is not yet compatible with Enterprise Runners. If you have Enterprise Runners enabled, Health Checks will show nodes as unhealthy. This will be addressed in an upcoming release.
+:::tip Health Checks with Enterprise Runners
+Health Checks are fully compatible with Enterprise Runners as of version 5.18.0. Health Checks will continue to work correctly when Runners are enabled and assigned to projects.
 :::

--- a/docs/manual/healthchecks.md
+++ b/docs/manual/healthchecks.md
@@ -8,9 +8,8 @@
 Health Checks allow the ability to check the *Health Status* of Nodes periodically and on-demand.
 It can show the heatlh status visually in the GUI, and use the status to filter out unhealthy nodes when running Jobs.
 
-:::warning Limitation with Enterprise Runners
-The Health Checks feature is not yet compatible with Enterprise Runners. If you have Enterprise Runners enabled, Health Checks will show nodes as unhealthy.
-This will be addressed in an upcoming release
+:::tip Health Checks with Enterprise Runners
+Health Checks are fully compatible with Enterprise Runners as of version 5.18.0. Health Checks will continue to work correctly when Runners are enabled and assigned to projects.
 :::
 
 ![Health Checks](/assets/img/healthchecks-health-status-ui.png)<br>


### PR DESCRIPTION
This pull request updates the documentation to reflect that Health Checks are now fully compatible with Enterprise Runners as of version 5.18.0. Previously, the documentation stated that this feature was not yet supported for Enterprise Runners. The changes ensure users are aware that Health Checks will work as expected with Enterprise Runners enabled and assigned to projects.

**Documentation updates regarding Health Checks and Enterprise Runners:**

* Updated `docs/manual/healthchecks.md` to state that Health Checks are fully compatible with Enterprise Runners as of version 5.18.0, replacing the previous warning about incompatibility.
* Updated `docs/administration/runner/runner-plugins/runner-plugins.md` to replace the warning about Health Checks not being compatible with Enterprise Runners with a tip indicating full compatibility as of version 5.18.0.
* Updated `docs/administration/runner/runner-faq.md` to clarify that Health Checks work correctly with Enterprise Runners from version 5.18.0 onwards.

**Note:**
- Health checks were previously reported to stop working when enabling the runner feature ([RUN-3363](https://pagerduty.atlassian.net/browse/RUN-3363)).
- This issue was reproducible in version 5.1.2, but is resolved in 5.18 and newer.

[RUN-3363]: https://pagerduty.atlassian.net/browse/RUN-3363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ