### PR TITLE
RUN-4102: Update documentation for plugin grouping API changes

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6319,7 +6319,26 @@ Same response as [Setup SCM Plugin for a Project](#setup-scm-plugin-for-a-projec
         "service": "NodeExecutor",
         "title": "Kubernetes / Pods / Node Executor",
         "iconUrl": "...",
-        "providerMetadata": { }
+        "providerMetadata": {
+            "groupBy": "Kubernetes",
+            "groupIconUrl": "/path/to/kubernetes-icon.svg"
+        }
+    },
+    {
+        "artifactName": "aws-vm-plugin",
+        "author": "Rundeck",
+        "builtin": false,
+        "description": "AWS VM management plugin",
+        "id": "abc123def456",
+        "name": "AwsVmStartPlugin",
+        "pluginVersion": "2.0.0",
+        "service": "WorkflowStep",
+        "title": "AWS VM Start",
+        "iconUrl": "...",
+        "providerMetadata": {
+            "groupBy": "AWS VM",
+            "groupIconUrl": "/path/to/aws-icon.svg"
+        }
     },
     {
         "artifactName": "py-winrm-plugin",
@@ -6340,6 +6359,8 @@ Same response as [Setup SCM Plugin for a Project](#setup-scm-plugin-for-a-projec
 
 * `iconUrl` - URL to icon file for the plugin if present. **since V40**
 * `providerMetadata` - Map of metadata about the plugin if present. **since V40**
+  * `groupBy` - The group name for the plugin, used for UI grouping. Plugins with the same `groupBy` value will be grouped together in the UI. **since V57**
+  * `groupIconUrl` - The icon URL for the plugin group. This may be explicitly defined for the group or automatically determined from the first plugin in the group. **since V57**
 
 ### Get Plugin Detail
 
@@ -6361,7 +6382,10 @@ Since: v49
   "targetHostCompatibility": "all",
   "ver": null,
   "id": "d36b17dfae7b",
-  "providerMetadata": {},
+  "providerMetadata": {
+    "groupBy": "MyGroup",
+    "groupIconUrl": "/path/to/group-icon.svg"
+  },
   "dynamicProps": null,
   "thirdPartyDependencies": null,
   "name": "<provider-name>",
@@ -6394,6 +6418,10 @@ Since: v49
   "dynamicDefaults": null
 }
 ```
+
+The `providerMetadata` object may contain:
+* `groupBy` - The group name for the plugin, used for UI grouping. **since V57**
+* `groupIconUrl` - The icon URL for the plugin group. **since V57**
 
 ## Webhooks
 

--- a/docs/api/rundeck-api-versions.md
+++ b/docs/api/rundeck-api-versions.md
@@ -35,6 +35,12 @@ Changes introduced by API Version number:
 API versions below `{{$apiDepVersion}}` are *deprecated*.  Clients using earlier versions should upgrade to use `{{$apiDepVersion}}` as the minimum version before release `{{ $apiDepRelease }}` to avoid errors.
 :::
 
+### Version 57
+
+* Updated Endpoints:
+  * [`GET /api/V/plugin/list`][GET /api/V/plugin/list] - Plugin list response `providerMetadata` now includes `groupBy` and `groupIconUrl` fields for plugin UI grouping
+  * [`GET /api/V/plugin/detail/[SERVICE]/[PROVIDER]`][GET /api/V/plugin/detail/\[SERVICE\]/\[PROVIDER\]] - Plugin detail response `providerMetadata` now includes `groupBy` and `groupIconUrl` fields for plugin UI grouping
+
 ### Version 56
 
 * Updated Endpoints:

--- a/docs/developer/02-plugin-annotations.md
+++ b/docs/developer/02-plugin-annotations.md
@@ -69,6 +69,46 @@ See [Provider Metadata](/developer/01-plugin-development.md#provider-metadata-1)
 
 [\@pluginmetadata]: {{$javaDocBase}}/com/dtolabs/rundeck/plugins/descriptions/PluginMetadata.html
 
+### Plugin Grouping
+
+Plugins can be grouped together in the UI by using the `groupBy` metadata key. This allows related plugins (such as plugins for the same service or cloud provider) to be visually grouped together.
+
+To group your plugin, use the `@PluginMetadata` annotation with the key `PluginGroupConstants.PLUGIN_GROUP_KEY`:
+
+```java
+import com.dtolabs.rundeck.plugins.PluginGroupConstants;
+
+@Plugin(name="myplugin", service=ServiceNameConstants.WorkflowStep)
+@PluginDescription(title="My Plugin", description="Performs a custom step")
+@PluginMetadata(key=PluginGroupConstants.PLUGIN_GROUP_KEY, value="MyGroup")
+public class MyPlugin implements StepPlugin{
+    ...
+}
+```
+
+The group name you specify will be used to group plugins together in the UI. Plugins with the same group name will appear together.
+
+You can also define constants for group names in a constants class:
+
+```java
+public class MyPluginGroupConstants {
+    public static final String GROUP_MY_SERVICE = "MyService";
+}
+```
+
+Then use it in your plugin:
+
+```java
+@Plugin(name="myplugin", service=ServiceNameConstants.WorkflowStep)
+@PluginMetadata(key=PluginGroupConstants.PLUGIN_GROUP_KEY, 
+                value=MyPluginGroupConstants.GROUP_MY_SERVICE)
+public class MyPlugin implements StepPlugin{
+    ...
+}
+```
+
+The group icon will be automatically determined from the first plugin in the group that has an icon, or can be explicitly defined using `PluginGroupDefinitions.getGroupIconUrl()`.
+
 ## Plugin Properties
 
 You can annotate individual fields in your class to define the configuration

--- a/docs/developer/02-plugin-annotations.md
+++ b/docs/developer/02-plugin-annotations.md
@@ -107,7 +107,7 @@ public class MyPlugin implements StepPlugin{
 }
 ```
 
-The group icon will be automatically determined from the first plugin in the group that has an icon, or can be explicitly defined using `PluginGroupDefinitions.getGroupIconUrl()`.
+The group icon is automatically determined from the first plugin in the group that defines an icon; there is no separate group-level icon configuration.
 
 ## Plugin Properties
 


### PR DESCRIPTION
## Summary
Updates documentation to reflect API changes for the ticket RUN-4102. Adds plugin grouping support via new providerMetadata fields in plugin API responses.

## Changes Made
1. API Reference Documentation (docs/api/index.md)

- Updated plugin list endpoint (GET /api/V/plugin/list) response examples to include groupBy and groupIconUrl in providerMetadata
- Updated plugin detail endpoint (GET /api/V/plugin/detail/[SERVICE]/[PROVIDER]) response example to include these fields
Documented both fields with descriptions and version notes (since V57)

2. Plugin Annotations Documentation (docs/developer/02-plugin-annotations.md)

- Added "Plugin Grouping" section explaining how to use @PluginMetadata with PluginGroupConstants.PLUGIN_GROUP_KEY

- Included code examples showing:
   - Basic plugin grouping usage
   - Using constants for group names
   - How group icons are determined

3. API Version History (docs/api/rundeck-api-versions.md)

- Added Version 57 entry documenting the new groupBy and groupIconUrl fields in plugin API endpoints