### PR TITLE
Metrics note for SaaS product

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -629,7 +629,7 @@ rundeck.metrics.jmxEnabled=true/false
 ```
 
 :::tip
-By security design, the Metrics Capturing is capped by default in the SaaS product.
+By security design, metrics capturing is capped by default in the SaaS product.
 :::
 
 #### Metrics API Endpoints

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -628,6 +628,10 @@ rundeck.metrics.requestFilterEnabled=true/false
 rundeck.metrics.jmxEnabled=true/false
 ```
 
+:::tip
+By security design, the Metrics Capturing is capped by default in the SaaS product.
+:::
+
 #### Metrics API Endpoints
 
 Rundeck exposes Metrics data via API endpoints, which are enabled by default.


### PR DESCRIPTION
This pull request adds a documentation note to clarify the default security behavior of metrics capturing in the SaaS product.
