### PR TITLE
RUN-4231: Document API v58 `metaExclude` for jobs browse and job meta

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -3499,7 +3499,10 @@ Since: v46
 Request parameters:
 
 * `meta` - Comma-separated list of metadata item names to include, or "*" for all (default)
-* `metaExclude` - (**API v58+**, ignored for lower API versions in the request URL) Optional comma-separated list of metadata component names to omit after resolving `meta`. If `meta` contains `*`, the effective set is all registered job metadata names minus these entries. If `meta` is an explicit list, each name in `metaExclude` is removed from that list. Omit the parameter to keep the previous behavior.
+
+**Additional Parameters (API v58+):**
+
+* `metaExclude` - Optional comma-separated list of metadata component names to omit after resolving `meta`. Requires API v58 or higher in the request URL; if the URL uses a lower API version, this parameter is ignored. If `meta` contains `*`, the server expands `*` to the union of all registered job metadata component names, then removes excluded names (the literal `*` is not treated as a component name). If `meta` is an explicit list, each name in `metaExclude` is removed from that list. Omit the parameter to keep the previous behavior.
 
 **Response:**
 
@@ -5551,11 +5554,14 @@ Since: v46
 Query Parameters:
 * `path` - Group path root, or blank for the root
 * `meta` - Comma-separated list of metadata items to include, or "*" for all
-* `metaExclude` - (**API v58+**, ignored for lower API versions in the request URL) Optional comma-separated list of metadata component names to omit after resolving `meta`. If `meta` contains `*`, the server expands `*` to all names from registered job metadata components, then drops excluded names. If `meta` is an explicit list, excluded names are removed from that list. Omit the parameter to keep the previous behavior.
 * `breakpoint` - Breakpoint, max number of jobs to load with metadata, if more results than the 
 breakpoint are available, no metadata will be loaded
 
 * Additional query parameters, see [Listing Jobs](#listing-jobs).
+
+**Additional Parameters (API v58+):**
+
+* `metaExclude` - Optional comma-separated list of metadata component names to omit after resolving `meta`. Requires API v58 or higher in the request URL; if the URL uses a lower API version, this parameter is ignored. If `meta` contains `*`, the server expands `*` to the union of all registered job metadata component names, then removes excluded names (the literal `*` is not treated as a component name). If `meta` is an explicit list, excluded names are removed from that list. Omit the parameter to keep the previous behavior.
 
 **Response**
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -3499,6 +3499,7 @@ Since: v46
 Request parameters:
 
 * `meta` - Comma-separated list of metadata item names to include, or "*" for all (default)
+* `metaExclude` - (**API v58+**, ignored for lower API versions in the request URL) Optional comma-separated list of metadata component names to omit after resolving `meta`. If `meta` contains `*`, the effective set is all registered job metadata names minus these entries. If `meta` is an explicit list, each name in `metaExclude` is removed from that list. Omit the parameter to keep the previous behavior.
 
 **Response:**
 
@@ -5550,6 +5551,7 @@ Since: v46
 Query Parameters:
 * `path` - Group path root, or blank for the root
 * `meta` - Comma-separated list of metadata items to include, or "*" for all
+* `metaExclude` - (**API v58+**, ignored for lower API versions in the request URL) Optional comma-separated list of metadata component names to omit after resolving `meta`. If `meta` contains `*`, the server expands `*` to all names from registered job metadata components, then drops excluded names. If `meta` is an explicit list, excluded names are removed from that list. Omit the parameter to keep the previous behavior.
 * `breakpoint` - Breakpoint, max number of jobs to load with metadata, if more results than the 
 breakpoint are available, no metadata will be loaded
 

--- a/docs/api/rundeck-api-versions.md
+++ b/docs/api/rundeck-api-versions.md
@@ -35,6 +35,12 @@ Changes introduced by API Version number:
 API versions below `{{$apiDepVersion}}` are *deprecated*.  Clients using earlier versions should upgrade to use `{{$apiDepVersion}}` as the minimum version before release `{{ $apiDepRelease }}` to avoid errors.
 :::
 
+### Version 58
+
+* Updated Endpoints:
+  * [`GET /api/V/project/[PROJECT]/jobs/browse`][/api/V/project/\[PROJECT\]/jobs/browse] - Optional query parameter `metaExclude`: comma-separated job metadata component names to omit after resolving `meta`. When `meta` includes `*`, the server expands `*` to the union of all names reported by registered `JobMetadataComponent` beans, then removes excluded names (the literal `*` is not passed to loaders). For an explicit comma-separated `meta` list, excluded names are removed from that list. The parameter is ignored if the request URL uses an API version below 58.
+  * [`GET /api/V/job/[ID]/meta`][/api/V/job/\[ID\]/meta] - Same optional `metaExclude` query parameter and resolution rules (API version 58+ only).
+
 ### Version 57
 
 * Updated Endpoints:

--- a/docs/api/rundeck-api-versions.md
+++ b/docs/api/rundeck-api-versions.md
@@ -38,7 +38,7 @@ API versions below `{{$apiDepVersion}}` are *deprecated*.  Clients using earlier
 ### Version 58
 
 * Updated Endpoints:
-  * [`GET /api/V/project/[PROJECT]/jobs/browse`][/api/V/project/\[PROJECT\]/jobs/browse] - Optional query parameter `metaExclude`: comma-separated job metadata component names to omit after resolving `meta`. When `meta` includes `*`, the server expands `*` to the union of all names reported by registered `JobMetadataComponent` beans, then removes excluded names (the literal `*` is not passed to loaders). For an explicit comma-separated `meta` list, excluded names are removed from that list. The parameter is ignored if the request URL uses an API version below 58.
+  * [`GET /api/V/project/[PROJECT]/jobs/browse`][/api/V/project/\[PROJECT\]/jobs/browse] - Optional query parameter `metaExclude`: comma-separated job metadata component names to omit after resolving `meta`. When `meta` includes `*`, the server expands `*` to the union of all registered job metadata component names, then removes excluded names (the literal `*` is not treated as a component name). For an explicit comma-separated `meta` list, excluded names are removed from that list. The parameter is ignored if the request URL uses an API version below 58.
   * [`GET /api/V/job/[ID]/meta`][/api/V/job/\[ID\]/meta] - Same optional `metaExclude` query parameter and resolution rules (API version 58+ only).
 
 ### Version 57


### PR DESCRIPTION
## Summary
Documents **API version 58** optional query parameter **`metaExclude`** for:
- `GET /api/V/project/[PROJECT]/jobs/browse` — Project Job Group browse
- `GET /api/V/job/[ID]/meta` — Get Job UI Metadata

## Behavior (as documented)

- **`metaExclude`** is only applied when the request uses **API v58+** in the URL; otherwise it is ignored.
- Comma-separated list of metadata component names to **omit** after resolving **`meta`**.
- If **`meta`** includes **`*`**, the server expands to all registered job metadata names, then removes excluded names (literal `*` is not passed through to loaders).
- If **`meta`** is an explicit list, names in **`metaExclude`** are removed from that list.
- Omitting **`metaExclude`** keeps the previous behavior.

## Files
- `docs/api/rundeck-api-versions.md` — new **Version 58** section.
- `docs/api/index.md` — parameter descriptions on the two endpoints above.

## Related
- Product change: [rundeck/rundeck#10026](https://github.com/rundeck/rundeck/pull/10026) (RUN-4231).