### PR TITLE
RUN-4277: Document ACE editor min/max lines configuration

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -1067,7 +1067,7 @@ Controls the height of the ACE code editor rendered inside plugin configuration 
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum number of visible lines shown in the editor, which sets its minimum visible height |
+| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum number of visible lines shown in the editor, which sets its minimum visible height. |
 | `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Set to `0` for unlimited. |
 
 These settings can be changed at runtime via **System Configuration → GUI** without restarting Rundeck. The new values take effect on the next page load.

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -1067,7 +1067,7 @@ Controls the height of the ACE code editor rendered inside plugin configuration 
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum number of visible lines before the editor scrolls |
+| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum number of visible lines shown in the editor, which sets its minimum visible height |
 | `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Set to `0` for unlimited. |
 
 These settings can be changed at runtime via **System Configuration → GUI** without restarting Rundeck. The new values take effect on the next page load.

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -1063,7 +1063,7 @@ Trim Output: Max size of visible Log Output (not present by default).
 
 ### Code Editor Settings
 
-Controls the height of the ACE code editor rendered inside plugin configuration forms (for example, inline script steps and node executor configuration).
+Controls the height of the ACE code editor rendered inside plugin configuration forms (for example, inline script steps, orchestrator configuration, and execution lifecycle plugins).
 
 | Property | Default | Description |
 |----------|---------|-------------|
@@ -1071,6 +1071,8 @@ Controls the height of the ACE code editor rendered inside plugin configuration 
 | `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Set to `0` for unlimited. |
 
 These settings can be changed at runtime via **System Configuration → GUI** without restarting Rundeck. The new values take effect on the next page load.
+
+**Scope:** These settings apply only to plugin configuration forms rendered by Vue components (job workflow steps, orchestrator, execution lifecycle, key storage, and webhooks). Plugin configuration forms that use the legacy Grails/Knockout UI are not affected.
 
 ### Groovy config format
 

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -1061,6 +1061,17 @@ Trim Output: Max size of visible Log Output (not present by default).
 : `rundeck.logviewer.trimOutput=250kb` Remove the oldest lines in Log Output after displaying 250kb of logs
 
 
+### Code Editor Settings
+
+Controls the height of the ACE code editor rendered inside plugin configuration forms (for example, inline script steps and node executor configuration).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum number of visible lines before the editor scrolls |
+| `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Set to `0` for unlimited. |
+
+These settings can be changed at runtime via **System Configuration → GUI** without restarting Rundeck. The new values take effect on the next page load.
+
 ### Groovy config format
 
 If you would prefer to use Groovy for the config file, you can use rundeck-config.groovy instead of rundeck-config.properties. Or, you can use a combination of the two (i.e. some settings configured in the properties file and some in the Groovy file).


### PR DESCRIPTION
## Jira
[RUN-4277](https://pagerduty.atlassian.net/browse/RUN-4277) — Inline-script step editor area limited to 12 lines with no expand/resize option in 5.20 UI

## Implementation PR
rundeck/rundeck#10137

## What changed
Added a new **Code Editor Settings** section to `docs/administration/configuration/config-file-reference.md` documenting two new runtime-configurable properties:

| Property | Default | Description |
|----------|---------|-------------|
| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum visible lines in the ACE code editor in plugin configuration forms |
| `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum lines the editor auto-expands to; `0` = unlimited |

Both properties are configurable via **System Configuration → GUI** without restarting Rundeck.

## Validation
- Property names and defaults verified against source (`RundeckConfigBase.java:480-481`, `FeatureFlagConfigurable.groovy:26-38`)
- Confirmed zero prior coverage (grep across all docs `.md` files)
- Placed alongside other display-limit settings (`### Limit displayed Job execution Log Output`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RUN-4277]: https://pagerduty.atlassian.net/browse/RUN-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ