### PR TITLE
Add Windows Service installation reference to runner-install page

### DIFF
--- a/docs/administration/runner/runner-installation/runner-install.md
+++ b/docs/administration/runner/runner-installation/runner-install.md
@@ -44,6 +44,12 @@ The Runner can be installed as a `systemd` service on Linux systems.
     # sudo service runner start
     ```
 
+## Windows Service for the Runner
+
+For Windows environments, the Runner can be installed as a Windows service using either Apache Commons Daemon or NSSM. This ensures the Runner starts automatically with the system and runs in the background.
+
+See the [Enterprise Runner as Windows Service](/learning/howto/runner-service-windows.html) guide for detailed installation instructions.
+
 ## Manual Docker Installation
 
 The standard method for deploying the Runner with Docker is with `docker-compose` as outlined in the [Creating Runner](/administration/runner/runner-installation/creating-runners.md) documentation by selecting **`Docker`** for the **Platform**.


### PR DESCRIPTION
## Summary
- Add reference to the Enterprise Runner as Windows Service guide in the Advanced Installation Options page
- Position the new section after Linux Service section for logical grouping of platform-specific installations
- Provides Windows users with a clear path to service installation options

## Context
The Advanced Installation Options page (https://docs.rundeck.com/docs/administration/runner/runner-installation/runner-install.html) covers Linux service installation and Docker methods but has no mention of Windows service installation, even though a comprehensive guide exists at https://docs.rundeck.com/docs/learning/howto/runner-service-windows.html. This creates a documentation gap for Windows users looking for service installation options.

## Changes
- Added "Windows Service for the Runner" section with brief description and link to detailed guide
- Positioned after Linux Service section for logical platform grouping

## Test plan
- [x] Verify link resolves correctly to existing Windows service guide
- [x] Confirm section placement flows logically after Linux Service section
- [x] Review formatting and consistency with existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)