### PR TITLE
Update Runner configuration with installation and replica types

### DIFF
--- a/docs/manual/plugins/kubernetes-plugins-overview.md
+++ b/docs/manual/plugins/kubernetes-plugins-overview.md
@@ -57,7 +57,9 @@ Follow these steps to set up a Runner in a Kubernetes cluster:
    --data-raw '{
       "name": "K8s Runner US-WEST-1 Cluster 1",
       "description": "Runner installed in US-WEST-1 Cluster 1",
-      "tagNames": ["K8S-RUNNER", "us-west-1", "cluster-1"]
+      "tagNames": ["K8S-RUNNER", "us-west-1", "cluster-1"],
+      "installationType": "kubernetes",
+      "replicaType": "ephemeral"
      }'
       ```
    :::tip Tip


### PR DESCRIPTION
Added installationType and replicaType fields to the Runner configuration. Otherwise, the Runner is created in manual mode and the Pod will fail to start up...