### PR TITLE
[RUN-3585] add alternative mode to start runner as service

### DIFF
--- a/docs/learning/howto/runner-service-windows.md
+++ b/docs/learning/howto/runner-service-windows.md
@@ -202,7 +202,7 @@ runner.exe //IS//Runner ^
 ```
 
 :::warning Set `--Jvm` to your real `jvm.dll` path
-In `jvm` mode `--Jvm=auto` often fails with `no JVM configured or found in registry` (many JDK/JRE builds don't register in the Windows registry, and the `LocalSystem` account doesn't see a user-level `JAVA_HOME`). Replace `<JAVA_INSTALL_PATH>` with your Java installation directory (the same path as `JAVA_HOME`)
+In `jvm` mode, `--Jvm=auto` often fails with `no JVM configured or found in registry` (many JDK/JRE builds don't register in the Windows registry, and the `LocalSystem` account doesn't see a user-level `JAVA_HOME`). Replace `<JAVA_INSTALL_PATH>` with your Java installation directory (the same path as `JAVA_HOME`).
 
 Note that `jvm` mode replaces `--StartMode=java`/`--StartParams=-jar#runner.jar` with `--StartMode=jvm`, `--Classpath` (the path to `runner.jar`) and `--StartClass` (the Runner main class). The `runner.exe` (procrun) and the `jvm.dll` must be the **same architecture** (use the 64-bit `prunsrv.exe` from `amd64\` with a 64-bit JRE/JDK).
 :::

--- a/docs/learning/howto/runner-service-windows.md
+++ b/docs/learning/howto/runner-service-windows.md
@@ -141,7 +141,7 @@ endlocal
 
 7. Execute the following command (you can copy and paste it directly on the CMD terminal to execute it):
 
-::: tabs
+:::: tabs
 
 @tab Standard (`java` mode)
 
@@ -168,7 +168,7 @@ runner.exe //IS//Runner ^
  --StdError=C:\runner\runner.log
 ```
 
-:::tip Note
+::: tip Note
 The service name uses a double slash (`//IS//runner`) — this is the procrun syntax for "install service". `--Jvm=auto` lets procrun locate `jvm.dll` automatically from `JAVA_HOME` / the registry. The stop is delegated to `stop-runner.bat` through `cmd.exe`; the full path to `cmd.exe` is required because procrun passes `--StopImage` directly to `CreateProcess`, which does not search the `PATH` (a bare `cmd` fails with `The system cannot find the file specified`).
 :::
 

--- a/docs/learning/howto/runner-service-windows.md
+++ b/docs/learning/howto/runner-service-windows.md
@@ -141,7 +141,7 @@ endlocal
 
 7. Execute the following command (you can copy and paste it directly on the CMD terminal to execute it):
 
-:::: tabs
+::: tabs
 
 @tab Standard (`java` mode)
 

--- a/docs/learning/howto/runner-service-windows.md
+++ b/docs/learning/howto/runner-service-windows.md
@@ -172,7 +172,7 @@ runner.exe //IS//Runner ^
 The service name uses a double slash (`//IS//runner`) — this is the procrun syntax for "install service". `--Jvm=auto` lets procrun locate `jvm.dll` automatically from `JAVA_HOME` / the registry. The stop is delegated to `stop-runner.bat` through `cmd.exe`; the full path to `cmd.exe` is required because procrun passes `--StopImage` directly to `CreateProcess`, which does not search the `PATH` (a bare `cmd` fails with `The system cannot find the file specified`).
 :::
 
-@tab Alternative More logging (`jvm` mode)
+@tab Alternative (more logging, `jvm` mode)
 
 With `--StartMode=java`, procrun launches the Runner as a **separate** `java.exe` process and does not pipe that process's output into `--StdOutput`/`--StdError`, so `runner.log` can stay empty. Use this `jvm`-mode variant instead: procrun loads the JVM **in-process** and captures the Runner's `System.out`/`System.err` directly into the log file.
 

--- a/docs/learning/howto/runner-service-windows.md
+++ b/docs/learning/howto/runner-service-windows.md
@@ -141,6 +141,10 @@ endlocal
 
 7. Execute the following command (you can copy and paste it directly on the CMD terminal to execute it):
 
+:::: tabs
+
+@tab Standard (`java` mode)
+
 ```bat
 runner.exe //IS//Runner ^
  --DisplayName=Runner ^
@@ -167,6 +171,43 @@ runner.exe //IS//Runner ^
 :::tip Note
 The service name uses a double slash (`//IS//runner`) — this is the procrun syntax for "install service". `--Jvm=auto` lets procrun locate `jvm.dll` automatically from `JAVA_HOME` / the registry. The stop is delegated to `stop-runner.bat` through `cmd.exe`; the full path to `cmd.exe` is required because procrun passes `--StopImage` directly to `CreateProcess`, which does not search the `PATH` (a bare `cmd` fails with `The system cannot find the file specified`).
 :::
+
+@tab Alternative More logging (`jvm` mode)
+
+With `--StartMode=java`, procrun launches the Runner as a **separate** `java.exe` process and does not pipe that process's output into `--StdOutput`/`--StdError`, so `runner.log` can stay empty. Use this `jvm`-mode variant instead: procrun loads the JVM **in-process** and captures the Runner's `System.out`/`System.err` directly into the log file.
+
+```bat
+runner.exe //IS//Runner ^
+ --DisplayName=Runner ^
+ --LogLevel=Info ^
+ --LogPath=C:\runner ^
+ --ServiceUser=LocalSystem ^
+ --Startup=auto ^
+ --Jvm="<JAVA_INSTALL_PATH>\bin\server\jvm.dll" ^
+ --StartMode=jvm ^
+ --Classpath=C:\runner\runner.jar ^
+ --StartClass=com.rundeck.runner.agent.RunnerApplication ^
+ --StartMethod=main ^
+ --StartPath=C:\runner ^
+ --StopMode=exe ^
+ --StopImage=C:\Windows\System32\cmd.exe ^
+ --StopParams=/c#C:\runner\stop-runner.bat ^
+ --StopPath=C:\runner ^
+ --StopTimeout=30 ^
+ --PidFile=runner.pid ^
+ --JvmMs=1024 ^
+ --JvmMx=4096 ^
+ --StdOutput=C:\runner\runner.log ^
+ --StdError=C:\runner\runner.log
+```
+
+:::warning Set `--Jvm` to your real `jvm.dll` path
+In `jvm` mode `--Jvm=auto` often fails with `no JVM configured or found in registry` (many JDK/JRE builds don't register in the Windows registry, and the `LocalSystem` account doesn't see a user-level `JAVA_HOME`). Replace `<JAVA_INSTALL_PATH>` with your Java installation directory (the same path as `JAVA_HOME`)
+
+Note that `jvm` mode replaces `--StartMode=java`/`--StartParams=-jar#runner.jar` with `--StartMode=jvm`, `--Classpath` (the path to `runner.jar`) and `--StartClass` (the Runner main class). The `runner.exe` (procrun) and the `jvm.dll` must be the **same architecture** (use the 64-bit `prunsrv.exe` from `amd64\` with a 64-bit JRE/JDK).
+:::
+
+::::
 
 You will see messages similar to the following:
 


### PR DESCRIPTION
This pull request updates the Windows service installation documentation for the Runner, making it clearer and more comprehensive by introducing tabbed instructions for different installation modes. The most important changes are:

**Documentation improvements for Windows service installation:**

* Added tabbed sections to the `runner-service-windows.md` guide, allowing users to choose between standard (`java` mode) and alternative (`jvm` mode) installation instructions for `runner.exe`.
* Introduced a detailed example for installing the Runner in `jvm` mode, which provides more robust logging by capturing `System.out`/`System.err` directly into the log file.
* Added a warning explaining the importance of setting the `--Jvm` parameter to the correct `jvm.dll` path in `jvm` mode, and clarified differences between `java` and `jvm` modes, including architecture compatibility requirements.