### PR TITLE
fix(api): update token expiration format to include milliseconds

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -251,7 +251,7 @@ List all tokens or all tokens for a specific user.
     "id": "ece75ac8-2791-442e-b179-a9907d83fd05",
     "creator": "user3",
     "name": "Admin RD-CLI",
-    "expiration": "2017-03-25T21:16:50Z",
+    "expiration": "2017-03-25T21:16:50.000Z",
     "roles": [
       "DEV_99",
       "FEDCD25B-C945-48D3-9821-A10D44535EA4"
@@ -263,7 +263,7 @@ List all tokens or all tokens for a specific user.
     "id": "abcb096f-cef4-451a-bd2b-43284a3ff2ad",
     "creator": "user3",
     "name": "CI Server",
-    "expiration": "2017-03-25T21:17:12Z",
+    "expiration": "2017-03-25T21:17:12.000Z",
     "roles": [
       "SVC_XYZ",
       "devops",
@@ -276,7 +276,7 @@ List all tokens or all tokens for a specific user.
     "id": "a99bd86d-0125-4eaa-9b16-caded4485476",
     "creator": "user3",
     "name": "GitHub Integration",
-    "expiration": "2018-03-24T21:17:26Z",
+    "expiration": "2018-03-24T21:17:26.000Z",
     "roles": [
       "user",
       "FEDCD25B-C945-48D3-9821-A10D44535EA4"
@@ -287,7 +287,7 @@ List all tokens or all tokens for a specific user.
     "user": "user3",
     "id": "c13de457-c429-4476-9acd-e1c89e3c2928",
     "creator": "user3",
-    "expiration": "2017-03-24T21:18:55Z",
+    "expiration": "2017-03-24T21:18:55.000Z",
     "roles": [
       "USER_ACCOUNT"
     ],
@@ -341,7 +341,7 @@ The `id` is the unique ID, and the `name` (since v37) is the name given at creat
   "id": "c13de457-c429-4476-9acd-e1c89e3c2928",
   "creator": "user3",
   "name": "CI Server Token",
-  "expiration": "2017-03-24T21:18:55Z",
+  "expiration": "2017-03-24T21:18:55.000Z",
   "roles": [
     "USER_ACCOUNT"
   ],
@@ -361,7 +361,7 @@ The `id` is the unique ID, and the `token` value is the token string.
   "token": "VjkbX2zUAwnXjDIbRYFp824tF5X2N7W1",
   "id": "c13de457-c429-4476-9acd-e1c89e3c2928",
   "creator": "user3",
-  "expiration": "2017-03-24T21:18:55Z",
+  "expiration": "2017-03-24T21:18:55.000Z",
   "roles": [
     "USER_ACCOUNT"
   ],
@@ -441,7 +441,7 @@ then the generated token will have all roles as the authenticated user.
   "id": "b6ea87e3-43e5-4210-bd51-b82f8e33d9a4",
   "creator": "admin",
   "name": "Example Token",
-  "expiration": "2017-07-22T22:43:53Z",
+  "expiration": "2017-07-22T22:43:53.000Z",
   "roles": [
     "dev",
     "sre"


### PR DESCRIPTION
## Summary

The \`expiration\` field in the Token API endpoints currently shows timestamps without milliseconds in the docs (e.g. \`2017-03-25T21:16:50Z\`). The actual API response now includes milliseconds (e.g. \`2017-03-25T21:16:50.403Z\`), causing customer automation scripts that do strict timestamp parsing to break.

## Verification

Verified against a live RBA staging environment:

- **List Tokens** (\`GET /api/47/tokens\`) — confirmed, all non-null expiration values include milliseconds
- **Get a Token** (\`GET /api/47/token/[ID]\`) — confirmed, e.g. \`"2026-01-13T09:28:31.403Z"\`
- **Create a Token** (\`POST /api/47/tokens\`) — inferred from same underlying token serialization layer

## Changes

Updated 7 \`expiration\` field examples across 3 sections in \`docs/api/index.md\`:

| Section | Lines |
|---------|-------|
| List Tokens | 254, 266, 279, 290 |
| Get a Token | 344, 364 |
| Create a Token | 444 |

Format corrected: \`YYYY-MM-DDTHH:MM:SSZ\` → \`YYYY-MM-DDTHH:MM:SS.mmmZ\`

Note: \`expirationDate\` fields in other API sections were intentionally left unchanged as they are unrelated to token management.

## Root Cause Analysis

This is an **unintentional side effect of the Grails 7 migration** — not a deliberate API change.

| | Detail |
|---|---|
| **Build deployed** | \`6.0-RBA-20260610-9b4775e-e87f288\`, deployed ~June 15–16 JST |
| **Key change** | Grails upgraded from 6 → **Grails 7.1.1** (Spring Boot 3.x, Jackson 2.21.3), landed on \`main\` ~April 4 (commit \`c9adfb1a\`) |
| **Why the format changed** | In Grails 7, \`respond()\` uses **Jackson's \`MappingJackson2HttpMessageConverter\`** instead of the old Grails-specific JSON converter. Jackson's default ISO 8601 serializer for \`java.util.Date\` always emits milliseconds when they are non-zero |
| **Why there was no explicit format** | \`Token.groovy\` declares \`Date expiration\` with no \`@JsonFormat\` annotation, so the format is entirely dictated by the runtime serializer |
| **Grails 6 behavior** | The old Grails JSON converter used \`yyyy-MM-dd'T'HH:mm:ssX\` — no milliseconds |
| **Grails 7 behavior** | Jackson's \`StdDateFormat\` emits \`yyyy-MM-dd'T'HH:mm:ss.SSSZ\` — milliseconds included |

The field in question is \`rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/tokens/Token.groovy\`:

```groovy
@Ignore(onlyIfNull = true)
@ApiVersion(19)
@Schema(description = "since: v19", implementation = String, format = 'iso')
Date expiration   // no @JsonFormat — format depends on runtime serializer
```

A permanent fix would be to pin the format explicitly:
```groovy
@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssX")
Date expiration
```
This would restore the previous no-milliseconds format. Alternatively, the current millisecond-inclusive format can be accepted as correct going forward — which is what this doc PR does.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)