### PR TITLE
[RUN-4503] Document ssm-sts-region property for AWS opt-in regions

### DIFF
--- a/docs/learning/howto/cross-account-aws-ssm.md
+++ b/docs/learning/howto/cross-account-aws-ssm.md
@@ -292,7 +292,7 @@ If your remote EC2 nodes reside in an **AWS opt-in region**, you must also set t
 **Why?** AWS opt-in regions reject STS v1 tokens with `InvalidClientTokenId (HTTP 403)`. Regional STS endpoints always issue v2 tokens that are valid in all AWS regions, including opt-in regions.
 
 Add the following to your **Mapping Params**:
-```
+```properties
 ssm-sts-region.default=us-east-1
 ```
 Or as a project-level property: **`project.ssm-sts-region=us-east-1`**

--- a/docs/learning/howto/cross-account-aws-ssm.md
+++ b/docs/learning/howto/cross-account-aws-ssm.md
@@ -286,6 +286,20 @@ The SSM Node Executor and File Copier can be configured on a per **Node Source**
 
 If the same S3 bucket will be used across multiple Node Sources (thereby serving multiple AWS Accounts), _and_ the **Default File Copier** is not set to use SSM, then this can instead be added as a Project level property: **`project.ssm-copier-bucket=<<S3 bucket name>>`**.
 
+:::warning Nodes in AWS Opt-In Regions (e.g., eu-central-2, ap-east-1)
+If your remote EC2 nodes reside in an **AWS opt-in region**, you must also set the `ssm-sts-region` property to a **standard** (non-opt-in) AWS region such as `us-east-1`.
+
+**Why?** AWS opt-in regions reject STS v1 tokens with `InvalidClientTokenId (HTTP 403)`. Regional STS endpoints always issue v2 tokens that are valid in all AWS regions, including opt-in regions.
+
+Add the following to your **Mapping Params**:
+```
+ssm-sts-region.default=us-east-1
+```
+Or as a project-level property: **`project.ssm-sts-region=us-east-1`**
+
+See the [STS Region Configuration](/manual/projects/node-execution/aws-ssm.md#sts-region-configuration-for-aws-opt-in-regions) section for full details and all configuration methods.
+:::
+
 #### Option 2: Project Wide Configuration
 The SSM Node Executor can be set as the **Default Node Executor** - thereby making it the standard node executor for the whole project:
 

--- a/docs/manual/projects/node-execution/aws-ssm.md
+++ b/docs/manual/projects/node-execution/aws-ssm.md
@@ -255,6 +255,57 @@ ssm-execution-timeout=7200
 #### Default Value
 If not specified, the execution timeout defaults to **3600 seconds (1 hour)**.
 
+## STS Region Configuration for AWS Opt-In Regions
+
+By default, the SSM Node Executor uses the node's `region` attribute to determine which AWS STS regional endpoint to call when performing AssumeRole authentication. This works correctly for standard AWS regions.
+
+**AWS opt-in regions** (e.g., `eu-central-2` — Zurich, `ap-east-1` — Hong Kong, `me-south-1` — Bahrain) require STS tokens issued by a **regional STS endpoint** rather than the global endpoint. If your Runbook Automation instance is running in a standard region but needs to execute SSM commands on nodes in opt-in regions, use the `ssm-sts-region` property to explicitly control which STS endpoint region is used for the AssumeRole call.
+
+:::tip Why this matters
+AWS STS has two token versions:
+- **v1 tokens** — issued by the global endpoint (`sts.amazonaws.com`). Opt-in regions **reject** v1 tokens with `InvalidClientTokenId (HTTP 403)`.
+- **v2 tokens** — issued by any **regional STS endpoint** (e.g., `sts.us-east-1.amazonaws.com`). Valid in **all** AWS regions, including opt-in regions.
+
+Setting `ssm-sts-region` to any standard region (e.g., `us-east-1`) forces the plugin to use a regional STS endpoint, producing v2 tokens that work in opt-in regions.
+:::
+
+:::warning Backward Compatibility
+When `ssm-sts-region` is **not** configured, behavior is identical to previous versions — no change for existing setups.
+:::
+
+### Configuration Methods
+
+**1. Project-wide Configuration (Default Node Executor)**
+1. Navigate to **Project Settings** → **Edit Configuration** → **Default Node Executor**.
+2. Select **AWS / SSM / Node Executor**.
+3. Set the **STS Region** field to a standard AWS region (e.g., `us-east-1`).
+
+**2. Node Source Level (EC2 Node Source)**
+
+Using the **Mapping Params** field:
+```
+ssm-sts-region.default=us-east-1
+```
+
+**3. Project Configuration File**
+
+Add to your project configuration file:
+```
+project.ssm-sts-region=us-east-1
+```
+
+**4. Node Level (Individual Nodes)**
+
+Using the [Attribute Match](/manual/node-enhancers.md#attribute-match) node enhancer, add as a node-attribute:
+```
+ssm-sts-region=us-east-1
+```
+
+### Default Value
+If not specified, `ssm-sts-region` defaults to the node's **`region`** attribute value, which is the same behavior as previous plugin versions.
+
+---
+
 ## Using CloudWatch Logs (Optional)
 The example policies in the prior sections enable Runbook Automation to retrieve logs directly from SSM.  
 However, these logs are truncated to 48,000 characters. To view logs that are longer than this limit, CloudWatch logs are used.  

--- a/docs/manual/projects/node-execution/aws-ssm.md
+++ b/docs/manual/projects/node-execution/aws-ssm.md
@@ -283,21 +283,21 @@ When `ssm-sts-region` is **not** configured, behavior is identical to previous v
 **2. Node Source Level (EC2 Node Source)**
 
 Using the **Mapping Params** field:
-```
+```properties
 ssm-sts-region.default=us-east-1
 ```
 
 **3. Project Configuration File**
 
 Add to your project configuration file:
-```
+```properties
 project.ssm-sts-region=us-east-1
 ```
 
 **4. Node Level (Individual Nodes)**
 
 Using the [Attribute Match](/manual/node-enhancers.md#attribute-match) node enhancer, add as a node-attribute:
-```
+```properties
 ssm-sts-region=us-east-1
 ```
 


### PR DESCRIPTION
## Summary

Documents the new `ssm-sts-region` plugin property introduced in [rundeckpro/rundeckpro#4748](https://github.com/rundeckpro/rundeckpro/pull/4748) to fix `InvalidClientTokenId (HTTP 403)` errors when executing SSM commands on nodes in AWS opt-in regions (e.g., `eu-central-2` — Zurich).

**Jira:** [RUN-4503](https://pagerduty.atlassian.net/browse/RUN-4503)

## Changes

### `docs/manual/projects/node-execution/aws-ssm.md`
- New section: **"STS Region Configuration for AWS Opt-In Regions"**
  - Explains AWS v1 vs v2 STS token behavior and why opt-in regions reject v1 tokens
  - Documents all 4 configuration methods: Project UI, Mapping Params, `project.ssm-sts-region`, node-attribute
  - Includes tip callout explaining the root cause and backward compatibility note

### `docs/learning/howto/cross-account-aws-ssm.md`
- Added `::: warning` callout in the **"Option 1: Individual Nodes and Node Sources Setting"** section
  - Alerts users with nodes in opt-in regions to configure `ssm-sts-region.default=us-east-1`
  - Explains why (v1/v2 token rejection)
  - Links to the full reference section in `aws-ssm.md`

## Context

AWS opt-in regions (those that must be manually enabled in the AWS account) reject STS v1 tokens with `InvalidClientTokenId`. The global STS endpoint (`sts.amazonaws.com`) issues v1 tokens by default. The new `ssm-sts-region` property forces the plugin to use a regional STS endpoint, which always issues v2 tokens valid in all AWS regions.

The property is optional and backward-compatible — when not set, behavior is identical to previous versions.

## Test plan

- [ ] Verify new section renders correctly in local docs preview
- [ ] Verify links to `aws-ssm.md#sts-region-configuration` anchor resolve correctly
- [ ] Confirm warning block displays properly in VuePress

Made with [Cursor](https://cursor.com)

[RUN-4503]: https://pagerduty.atlassian.net/browse/RUN-4503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ