### PR TITLE
[RUN-4518] Document nodeFilter URL parameter for job linking

### DIFF
--- a/docs/manual/jobs/job-options.md
+++ b/docs/manual/jobs/job-options.md
@@ -800,9 +800,10 @@ In this case, the option will be allowed to use a text field to set the value.
 
 You can create a URL to link to a specific Job, and pre-fill some of the option values by adding URL query parameters to the Job's URL.
 
-Query Parameters format for options:
+Supported query parameters:
 
 - `opt.NAME`: provide a value for an option named `NAME`
+- `nodeFilter`: pre-populate the node filter field with the given filter expression. This parameter is only applied when the Job has **Node Filter** set to **Editable** (`nodeFilterEditable: true`); it is ignored otherwise.
 
 For example, if the URL for the Job is:
 
@@ -815,5 +816,9 @@ Then you can pre-fill the values for `myopt1` and `myotheropt` by appending this
 The result would be:
 
     http://rundeck:4440/project/MyProject/job/show/ab698597-9753-4e98-bdab-90ebf395b0d0?opt.myopt1=some+value&opt.myotheropt=another+value
+
+To also pre-populate the node filter, combine `nodeFilter` with option parameters:
+
+    http://rundeck:4440/project/MyProject/job/show/ab698597-9753-4e98-bdab-90ebf395b0d0?opt.myopt1=some+value&nodeFilter=name%3A+web-server-01
 
 Note: be sure to properly escape the strings for option values, and if necessary for the option names as well.

--- a/docs/manual/jobs/job-options.md
+++ b/docs/manual/jobs/job-options.md
@@ -821,4 +821,4 @@ To also pre-populate the node filter, combine `nodeFilter` with option parameter
 
     http://rundeck:4440/project/MyProject/job/show/ab698597-9753-4e98-bdab-90ebf395b0d0?opt.myopt1=some+value&nodeFilter=name%3A+web-server-01
 
-Note: be sure to properly escape the strings for option values, and if necessary for the option names as well.
+Note: be sure to properly URL-encode all parameter values. This applies to option values, option names, and `nodeFilter` expressions — filter syntax characters such as spaces and `:` must be encoded (e.g., `name: web-01` becomes `name%3A+web-01`).


### PR DESCRIPTION
## Summary

Documents the new `?nodeFilter=` URL query parameter introduced in [rundeck/rundeck#10194](https://github.com/rundeck/rundeck/pull/10194).

**File changed:** `docs/manual/jobs/job-options.md` — "Linking to Jobs and providing option values" section.

**Changes:**
- Renamed "Query Parameters format for options" → "Supported query parameters" to reflect the expanded list
- Added `nodeFilter` entry with the `nodeFilterEditable: true` requirement clearly stated
- Added a combined usage example showing `nodeFilter` alongside `opt.NAME` parameters

## Release Notes

Add `?nodeFilter=` URL parameter support to the Job linking section. When a Job has **Node Filter** set to **Editable**, you can now pre-populate the node filter via URL using `?nodeFilter=<filter expression>`, enabling deep-linking workflows such as incident response integrations (e.g. ServiceNow) that include the target hostname.

## Related

- Rundeck PR: https://github.com/rundeck/rundeck/pull/10194
- Jira: https://pagerduty.atlassian.net/browse/RUN-4518