### PR TITLE
[RUN-4513] Document activity default time filter feature

### DIFF
--- a/docs/manual/08-activity.md
+++ b/docs/manual/08-activity.md
@@ -60,7 +60,7 @@ RUNDECK_FEATURE_ACTIVITYDEFAULTTIMEFILTER_ENABLED=true
 RUNDECK_GUI_ACTIVITY_DEFAULTTIMEFILTER=1w
 ```
 
-When enabled, the **Activity**, **Jobs**, and **Adhoc Commands** pages all apply this filter on first load when no other filters are active. Users can still change or clear the filter manually at any time.
+When enabled, the **Activity**, **Jobs**, and **Ad hoc commands** pages all apply this filter on first load when no other filters are active. Users can still change or clear the filter manually at any time.
 
 :::tip
 Setting a default time filter is recommended for production instances with months or years of execution history, as it significantly reduces initial page load time.

--- a/docs/manual/08-activity.md
+++ b/docs/manual/08-activity.md
@@ -25,6 +25,31 @@ The filter form contains a number of fields to limit search:
 After filling the form pressing the "Filter" button, the page will
 display executions matching the search.
 
+### Default Time Filter
+
+By default the Activity view loads all executions without a time boundary, which can be slow on instances with large execution history. Administrators can configure a default time filter so the Activity page opens pre-filtered to a recent window.
+
+This is controlled by the `ACTIVITY_DEFAULT_TIME_FILTER` feature flag in `rundeck-config.properties`:
+
+```properties
+rundeck.feature.activityDefaultTimeFilter.enabled=true
+rundeck.feature.activityDefaultTimeFilter.value=1w
+```
+
+Supported values for `value`:
+
+| Value | Description |
+|-------|-------------|
+| `1d`  | Last 1 day  |
+| `1w`  | Last 1 week (default when enabled) |
+| `1m`  | Last 1 month |
+
+When enabled, the **Activity**, **Jobs**, and **Adhoc Commands** pages all apply this filter when they first load. Users can still change or clear the filter manually.
+
+:::tip
+Setting a default time filter is recommended for production instances with months or years of execution history, as it significantly reduces initial page load time.
+:::
+
 ## Activity in PagerDuty Runbook Automation Self-Hosted Home
 
 On the home page, users can check activity for a specific project, such as failed executions for each project.

--- a/docs/manual/08-activity.md
+++ b/docs/manual/08-activity.md
@@ -29,22 +29,38 @@ display executions matching the search.
 
 By default the Activity view loads all executions without a time boundary, which can be slow on instances with large execution history. Administrators can configure a default time filter so the Activity page opens pre-filtered to a recent window.
 
-This is controlled by the `ACTIVITY_DEFAULT_TIME_FILTER` feature flag in `rundeck-config.properties`:
+Two settings work together to enable this feature:
+
+**1. Enable the feature flag** in `rundeck-config.properties`:
 
 ```properties
 rundeck.feature.activityDefaultTimeFilter.enabled=true
-rundeck.feature.activityDefaultTimeFilter.value=1w
 ```
 
-Supported values for `value`:
+**2. Set the default time window** (optional — defaults to `1m`):
+
+```properties
+rundeck.gui.activity.defaultTimeFilter=1w
+```
+
+Accepted values:
 
 | Value | Description |
 |-------|-------------|
+| `1h`  | Last 1 hour |
 | `1d`  | Last 1 day  |
-| `1w`  | Last 1 week (default when enabled) |
-| `1m`  | Last 1 month |
+| `1w`  | Last 1 week |
+| `1m`  | Last 1 month (default when not specified) |
 
-When enabled, the **Activity**, **Jobs**, and **Adhoc Commands** pages all apply this filter when they first load. Users can still change or clear the filter manually.
+**Docker / environment variable configuration:**
+
+```bash
+RUNDECK_FEATURE_ACTIVITYDEFAULTTIMEFILTER_NAME=activityDefaultTimeFilter
+RUNDECK_FEATURE_ACTIVITYDEFAULTTIMEFILTER_ENABLED=true
+RUNDECK_GUI_ACTIVITY_DEFAULTTIMEFILTER=1w
+```
+
+When enabled, the **Activity**, **Jobs**, and **Adhoc Commands** pages all apply this filter on first load when no other filters are active. Users can still change or clear the filter manually at any time.
 
 :::tip
 Setting a default time filter is recommended for production instances with months or years of execution history, as it significantly reduces initial page load time.

--- a/docs/manual/jobs/job-options.md
+++ b/docs/manual/jobs/job-options.md
@@ -816,4 +816,4 @@ The result would be:
 
     http://rundeck:4440/project/MyProject/job/show/ab698597-9753-4e98-bdab-90ebf395b0d0?opt.myopt1=some+value&opt.myotheropt=another+value
 
-Note: be sure to properly escape the strings for option values, and if necessary for the option names as well.
+Note: be sure to properly URL-encode all parameter values. This applies to option values, option names, and `nodeFilter` expressions — filter syntax characters such as spaces and `:` must be encoded (e.g., `name: web-01` becomes `name%3A+web-01`).

--- a/docs/manual/jobs/job-options.md
+++ b/docs/manual/jobs/job-options.md
@@ -816,4 +816,4 @@ The result would be:
 
     http://rundeck:4440/project/MyProject/job/show/ab698597-9753-4e98-bdab-90ebf395b0d0?opt.myopt1=some+value&opt.myotheropt=another+value
 
-Note: be sure to properly URL-encode all parameter values. This applies to option values, option names, and `nodeFilter` expressions — filter syntax characters such as spaces and `:` must be encoded (e.g., `name: web-01` becomes `name%3A+web-01`).
+Note: be sure to properly escape the strings for option values, and if necessary for the option names as well.


### PR DESCRIPTION
## Summary

- Adds a new **Default Time Filter** section to the Activity page docs (`docs/manual/08-activity.md`)
- Documents both `rundeck-config.properties` and Docker environment variable configuration
- Covers the feature flag (`rundeck.feature.activityDefaultTimeFilter.enabled`) and the value setting (`rundeck.gui.activity.defaultTimeFilter`)
- Includes the required `RUNDECK_FEATURE_ACTIVITYDEFAULTTIMEFILTER_NAME` env var for Docker deployments

## Test plan

- [ ] Verify rendered page looks correct locally (`npm run dev`)
- [ ] Confirm property names match the implementation in RUN-4513

🤖 Generated with [Claude Code](https://claude.com/claude-code)