### PR TITLE
[RUN-4429] Document child process kill limitation

### DIFF
--- a/docs/manual/jobs/index.md
+++ b/docs/manual/jobs/index.md
@@ -210,4 +210,6 @@ When prompted "Really kill this job?" Click the "Yes" button.
 
 The Job will terminate with a "Killed" completion status.
 
+> **Note:** Killing a job does not guarantee that child processes on the node will also be terminated. This is an architectural limitation of how Rundeck interacts with the underlying OS and remote executors.
+
 ![Job definition](/assets/img/fig0319-d.png)


### PR DESCRIPTION
Killing a job does not guarantee that child processes on the node will also be terminated. This is an architectural limitation of how Rundeck interacts with the underlying OS and remote executors. 