### PR TITLE
[RUN-4336] Add encryption downgrade notes to 6.0 docs

### DIFF
--- a/docs/history/6_x/version-6.0.0.md
+++ b/docs/history/6_x/version-6.0.0.md
@@ -77,7 +77,7 @@ Initial Grails 7 Upgrade for Rundeck Core.  Versions and code from this pull req
 
 #####  ::circle-dot:: [Eliminate Jasypt dependency and upgrade BouncyCastle to 1.84](https://github.com/rundeck/rundeck/pull/10094)
   
-Rundeck&#39;s storage encryption has been upgraded to use modern AES-256-GCM authenticated encryption, replacing the legacy Jasypt library and resolving security vulnerability CVE-2026-5588 by upgrading BouncyCastle to version 1.84. This enhancement provides stronger encryption for stored credentials and keys while maintaining full backward compatibility—existing encrypted data continues to work and is automatically migrated to the new encryption format when next updated, requiring no manual intervention or downtime.
+Rundeck&#39;s storage encryption has been upgraded to use modern AES-256-GCM authenticated encryption, replacing the legacy Jasypt library and resolving security vulnerability CVE-2026-5588 by upgrading BouncyCastle to version 1.84. This enhancement provides stronger encryption for stored credentials and keys while maintaining full backward compatibility—existing encrypted data continues to work and is automatically migrated to the new encryption format when next updated, requiring no manual intervention or downtime. See the [upgrade notes](/upgrading/upgrading-to-6.0.md#storage-encryption-aes-256-gcm) for details and [downgrade considerations](/upgrading/upgrading-to-6.0.md#encryption-downgrade).
 
 #####  ::circle-dot:: [Make script editor min/max lines configurable via System Configuration](https://github.com/rundeck/rundeck/pull/10137)
 

--- a/docs/upgrading/upgrading-to-6.0.md
+++ b/docs/upgrading/upgrading-to-6.0.md
@@ -149,18 +149,20 @@ Because re-encryption is lazy (only on modification), the risk level depends on 
 
 1. **Restore from the pre-upgrade database backup** — this is the safest path. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
 
-2. **Identify affected records** — the following query identifies records re-encrypted to AES-256-GCM in the `storage` table (which holds both Key Storage and Project Configuration data). Works on **MySQL**:
-
-    ```sql
-    SELECT id, dir, name
-    FROM storage
-    WHERE JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."aes-gcm-encryption:encrypted"')) = 'true'
-      AND (JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) IS NULL
-           OR JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) = 'false');
-    ```
-
-    Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries.
-
-3. **Re-create affected data** — after downgrading, re-upload affected keys and passwords through the Rundeck 5.x Key Storage UI or API, and re-save affected project settings, so they are re-encrypted with the Jasypt plugin.
+2. **Re-create affected data** — if restoring from backup is not an option, re-upload affected keys and passwords through the Rundeck 5.x Key Storage UI or API, and re-save affected project settings, so they are re-encrypted with the Jasypt plugin.
 
 **Recommendation:** Before upgrading to 6.0 in production, test the upgrade in a staging environment and confirm that a rollback to the database backup works correctly.
+
+:::tip Diagnostic query
+To assess the scope of affected records, the following query identifies storage entries that were re-encrypted to AES-256-GCM. The `storage` table holds both Key Storage and Project Configuration data. Works on **MySQL**:
+
+```sql
+SELECT id, dir, name
+FROM storage
+WHERE JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."aes-gcm-encryption:encrypted"')) = 'true'
+  AND (JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) IS NULL
+       OR JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) = 'false');
+```
+
+Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries.
+:::

--- a/docs/upgrading/upgrading-to-6.0.md
+++ b/docs/upgrading/upgrading-to-6.0.md
@@ -115,4 +115,44 @@ Rundeck 6.0 upgrades to **Jetty 12**, which removes the legacy Jetty JAAS packag
 
 See the [Authentication documentation](/administration/security/authentication.md) for current JAAS configuration examples and supported password formats.
 
+## Storage encryption: AES-256-GCM replaces Jasypt {#storage-encryption-aes-256-gcm}
 
+Rundeck **6.0** replaces the legacy **Jasypt**-based storage encryption plugin with a new **AES-256-GCM** authenticated encryption plugin (`aes-gcm-encryption`), resolving the BouncyCastle CVE-2026-5588 dependency issue and providing stronger encryption for Key Storage and Project Configuration data.
+
+### What happens on upgrade
+
+- The default converter type in `rundeck-config.properties` changes from `jasypt-encryption` to `aes-gcm-encryption`.
+- **Existing Jasypt-encrypted data continues to work** — the new plugin can read and decrypt legacy Jasypt payloads with no manual intervention.
+- **Lazy migration**: when a Jasypt-encrypted item is next updated (edited, re-saved, or rotated), it is automatically re-encrypted using AES-256-GCM. Items that are never updated remain Jasypt-encrypted and readable indefinitely.
+- The legacy provider name `jasypt-encryption` is supported as an alias, so existing `rundeck-config.properties` entries that reference `type=jasypt-encryption` continue to work without changes.
+- The legacy `encryptorType`, `algorithm`, `provider`, and `keyObtentionIterations` configuration properties are supported by the new plugin to ensure it can correctly decrypt data encrypted with custom Jasypt settings.
+
+No configuration changes are **required** for a standard upgrade. The same encryption password is used for both legacy decryption and new AES-GCM encryption.
+
+For full plugin configuration details, see the [AES-GCM Encryption Plugin](/administration/configuration/plugins/bundled-plugins.md#aes-gcm-encryption-plugin) reference.
+
+### Downgrading from 6.0 to 5.x {#encryption-downgrade}
+
+:::warning
+If you need to downgrade from Rundeck 6.0 back to 5.x, any storage items that were **re-encrypted as AES-256-GCM** during the 6.0 run will **not** be readable by the 5.x Jasypt plugin. Plan accordingly before upgrading.
+:::
+
+**Before upgrading**, take a **full database backup** so you can restore to the pre-upgrade state if a downgrade is needed.
+
+**If a downgrade becomes necessary** after running on 6.0:
+
+1. **Restore from the pre-upgrade database backup** — this is the safest path. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
+
+2. **Identify affected records** — if restoring from backup is not an option, records that were re-encrypted to AES-256-GCM during the 6.0 run can be identified in the database. AES-GCM encrypted content starts with a `0x01` version byte, and these records will have `aes-gcm-encryption:encrypted = "true"` in their JSON metadata. The following query works on **MySQL**:
+
+    ```sql
+    SELECT id, name
+    FROM storage
+    WHERE JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."aes-gcm-encryption:encrypted"')) = 'true'
+      AND (JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) IS NULL
+           OR JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) = 'false');
+    ```
+
+3. **Re-create affected secrets** — for any records identified above, re-upload the keys or passwords through the Rundeck 5.x Key Storage UI or API after the downgrade, so they are re-encrypted with the Jasypt plugin.
+
+**Recommendation:** Before upgrading to 6.0 in production, test the upgrade in a staging environment and confirm that a rollback to the database backup works correctly.

--- a/docs/upgrading/upgrading-to-6.0.md
+++ b/docs/upgrading/upgrading-to-6.0.md
@@ -123,7 +123,7 @@ Rundeck **6.0** replaces the legacy **Jasypt**-based storage encryption plugin w
 
 - The default converter type in `rundeck-config.properties` changes from `jasypt-encryption` to `aes-gcm-encryption`.
 - **Existing Jasypt-encrypted data continues to work** — the new plugin can read and decrypt legacy Jasypt payloads with no manual intervention.
-- **Lazy migration**: when a Jasypt-encrypted item is next updated (edited, re-saved, or rotated), it is automatically re-encrypted using AES-256-GCM. Items that are never updated remain Jasypt-encrypted and readable indefinitely.
+- **Lazy migration**: re-encryption to AES-256-GCM only happens when a storage item is **actively modified** — for example, editing a project's settings, updating a key or password in Key Storage, or rotating a credential. Simply reading or using existing data does **not** trigger re-encryption. Items that are never modified remain Jasypt-encrypted and readable indefinitely.
 - The legacy provider name `jasypt-encryption` is supported as an alias, so existing `rundeck-config.properties` entries that reference `type=jasypt-encryption` continue to work without changes.
 - The legacy `encryptorType`, `algorithm`, `provider`, and `keyObtentionIterations` configuration properties are supported by the new plugin to ensure it can correctly decrypt data encrypted with custom Jasypt settings.
 
@@ -133,17 +133,23 @@ For full plugin configuration details, see the [AES-GCM Encryption Plugin](/admi
 
 ### Downgrading from 6.0 to 5.x {#encryption-downgrade}
 
-:::warning
-If you need to downgrade from Rundeck 6.0 back to 5.x, any storage items that were **re-encrypted as AES-256-GCM** during the 6.0 run will **not** be readable by the 5.x Jasypt plugin. Plan accordingly before upgrading.
+:::danger
+Downgrading from Rundeck 6.0 to 5.x is **not recommended**. Any storage items that were **re-encrypted as AES-256-GCM** during the 6.0 run — including Project Configuration — will **not** be readable by the 5.x Jasypt plugin. If project settings were modified on 6.0, Rundeck 5.x will **fail to load those projects on startup**.
 :::
+
+Because re-encryption is lazy (only on modification), the risk level depends on how much activity occurred on 6.0:
+
+- **No projects or keys were modified** → downgrade is safe; all data remains Jasypt-encrypted.
+- **Keys/passwords were modified but no project settings** → Rundeck 5.x starts normally but affected keys must be re-uploaded.
+- **Project settings were modified** → Rundeck 5.x **cannot decrypt the project configuration** and affected projects will fail to load. A database restore is required.
 
 **Before upgrading**, take a **full database backup** so you can restore to the pre-upgrade state if a downgrade is needed.
 
 **If a downgrade becomes necessary** after running on 6.0:
 
-1. **Restore from the pre-upgrade database backup** — this is the safest path. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
+1. **Restore from the pre-upgrade database backup** — this is the **only safe path** when project settings were modified on 6.0. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
 
-2. **Identify affected records** — if restoring from backup is not an option, records that were re-encrypted to AES-256-GCM during the 6.0 run can be identified by their metadata flags in the `storage` table (which holds both Key Storage and Project Configuration data). The following query works on **MySQL**:
+2. **Identify affected records** — the following query identifies records re-encrypted to AES-256-GCM in the `storage` table (which holds both Key Storage and Project Configuration data). Works on **MySQL**:
 
     ```sql
     SELECT id, dir, name
@@ -153,8 +159,8 @@ If you need to downgrade from Rundeck 6.0 back to 5.x, any storage items that we
            OR JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) = 'false');
     ```
 
-    Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries.
+    Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries. **If any `projects/` records appear, a database restore is required** — Rundeck 5.x cannot start with AES-GCM-encrypted project configuration.
 
-3. **Re-create affected secrets** — for any Key Storage records identified above, re-upload the keys or passwords through the Rundeck 5.x Key Storage UI or API after the downgrade so they are re-encrypted with the Jasypt plugin. For Project Configuration records, re-save the project settings through the UI or API.
+3. **Re-upload affected keys** — if **only** Key Storage records were re-encrypted (no `projects/` records in the query above), you can downgrade and then re-upload the affected keys or passwords through the Rundeck 5.x Key Storage UI or API so they are re-encrypted with the Jasypt plugin.
 
 **Recommendation:** Before upgrading to 6.0 in production, test the upgrade in a staging environment and confirm that a rollback to the database backup works correctly.

--- a/docs/upgrading/upgrading-to-6.0.md
+++ b/docs/upgrading/upgrading-to-6.0.md
@@ -143,16 +143,18 @@ If you need to downgrade from Rundeck 6.0 back to 5.x, any storage items that we
 
 1. **Restore from the pre-upgrade database backup** — this is the safest path. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
 
-2. **Identify affected records** — if restoring from backup is not an option, records that were re-encrypted to AES-256-GCM during the 6.0 run can be identified in the database. AES-GCM encrypted content starts with a `0x01` version byte, and these records will have `aes-gcm-encryption:encrypted = "true"` in their JSON metadata. The following query works on **MySQL**:
+2. **Identify affected records** — if restoring from backup is not an option, records that were re-encrypted to AES-256-GCM during the 6.0 run can be identified by their metadata flags in the `storage` table (which holds both Key Storage and Project Configuration data). The following query works on **MySQL**:
 
     ```sql
-    SELECT id, name
+    SELECT id, dir, name
     FROM storage
     WHERE JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."aes-gcm-encryption:encrypted"')) = 'true'
       AND (JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) IS NULL
            OR JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) = 'false');
     ```
 
-3. **Re-create affected secrets** — for any records identified above, re-upload the keys or passwords through the Rundeck 5.x Key Storage UI or API after the downgrade, so they are re-encrypted with the Jasypt plugin.
+    Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries.
+
+3. **Re-create affected secrets** — for any Key Storage records identified above, re-upload the keys or passwords through the Rundeck 5.x Key Storage UI or API after the downgrade so they are re-encrypted with the Jasypt plugin. For Project Configuration records, re-save the project settings through the UI or API.
 
 **Recommendation:** Before upgrading to 6.0 in production, test the upgrade in a staging environment and confirm that a rollback to the database backup works correctly.

--- a/docs/upgrading/upgrading-to-6.0.md
+++ b/docs/upgrading/upgrading-to-6.0.md
@@ -134,20 +134,20 @@ For full plugin configuration details, see the [AES-GCM Encryption Plugin](/admi
 ### Downgrading from 6.0 to 5.x {#encryption-downgrade}
 
 :::danger
-Downgrading from Rundeck 6.0 to 5.x is **not recommended**. Any storage items that were **re-encrypted as AES-256-GCM** during the 6.0 run — including Project Configuration — will **not** be readable by the 5.x Jasypt plugin. If project settings were modified on 6.0, Rundeck 5.x will **fail to load those projects on startup**.
+Downgrading from Rundeck 6.0 to 5.x is **not recommended**. Any storage items that were **re-encrypted as AES-256-GCM** during the 6.0 run will **not** be readable by the 5.x Jasypt plugin. Rundeck 5.x will start and projects will appear, but encrypted data that was re-encrypted on 6.0 — such as project configuration properties, keys, and passwords — will fail to decrypt and will not be available.
 :::
 
 Because re-encryption is lazy (only on modification), the risk level depends on how much activity occurred on 6.0:
 
 - **No projects or keys were modified** → downgrade is safe; all data remains Jasypt-encrypted.
-- **Keys/passwords were modified but no project settings** → Rundeck 5.x starts normally but affected keys must be re-uploaded.
-- **Project settings were modified** → Rundeck 5.x **cannot decrypt the project configuration** and affected projects will fail to load. A database restore is required.
+- **Keys/passwords were modified but no project settings** → Rundeck 5.x starts normally and projects load, but affected keys and passwords are not usable until re-uploaded.
+- **Project settings were modified** → Rundeck 5.x starts and the project is visible, but the encrypted project configuration properties cannot be decrypted. The project will not function correctly until the data is restored or re-created.
 
 **Before upgrading**, take a **full database backup** so you can restore to the pre-upgrade state if a downgrade is needed.
 
 **If a downgrade becomes necessary** after running on 6.0:
 
-1. **Restore from the pre-upgrade database backup** — this is the **only safe path** when project settings were modified on 6.0. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
+1. **Restore from the pre-upgrade database backup** — this is the safest path. All storage items return to their Jasypt-encrypted state and 5.x can read them without issues.
 
 2. **Identify affected records** — the following query identifies records re-encrypted to AES-256-GCM in the `storage` table (which holds both Key Storage and Project Configuration data). Works on **MySQL**:
 
@@ -159,8 +159,8 @@ Because re-encryption is lazy (only on modification), the risk level depends on 
            OR JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."jasypt-encryption:encrypted"')) = 'false');
     ```
 
-    Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries. **If any `projects/` records appear, a database restore is required** — Rundeck 5.x cannot start with AES-GCM-encrypted project configuration.
+    Records under `keys/` are Key Storage entries; records under `projects/` are Project Configuration entries.
 
-3. **Re-upload affected keys** — if **only** Key Storage records were re-encrypted (no `projects/` records in the query above), you can downgrade and then re-upload the affected keys or passwords through the Rundeck 5.x Key Storage UI or API so they are re-encrypted with the Jasypt plugin.
+3. **Re-create affected data** — after downgrading, re-upload affected keys and passwords through the Rundeck 5.x Key Storage UI or API, and re-save affected project settings, so they are re-encrypted with the Jasypt plugin.
 
 **Recommendation:** Before upgrading to 6.0 in production, test the upgrade in a staging environment and confirm that a rollback to the database backup works correctly.


### PR DESCRIPTION
## Summary

- Adds AES-256-GCM encryption upgrade/downgrade section to the **6.0 upgrade guide** (`upgrading-to-6.0.md`), including what happens on upgrade, lazy migration behavior, and a detailed downgrade procedure with a diagnostic SQL query.
- Adds downgrade cross-reference links to the existing encryption entry ([PR #10094](https://github.com/rundeck/rundeck/pull/10094)) in the **6.0.0 release notes**.

## Context

Related PRs:
- https://github.com/rundeck/rundeck/pull/10094
- https://github.com/rundeck/docs/pull/1802
- https://pagerduty.atlassian.net/browse/RUN-4336

The docs PR #1802 updated the encryption reference pages but did not add downgrade documentation.

## Test plan

- [x] Verify docs build locally (`npm run docs:dev`)
- [ ] Verify links to anchors resolve correctly in the built docs
- [ ] Confirm release note entry cross-links work