### PR TITLE
[RUN-4501] add option file restriction for runners

### DIFF
--- a/docs/administration/runner/runner-faq.md
+++ b/docs/administration/runner/runner-faq.md
@@ -26,4 +26,4 @@ Yes, Health Checks are fully compatible with Enterprise Runners as of version 5.
 
 ## Can I use the "File" Job Option (file upload) with Enterprise Runners?
 
-No. The File option type (file upload via UI or API) is not supported when the Job runs through an Enterprise Runner. The uploaded file is not made available on the Runner, so steps that reference `file.NAME` will fail or behave inconsistently. Note that there is currently no pre-execution warning when a Job that uses a File option is dispatched to a Runner. Use the Local Runner / Automation Server for Jobs that depend on file uploads.
+No. The **File** option type (file upload via UI or API) is not supported when the Job runs through an Enterprise Runner. The uploaded file is not made available on the Runner host, so steps that reference `file.NAME` will fail or behave inconsistently. Note that there is currently no pre-execution warning when a Job that uses a File option is dispatched to an Enterprise Runner. Use the **Local Runner** (Automation Server) for Jobs that depend on file uploads.

--- a/docs/administration/runner/runner-faq.md
+++ b/docs/administration/runner/runner-faq.md
@@ -23,3 +23,7 @@ Yes, multiple runners can be configured with the same tags. At this time only on
 ## Does this work with Health Checks?
 
 Yes, Health Checks are fully compatible with Enterprise Runners as of version 5.18.0. Health Checks will continue to work correctly when Runners are enabled and assigned to projects.
+
+## Can I use the "File" Job Option (file upload) with Enterprise Runners?
+
+No. The File option type (file upload via UI or API) is not supported when the Job runs through an Enterprise Runner. The uploaded file is not made available on the Runner, so steps that reference `file.NAME` will fail or behave inconsistently. Note that there is currently no pre-execution warning when a Job that uses a File option is dispatched to a Runner. Use the Local Runner / Automation Server for Jobs that depend on file uploads.

--- a/docs/learning/getting-started/jobs/job-options.md
+++ b/docs/learning/getting-started/jobs/job-options.md
@@ -44,6 +44,10 @@ If checked, and no default value(s) are specified, all of the remote or local va
 ## Option Type: File
 ![](/assets/img/joboptions2.png)<br>
 The option type file permits uploading a file that can be utilized as part of the Job. Areas displayed when setting up a File Option Type are a subset of those available in the Text Option Type.<br>
+
+::: warning Not supported with Enterprise Runners
+The **File** option type is **not supported** when a Job executes through an Enterprise Runner (distributed automation). Uploaded files are not transferred to the Runner, so `file.NAME` will not resolve on the remote side, and there is no pre-execution warning when this happens. For Jobs that depend on file uploads, run them on the Local Runner / Automation Server.
+:::
 ## How to reference options on command steps and script steps
 ### Command Step
 To reference a Job Option from a Command Step use the following notation:<br>

--- a/docs/learning/getting-started/jobs/job-options.md
+++ b/docs/learning/getting-started/jobs/job-options.md
@@ -46,7 +46,7 @@ If checked, and no default value(s) are specified, all of the remote or local va
 The option type file permits uploading a file that can be utilized as part of the Job. Areas displayed when setting up a File Option Type are a subset of those available in the Text Option Type.<br>
 
 ::: warning Not supported with Enterprise Runners
-The **File** option type is **not supported** when a Job executes through an Enterprise Runner (distributed automation). Uploaded files are not transferred to the Runner, so `file.NAME` will not resolve on the remote side, and there is no pre-execution warning when this happens. For Jobs that depend on file uploads, run them on the Local Runner / Automation Server.
+The **File** option type is **not supported** when a Job executes through an Enterprise Runner (distributed automation). Uploaded files are not transferred to the Runner host, so `file.NAME` will not resolve there. There is currently **no pre-execution warning** in the UI or API when a Job with a File option is dispatched to an Enterprise Runner. For Jobs that depend on file uploads, run them on the **Local Runner** (Automation Server).
 :::
 ## How to reference options on command steps and script steps
 ### Command Step

--- a/docs/manual/jobs/job-options.md
+++ b/docs/manual/jobs/job-options.md
@@ -204,6 +204,12 @@ Choose "File" from the Option Type:
 
 ![File Option Edit Form](/assets/img/fig-newoption-file.png)
 
+::: warning Not supported with Enterprise Runners
+The **File** option type is **not supported** when a Job executes through an Enterprise Runner (distributed automation), whether the Runner runs the step locally or dispatches it to nodes. Uploaded files are not transferred to the Runner, so `file.NAME` will not resolve on the remote side.
+
+There is currently **no pre-execution warning** in the UI or API when a Job that uses a File option is dispatched to a Runner. If your Job relies on file uploads, run it on the Local Runner / Automation Server.
+:::
+
 The Option Name and Description can be entered.
 
 Required


### PR DESCRIPTION
Jira ticket: [https://pagerduty.atlassian.net/browse/RUN-4501](url)

This pull request updates the documentation to clarify that the **File** job option (file upload) is not supported when running jobs on Enterprise Runners. The changes provide clear warnings in multiple documentation sections to help users avoid confusion and failed jobs when using file uploads with Enterprise Runners.

Documentation updates about File option limitations with Enterprise Runners:

* Added a warning to `docs/learning/getting-started/jobs/job-options.md` stating that the **File** option type is not supported with Enterprise Runners, and that uploaded files are not transferred to the Runner. The warning also notes the lack of a pre-execution warning and advises using the Local Runner or Automation Server for such jobs.
* Updated `docs/manual/jobs/job-options.md` with a similar warning, emphasizing that the File option does not work with Enterprise Runners, regardless of whether the Runner executes locally or dispatches to nodes, and reiterating that there is no pre-execution warning.
* Added a new FAQ entry in `docs/administration/runner/runner-faq.md` explaining that the File job option is not supported with Enterprise Runners, and that jobs referencing `file.NAME` will fail or behave inconsistently. The FAQ also points out the absence of a pre-execution warning.