### PR TITLE
[RUN-4642] Update rd-cli docs to point to PackageCloud

### DIFF
--- a/docs/rd-cli/extensions.md
+++ b/docs/rd-cli/extensions.md
@@ -25,7 +25,7 @@ Extensions can be developed as Java libraries.
 
 Add the `rd-cli-lib` dependency to your project.
 
-Available via PagerDuty's PackageCloud Maven repository (no credentials required to read).
+Starting with version `2.1.4`, `rd-cli-lib` (and `rd-api-client`) are published to PagerDuty's PackageCloud Maven repository (no credentials required to read) instead of Maven Central. Versions `2.1.3` and earlier remain permanently available on Maven Central.
 
 Javadoc:
 
@@ -38,9 +38,9 @@ Javadoc:
 A demo project can be seen here: <https://github.com/gschueler/rd-extension-demo>
 
 ~~~{groovy}
-//rd-cli-lib and rd-api-client are published to PagerDuty's PackageCloud repository (no credentials required to read)
+//rd-cli-lib and rd-api-client 2.1.4+ are published to PagerDuty's PackageCloud repository (no credentials required to read)
 repositories {
-    mavenCentral()
+    mavenCentral() //still needed for cli-toolbelt, and for rd-cli-lib/rd-api-client versions 2.1.3 and earlier
     maven {
         url "https://packagecloud.io/pagerduty/rundeck/maven2"
     }

--- a/docs/rd-cli/extensions.md
+++ b/docs/rd-cli/extensions.md
@@ -25,7 +25,7 @@ Extensions can be developed as Java libraries.
 
 Add the `rd-cli-lib` dependency to your project.
 
-Available in Maven Central.
+Available via PagerDuty's PackageCloud Maven repository (no credentials required to read).
 
 Javadoc:
 
@@ -38,9 +38,12 @@ Javadoc:
 A demo project can be seen here: <https://github.com/gschueler/rd-extension-demo>
 
 ~~~{groovy}
-//use maven central
+//rd-cli-lib and rd-api-client are published to PagerDuty's PackageCloud repository (no credentials required to read)
 repositories {
     mavenCentral()
+    maven {
+        url "https://packagecloud.io/pagerduty/rundeck/maven2"
+    }
 }
 
 dependencies {

--- a/docs/rd-cli/javalib.md
+++ b/docs/rd-cli/javalib.md
@@ -11,9 +11,11 @@ The Java library used by RD can be used as a dependency in your Java project to 
 A demo project can be seen here: <https://github.com/gschueler/rd-api-demo>
 
 ~~~{groovy}
-//use maven central
+//rd-api-client is published to PagerDuty's PackageCloud repository (no credentials required to read)
 repositories {
-    mavenCentral()
+    maven {
+        url "https://packagecloud.io/pagerduty/rundeck/maven2"
+    }
 }
 
 dependencies {

--- a/docs/rd-cli/javalib.md
+++ b/docs/rd-cli/javalib.md
@@ -13,7 +13,7 @@ A demo project can be seen here: <https://github.com/gschueler/rd-api-demo>
 Starting with `rd-api-client` version `2.1.4`, releases are published to PagerDuty's PackageCloud repository instead of Maven Central. Versions `2.1.3` and earlier remain permanently available on Maven Central.
 
 ~~~{groovy}
-//rd-api-client 2.1.4+ is published to PagerDuty's PackageCloud repository (no credentials required to read)
+// rd-api-client 2.1.4+ is published to PagerDuty's PackageCloud repository (no credentials required to read)
 repositories {
     maven {
         url "https://packagecloud.io/pagerduty/rundeck/maven2"

--- a/docs/rd-cli/javalib.md
+++ b/docs/rd-cli/javalib.md
@@ -10,12 +10,15 @@ The Java library used by RD can be used as a dependency in your Java project to 
 
 A demo project can be seen here: <https://github.com/gschueler/rd-api-demo>
 
+Starting with `rd-api-client` version `2.1.4`, releases are published to PagerDuty's PackageCloud repository instead of Maven Central. Versions `2.1.3` and earlier remain permanently available on Maven Central.
+
 ~~~{groovy}
-//rd-api-client is published to PagerDuty's PackageCloud repository (no credentials required to read)
+//rd-api-client 2.1.4+ is published to PagerDuty's PackageCloud repository (no credentials required to read)
 repositories {
     maven {
         url "https://packagecloud.io/pagerduty/rundeck/maven2"
     }
+    mavenCentral() //for rd-api-client versions 2.1.3 and earlier
 }
 
 dependencies {


### PR DESCRIPTION
## What changed

[RUN-4642](https://pagerduty.atlassian.net/browse/RUN-4642) tracks reviewing docs that reference Maven Central as the publishing target for `org.rundeck*` artifacts, now that some of them moved to PagerDuty's PackageCloud (RUN-4570).

`rundeck-cli` (`rd-api-client`, `rd-cli-lib`, `rd-cli-tool`) migrated off Maven Central to PackageCloud under RUN-4639. This updates the two docs pages that show external consumers how to add these libraries as Gradle dependencies:

- `docs/rd-cli/javalib.md` — `rd-api-client` Gradle usage snippet now points at `https://packagecloud.io/pagerduty/rundeck/maven2` instead of `mavenCentral()`.
- `docs/rd-cli/extensions.md` — `rd-cli-lib` dependency note and Gradle example updated the same way (kept `mavenCentral()` alongside it since `cli-toolbelt` is still published there).

The PackageCloud Maven feed used here is publicly readable, no credentials required.

## Testing

Docs-only change, no build/render testing performed beyond reading the rendered markdown diff.


[RUN-4642]: https://pagerduty.atlassian.net/browse/RUN-4642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ