### PR TITLE
Sync rd-cli docs with current rundeck-cli source

### DIFF
--- a/docs/rd-cli/commands.md
+++ b/docs/rd-cli/commands.md
@@ -4,17 +4,20 @@ The `rd` command provides top level commands:
 
 Available commands:
 
-	   adhoc      - Dispatch adhoc COMMAND to matching nodes
+	   adhoc      - Run adhoc command or script on matching nodes
 	   executions - List running executions, attach and follow their output, or kill them
 	   jobs       - List and manage Jobs
 	   keys       - Manage Keys via the Key Storage Facility.
+	   metrics    - View metrics endpoints information.
 	   nodes      - List and manage node resources
 	   projects   - List and manage projects
+	   retry      - Run a Job based on a specific execution.
 	   run        - Run a Job
 	   scheduler  - View scheduler information
 	   system     - View system information
 	   tokens     - Create, and manage tokens
 	   users      - Manage user information
+	   version    - Print version information
 
 	Use "rd [command] help" to get help on any command.
 
@@ -25,7 +28,7 @@ See [rd acl](./rd-acl.md)
 
 ## adhoc
 
-Dispatch adhoc COMMAND to matching nodes.
+Run adhoc command or script on matching nodes.
 
 	Usage: adhoc options -- COMMAND...
 		[--quoted -Q] : Use quoted args
@@ -33,7 +36,7 @@ Dispatch adhoc COMMAND to matching nodes.
 		[--filter -F value] : A node filter string
 		[--follow -f] : Follow execution output as it runs
 		[--keepgoing -K] : Keep going when an error occurs
-		[--outformat -% value] : Output format specifier for execution logs. You can use "%key" where key is one of:time,level,log,user,command,node. E.g. "%user@%node/%level: %log"
+		[--outformat -% value] : Output format specifier for execution data. You can use "%key" where key is one of:id, project, description, argstring, permalink, href, status, job, job.*, user, serverUUID, dateStarted, dateEnded, successfulNodes, failedNodes, adhoc. E.g. "%id %href"
 		[--progress -r] : Do not echo log text, just an indicator that output is being received.
 		[--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/] : Project name
 		[--quiet -q] : Echo no output. Combine with -f/--follow to wait silently until the execution completes. Useful for non-interactive scripts.
@@ -60,6 +63,7 @@ List running executions, attach and follow their output, or kill them.
 	   kill       - Attempt to kill an execution by ID
 	   list       - List all running executions for a project
 	   query      - Query previous executions for a project
+	   metrics    - Obtain metrics over the result set of an execution query. (API v29 required)
 	   state      - Get detail about the node and step state of an execution by ID  
 	   deleteall  - Delete all executions for a job
 
@@ -69,7 +73,8 @@ Query previous executions for a project.
 
 	Usage: query options
 		[--adhoconly -A] : Adhoc executions only
-		[--confirm -y] : Force confirmation of delete request.
+		[--autopage] : Automatically load more results in non-interactive mode if there are more paged results. (query command only)
+		[--noninteractive] : Don't use interactive prompts to load more pages if there are more paged results (query command only)
 		[--xgroup value] : Group or partial group path to exclude, "-" means top-level jobs only
 		[--xgroupexact value] : Exact group path to exclude, "-" means top-level jobs only
 		[--xnameexact value] : Exclude Exact Job Name Filter, exclude any name that is equal to this value
@@ -87,13 +92,24 @@ Query previous executions for a project.
 		[--offset -o value] : First result offset to receive.
 		[--older -O value] : Get executions older than specified time. e.g. "3m" (3 months).
 	Use: h,n,s,d,w,m,y (hour,minute,second,day,week,month,year)
-		[--outformat -% value] : Output format specifier for execution data. You can use "%key" where key is one of:id, project, description, argstring, permalink, href, status, job, user, serverUUID, dateStarted, dateEnded, successfulNodes, failedNodes. E.g. "%id %href"
-		--project -p value : Project name
+		[--outformat -% value] : Output format specifier for execution data. You can use "%key" where key is one of:id, project, description, argstring, permalink, href, status, job, job.*, user, serverUUID, dateStarted, dateEnded, successfulNodes, failedNodes, adhoc. E.g. "%id %href"
+		[--project -p value] : Project name
 		[--recent -d value] : Get executions newer than specified time. e.g. "3m" (3 months).
 	Use: h,n,s,d,w,m,y (hour,minute,second,day,week,month,year)
 		[--status -s value] : Status filter, one of: running,succeeded,failed,aborted
 		[--user -u value] : User filter
 		[--verbose -v] : Extended verbose output
+
+### execution metrics
+
+Obtain metrics over the result set of an execution query. (API v29 required)
+
+	Usage: metrics options
+		[--jobids -i value...] : Job ID list to include
+		[--outformat -% value] : Output format specifier for execution metrics data. You can use "%key" where key is one of: total,failed-with-retry,failed,succeeded,duration-avg,duration-min,duration-max. E.g. "%total %failed %succeeded"
+		[--verbose -v] : Show verbose output
+
+	Accepts the same project/job filter options as `executions query` (`--project`, `--group`, `--name`, `--status`, `--recent`, `--older`, etc.), applied to the set of executions the metrics are computed over.
 
 ## jobs
 
@@ -104,9 +120,10 @@ List and manage Jobs.
 
        disable        - Disable execution for a job
        enable         - Enable execution for a job
+       files          - List and manage File options for Jobs (API v19)
        info           - Get info about a Job by ID (API v18)
        list           - List jobs found in a project, or download Job definitions (-f)
-       load           - Load Job definitions from a file in JSON, XML or YAML format
+       load           - Load Job definitions from a file in XML, YAML or JSON format
        purge          - Delete jobs matching the query parameters
        reschedule     - Enable schedule for a job
        unschedule     - Disable schedule for a job
@@ -116,10 +133,43 @@ List and manage Jobs.
        unschedulebulk - Disable schedule for a set of jobs
        forecast   - Get Schedule Forecast for a Job by ID (API v31)
 
+### jobs files
+
+List and manage File options for Jobs.
+
+	Available commands:
+
+	   info - Get info about a Job input option file (API v19)
+	   list - List files uploaded for a Job or Execution (API v19). Specify Job ID or Execution ID
+	   load - Upload a file as input for a job option (API v19). Returns a unique key for the uploaded file, which can be used as the option value when running the job.
+
+#### jobs files info
+
+	Usage: info options
+		--id -i value : File ID
+
+#### jobs files list
+
+	Usage: list options
+		[--eid -e value] : Execution ID
+		[--jobid -j value] : Job ID
+		[--max -m value] : Maximum number of results to retrieve at once.
+		[--offset -o value] : First result offset to receive.
+		[--state -s value] : File state filter for listing Files for a Job only. (default:temp), one of: temp,expired,deleted,retained.
+
+	One of `-j/--jobid` or `-e/--eid` is required. `-s/--state` is only valid with `-j/--jobid`.
+
+#### jobs files load
+
+	Usage: load options
+		--file -f value : File path of the file to upload
+		--id -i value : Job ID
+		--option -o value : Option name
+
 ## keys
 
 Manage Keys via the Key Storage Facility.
-Specify the path using -p/--path, or as the last argument to the command.
+Specify the path using -p/--path.
 
 
 	Available commands:
@@ -130,6 +180,45 @@ Specify the path using -p/--path, or as the last argument to the command.
 	   info   - Get metadata about the given path
 	   list   - List the keys and directories at a given path, or at the root by default
 	   update - Update an existing key entry
+
+## metrics
+
+View metrics endpoints information.
+
+	Available commands:
+
+	   data        - Prints the metrics data.
+	   healthcheck - Print health check status information.
+	   list        - Print system information and stats.
+	   ping        - Returns a simple response.
+	   threads     - Print system threads status information.
+
+### metrics list
+
+	Usage: list options
+		[--verbose -v] : Extended verbose output
+
+### metrics healthcheck
+
+	Usage: healthcheck options
+		[--fail -f] : Exit with unsuccessful status if unhealthy checks are found.
+		[--unhealthy -u] : Show only checks with unhealthy status.
+
+### metrics threads
+
+	Usage: threads options
+		[--verbose -v] : Extended verbose output
+
+### metrics data
+
+	Usage: data options
+		[--all -a] : Show all metrics available, which is the default. This option supersedes all other selection options.
+		[--counters -c] : Show all counter metrics available.
+		[--gauges -g] : Show all gauge metrics available.
+		[--histograms -h] : Show all histogram metrics available.
+		[--meters -m] : Show all meter metrics available.
+		[--summary -s] : Show only a summary of metric data selected.
+		[--timers -t] : Show all timer metrics available.
 
 ## nodes
 
@@ -142,6 +231,35 @@ List all nodes for a project.  You can use the -F/--filter to specify a node fil
 		[--outformat -% value] : Output format specifier for Node info. You can use "%key" where key is one of:nodename, hostname, osFamily, osVersion, osArch, description, username, tags, or any attribute. E.g. "%nodename %tags"
 		[--project -p value] : Project name
 		[--verbose -v] : Extended verbose output
+
+## plugins
+
+Manage Rundeck plugins.
+
+	Available commands:
+
+	   install   - Install a plugin from your plugin repository into your Rundeck instance
+	   list      - List plugins
+	   uninstall - Unistall a Rundeck plugin from your Rundeck instance
+	   upload    - Upload a Rundeck plugin to your plugin repository
+
+### plugins upload
+
+	Usage: upload options
+		--file -f value : Path to Rundeck 2.0 plugin to install in your repository
+		--repository -r value : Target name of repository to upload plugin into.
+
+### plugins install
+
+	Usage: install options
+		--id -i value : Id of the plugin you want to install
+		--repository -r value : Repository name that contains the plugin.
+		[--version -v value] : (Optional) Specific version of the plugin you want to install
+
+### plugins uninstall
+
+	Usage: uninstall options
+		--id -i value : Id of the plugin you want to uninstall
 
 ## projects
 
@@ -159,14 +277,62 @@ List and manage projects.
        readme    - Manage Project readme
        scm       - Manage Project SCM
 
+### projects acls
+
+Manage Project ACLs.
+
+	Available commands:
+
+	   create - Create a project ACL definition
+	   delete - Delete a project ACL definition
+	   get    - Get a project ACL definition
+	   list   - List project ACLs
+	   update - Update a project ACL definition
+
+#### projects acls list
+
+	Usage: list options
+		[--outformat -% value] : Output format specifier for ACL info. You can use "%key" where key is one of:name, type, href. E.g. "%name %href"
+		--project -p value : Project name
+		[--verbose -v] : Extended verbose output
+
+#### projects acls get
+
+	Usage: get options
+		--name -n value : name of the aclpolicy file
+		--project -p value : Project name
+
+#### projects acls create
+
+	Usage: create options
+		--file -f value : ACLPolicy file to upload
+		--name -n value : name of the aclpolicy file
+		--project -p value : Project name
+
+#### projects acls update
+
+Update an existing project ACL definition.
+
+	Usage: update options
+		--file -f value : ACLPolicy file to upload
+		--name -n value : name of the aclpolicy file
+		--project -p value : Project name
+
+#### projects acls delete
+
+	Usage: delete options
+		--name -n value : name of the aclpolicy file
+		--project -p value : Project name
+
 ### projects archives
 
 Project Archives import and export
 
     Available commands:
 
-       export - Export a project archive
-       import - Import a project archive
+       export              - Export a project archive
+       import              - Import a project archive
+       async-import-status - Get the status of an ongoing asynchronous import process.
 
 ### projects archives export
 
@@ -176,7 +342,7 @@ Export a project archive.
 		[--execids -e value...] : List of execution IDs. Exports only those ids.
 		--file -f value : Output file path
 		[--include -i value...] : List of archive contents to include. [all,jobs,executions,configs,readmes,acls,scm]. Default: all. (API v19 required for other options).
-		[--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/] : Project name
+		--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/ : Project name
 
 ### projects archives import
 
@@ -194,13 +360,20 @@ Import a project archive.
 		[--include-webhooks -w] : Include Webhooks in import, default: false (api v34 required)
 		[-x] : Do not include executions in import. Default: do include executions in import.
 		[--options -O value...] : Set options for enabled components, in the form name.key=value
-		[--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/] : Project name
+		--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/ : Project name
 		[-r] : Remove Job UUIDs in imported jobs. Default: preserve job UUIDs.
-		[--regenerate-tokens -t] : Regenerate the auth tokens associated with the webhook in import, default: false (api v34 required)
+		[--regenerate-tokens -t] : regenerate the auth tokens associated with the webhook in import, default: false (api v34 required)
 		[--remove-webhooks-uuids -R] : Remove Webhooks UUIDs in import. Default: preserve webhooks UUIDs. (api v47 required)
 		[--strict] : Return non-zero exit status if any imported item had an error. Default: only job import errors are treated as failures.
 
 	`--include` selects the archive contents to import using the same value syntax as `projects archives export`'s `--include` option. When `--include` is not specified, the individual `--include-*`/`-x` flags above are used instead, for backwards compatibility. If both are set, `--include` takes precedence.
+
+### projects archives async-import-status
+
+Get the status of an ongoing asynchronous import process.
+
+	Usage: async-import-status options
+		[--project -p value] : Project name
 
 ### projects scm
 
@@ -229,6 +402,51 @@ Manage Project configuration
        set    - Overwrite all configuration properties for a project
        update - Modify configuration properties for a project
 
+### projects readme
+
+Manage Project readme.md/motd.md.
+
+	Available commands:
+
+	   delete - Delete project readme/motd file
+	   get    - Get project readme/motd file
+	   put    - Set project readme/motd file
+
+#### projects readme get
+
+	Usage: get options
+		[--motd -m] : Choose the 'motd.md' file. If unset, choose 'readme.md'.
+		[--project -p value] : Project name
+
+#### projects readme put
+
+	Usage: put options
+		[--file -f value] : Path to a file to read for readme/motd contents.
+		[--motd -m] : Choose the 'motd.md' file. If unset, choose 'readme.md'.
+		[--project -p value] : Project name
+		[--text -t value] : Text to use for readme/motd contents.
+
+	One of `-f/--file` or `-t/--text` is required.
+
+#### projects readme delete
+
+	Usage: delete options
+		[--motd -m] : Choose the 'motd.md' file. If unset, choose 'readme.md'.
+		[--project -p value] : Project name
+
+## retry
+
+Run a Job based on a specific execution. (API v24 required)
+
+	Usage: retry options -- -OPT "VAL" -OPT2 "VAL"...
+		[--eid -e value] : Execution ID to retry on failed nodes.
+		[--failedNodes -F] : Run only on failed nodes (default=true).
+		[--loglevel -l /(verbose|info|warning|error)/] : Run the command using the specified LEVEL. LEVEL can be verbose, info, warning, error.
+		[--outformat -% value] : Output format specifier for execution logs. You can use "%key" where key is one of:time,level,log,user,command,node. E.g. "%user@%node/%level: %log"
+		[--raw] : Treat option values as raw text, so that '-opt @value' is sent literally
+		[--user -u value] : A username to run the job as, (runAs access required).
+		[--verbose -v] : Extended verbose output
+
 ## run
 
 Run a Job.
@@ -238,12 +456,14 @@ Run a Job.
          [--follow -f] : Follow execution output as it runs
          [--id -i value] : Run the Job with this IDENTIFIER
          [--job -j value] : Job job (group and name). Run a Job specified by Job name and group. eg: 'group/name'.
-         [--loglevel -l /(verbose|info|warning|error)/] : Run the command using the specified LEVEL. LEVEL can be verbose, info, warning, error.
+         [--loglevel -l /(debug|verbose|info|warning|error)/] : Run the command using the specified LEVEL. LEVEL can be debug, verbose, info, warning, error.
+         [--outformat -% value] : Output format specifier for execution data. You can use "%key" where key is one of:id, project, description, argstring, permalink, href, status, job, job.*, user, serverUUID, dateStarted, dateEnded, successfulNodes, failedNodes, adhoc. E.g. "%id %href"
          [--progress -r] : Do not echo log text, just an indicator that output is being received.
          [--project -p value] : Project name
          [--quiet -q] : Echo no output. Combine with -f/--follow to wait silently until the execution completes. Useful for non-interactive scripts.
+         [--raw] : Treat option values as raw text, so that '-opt @value' is sent literally
          [--restart -t] : Restart from the beginning
-         [--at -@ value] : Run the job at the specified date/time. ISO8601 format (yyyy-MM-dd'T'HH:mm:ss'Z')
+         [--at -@ value] : Run the job at the specified date/time. ISO8601 format (yyyy-MM-dd'T'HH:mm:ssXX)
          [--delay -d /(\d+[smhdwMY]\s*)+/] : Run the job at a certain time from now. Format: ##[smhdwMY] where ## is an integer and the units are seconds, minutes, hours, days, weeks, Months, Years. Can combine units, e.g. "2h30m", "20m30s"
          [--tail -T value] : Number of lines to tail from the end, default: 1
          [--user -u value] : A username to run the job as, (runAs access required).
@@ -286,7 +506,7 @@ Manage System ACLs
 	   delete - Delete a system ACL definition
 	   get    - get a system ACL definition
 	   list   - list system acls
-	   upload - Upload a system ACL definition
+	   update - Update an existing system ACL definition
 
 ### system info
 
@@ -312,8 +532,8 @@ Create, and manage tokens
 
        create - Create a token for a user
        delete - Delete a token
+       info   - Get token info for an ID (API v19+)
        list   - List tokens for a user
-       reveal - Reveal token value for an ID (API v19+)
 
 ## users
 
@@ -322,6 +542,16 @@ Manage user information
 
     Available commands:
 
-       edit - Edit information of the same user or another if 'user' is specified
-       info - Get information of the same user or from another if 'user' is specified
-       list - Get the list of users
+       edit  - Edit information of the same user or another if 'user' is specified
+       info  - Get information of the same user or from another if 'user' is specified
+       list  - Get the list of users
+       roles - Get the list of roles for the current user. (API v30 required)
+
+## version
+
+Print version information.
+
+	Usage: version options
+		[--verbose -v] : Extended verbose output
+
+	With `-v/--verbose`, also prints the git commit, branch, build date, minimum supported API version, and user agent string.

--- a/docs/rd-cli/commands.md
+++ b/docs/rd-cli/commands.md
@@ -168,6 +168,40 @@ Project Archives import and export
        export - Export a project archive
        import - Import a project archive
 
+### projects archives export
+
+Export a project archive.
+
+	Usage: export options
+		[--execids -e value...] : List of execution IDs. Exports only those ids.
+		--file -f value : Output file path
+		[--include -i value...] : List of archive contents to include. [all,jobs,executions,configs,readmes,acls,scm]. Default: all. (API v19 required for other options).
+		[--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/] : Project name
+
+### projects archives import
+
+Import a project archive.
+
+	Usage: import options
+		[--async-import-enabled -i] : Enables asynchronous import process for the uploaded project file.
+		[--component -I value...] : Enable named import components, such as tours-manager (enterprise). See <https://docs.rundeck.com/docs/api/rundeck-api.html#project-archive-import>
+		--file -f value : Import file path
+		[--include value...] : List of archive contents to import. [executions,config,acl,scm,webhooks,nodeSources]. Default: executions. (webhooks: requires API v34. nodeSources: requires API v38).
+		[--include-acl -a] : Include ACLs in import, default: false
+		[--include-config -c] : Include project configuration in import, default: false
+		[--include-node-sources -n] : Include node resources in import, default: false (api v38 required)
+		[--include-scm -s] : Include SCM configuration in import, default: false (api v28 required)
+		[--include-webhooks -w] : Include Webhooks in import, default: false (api v34 required)
+		[-x] : Do not include executions in import. Default: do include executions in import.
+		[--options -O value...] : Set options for enabled components, in the form name.key=value
+		[--project -p /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*$/] : Project name
+		[-r] : Remove Job UUIDs in imported jobs. Default: preserve job UUIDs.
+		[--regenerate-tokens -t] : Regenerate the auth tokens associated with the webhook in import, default: false (api v34 required)
+		[--remove-webhooks-uuids -R] : Remove Webhooks UUIDs in import. Default: preserve webhooks UUIDs. (api v47 required)
+		[--strict] : Return non-zero exit status if any imported item had an error. Default: only job import errors are treated as failures.
+
+	`--include` selects the archive contents to import using the same value syntax as `projects archives export`'s `--include` option. When `--include` is not specified, the individual `--include-*`/`-x` flags above are used instead, for backwards compatibility. If both are set, `--include` takes precedence.
+
 ### projects scm
 
 Manage Project SCM

--- a/docs/rd-cli/commands.md
+++ b/docs/rd-cli/commands.md
@@ -240,7 +240,7 @@ Manage Rundeck plugins.
 
 	   install   - Install a plugin from your plugin repository into your Rundeck instance
 	   list      - List plugins
-	   uninstall - Unistall a Rundeck plugin from your Rundeck instance
+	   uninstall - Uninstall a Rundeck plugin from your Rundeck instance
 	   upload    - Upload a Rundeck plugin to your plugin repository
 
 ### plugins upload

--- a/docs/rd-cli/configuration.md
+++ b/docs/rd-cli/configuration.md
@@ -32,6 +32,22 @@ export RD_URL=http://rundeck:4440/api/12
 
 All requests will be made using that API version.
 
+Alternatively, set the API version without modifying `RD_URL`:
+
+```shell
+export RD_API_VERSION=29
+```
+
+If a version is not specified via either method, the CLI uses its default supported API version.
+
+## Project
+
+You can set a default project to use when a command's `-p/--project` option is not specified:
+
+```shell
+export RD_PROJECT=myproject
+```
+
 ## Credentials
 
 Define access credentials as user/password or Token value:
@@ -61,21 +77,23 @@ export RD_AUTH_PROMPT=false
 
 ## ANSI color
 
-By default, `rd` will print some output using ANSI escapes for colorized output.
+`rd` auto-detects whether to print output using ANSI escapes for colorized output: it is enabled automatically
+when your terminal's `TERM` value contains `color`.
 
-You can disable this:
+You can force it on:
+
+```shell
+export RD_COLOR=1
+```
+
+Or force it off:
 
 ```shell
 export RD_COLOR=0
 ```
 
-You can set the default colors used by info/output/error/warning output:
-
-```shell
-export RD_COLOR_INFO=blue
-export RD_COLOR_WARN=orange
-export RD_COLOR_ERROR=cyan
-```
+`rd` also honors the [`NO_COLOR`](https://no-color.org/) convention: setting `NO_COLOR` to any non-empty value
+disables colorized output (unless `RD_COLOR=1` is also set).
 
 ## Date Format
 
@@ -147,6 +165,24 @@ Use `RD_CONNECT_RETRY` (default `true`):
 export RD_CONNECT_RETRY=false
 ```
 
+## API Version Downgrade
+
+If the server does not support the requested API version, `rd` can automatically retry the request using a lower,
+supported API version. This is disabled by default:
+
+```shell
+export RD_API_DOWNGRADE=true
+```
+
+## Cross-Origin Redirects
+
+By default, `rd` will not follow HTTP redirects to a different origin than the configured `RD_URL`, to prevent
+credentials from being sent to an unexpected host. To allow cross-origin redirects to be followed with credentials:
+
+```shell
+export RD_ALLOW_CROSS_ORIGIN_REDIRECT=true
+```
+
 ## Debug HTTP
 
 Use the `RD_DEBUG` env var to turn on HTTP debugging:
@@ -179,6 +215,12 @@ export RD_INSECURE_SSL=true
 When enabled, a value of `RD_DEBUG=2` will also report SSL certificate
 information.
 
+To suppress the warning that is printed when insecure SSL is enabled:
+
+```shell
+export RD_INSECURE_SSL_NO_WARN=true
+```
+
 ## Insecure SSL Hostname Verification
 
 To retain SSL certificate verification, but allow *any* hostname to be
@@ -198,3 +240,24 @@ it does not match the hostname you are using in your request:
 ```shell
 RD_ALT_SSL_HOSTNAME=hostname
 ```
+
+## YAML Output Format
+
+When using `RD_FORMAT=yaml` (see [Scripting](./scripting.md)), you can control the YAML output style:
+
+```shell
+# BLOCK (default) or FLOW
+export RD_YAML_FLOW=BLOCK
+# pretty-print flow style, default: true
+export RD_YAML_PRETTY=true
+```
+
+## Extensions
+
+Loading external [extension jars](./extensions.md) is disabled by default. To enable it:
+
+```shell
+export RD_EXT_DISABLED=false
+```
+
+See [Extensions](./extensions.md) for details.

--- a/docs/rd-cli/extensions.md
+++ b/docs/rd-cli/extensions.md
@@ -4,9 +4,15 @@ Rundeck CLI can use *extension jars* to add additional functionality.
 
 ## Using Extensions
 
+Extension loading is disabled by default. Enable it:
+
+```sh
+export RD_EXT_DISABLED=false
+```
+
 Download an extension jar, and place it in the `RD_EXT_DIR` directory.
 
-By default for UNIX this is located at `~/.rd/ext`, you can override the location in your `~/.rd/rd.conf` file by adding:
+By default for UNIX this is located at `~/.rd/extv2`, you can override the location in your `~/.rd/rd.conf` file by adding:
 
 ``` sh
 export RD_EXT_DIR=/my/ext/dir
@@ -30,12 +36,9 @@ Available in Maven Central.
 Javadoc:
 
 * [rd-cli-lib ![javadoc](https://javadoc.io/badge2/org.rundeck.cli/rd-cli-lib/javadoc.svg)](https://javadoc.io/doc/org.rundeck.cli/rd-cli-lib)
-* [cli-toolbelt ![cli-toolbelt](https://javadoc.io/badge2/org.rundeck.cli-toolbelt/toolbelt/javadoc.svg)](https://javadoc.io/doc/org.rundeck.cli-toolbelt/toolbelt)
 
 
 ### Gradle example
-
-A demo project can be seen here: <https://github.com/gschueler/rd-extension-demo>
 
 ~~~{groovy}
 //use maven central
@@ -45,7 +48,6 @@ repositories {
 
 dependencies {
     api "org.rundeck.cli:rd-cli-lib:{{$cliVersion}}"
-    api "org.rundeck.cli-toolbelt:toolbelt-jewelcli:0.2.28"
     implementation "org.rundeck.api:rd-api-client:{{$cliVersion}}"
 
     implementation 'com.squareup.retrofit2:retrofit:2.7.1'
@@ -57,33 +59,30 @@ dependencies {
 
 ## Implement `RdCommandExtension`
 
-The following example adds the command `rd sub path somecomand`.
+Argument parsing is done with [picocli](https://picocli.info). Extend `BaseCommand` (which implements
+`RdCommandExtension`) and annotate the class with picocli's `@CommandLine.Command`. Methods annotated with
+`@CommandLine.Command` are automatically registered as subcommands.
+
+The following example adds the command `rd somecommand`:
 
 ```java
 package com.mycompany;
-import org.rundeck.client.tool.extension.RdCommandExtension;
-import org.rundeck.client.tool.extension.RdTool;
-import org.rundeck.client.util.Client;
-import org.rundeck.client.util.ServiceClient;
-import org.rundeck.toolbelt.Command;
-import org.rundeck.toolbelt.CommandOutput;
-import org.rundeck.toolbelt.SubCommand;
 
-@SubCommand(path={"sub","path"})
-class MyClass implements RdCommandExtension{
-    RdTool rdTool;
-    public void setRdTool(RdTool rdTool){
-        this.rdTool=rdTool;
-    }   
+import org.rundeck.client.tool.extension.BaseCommand;
+import picocli.CommandLine;
 
-    @Command
-    public boolean someCommand(CommandOutput out){
-        out.output("running someCommand");
+@CommandLine.Command(name = "somecommand", description = "An example extension command")
+public class MyClass extends BaseCommand {
+
+    @CommandLine.Command(description = "Run the example subcommand")
+    public void run(@CommandLine.Option(names = {"-m", "--message"}) String message) {
+        getRdOutput().output("running somecommand: " + message);
     }
 }
 ```
 
-Argument parsing is done with the CLI Toolbelt, and can use the JewelCLI or Picocli libraries.  See the Example code.
+If you need direct access to the `RdTool` and output beyond what `BaseCommand` exposes, implement
+`RdCommandExtension` directly instead of extending `BaseCommand`.
 
 ## Declare the Service
 

--- a/docs/rd-cli/install.md
+++ b/docs/rd-cli/install.md
@@ -1,5 +1,7 @@
 # Rundeck CLI - Install
 
+**Requires Java 17 or later** to run.
+
 All artifacts can be downloaded from: [github releases](https://github.com/rundeck/rundeck-cli/releases/latest)
 
 * [zip install](#zip-install) `rd-{{$cliVersion}}.zip` / `rd-{{$cliVersion}}.tar`

--- a/docs/rd-cli/javalib.md
+++ b/docs/rd-cli/javalib.md
@@ -17,6 +17,6 @@ repositories {
 }
 
 dependencies {
-    compile "org.rundeck.api:rd-api-client:{{$cliVersion}}"
+    implementation "org.rundeck.api:rd-api-client:{{$cliVersion}}"
 }
 ~~~

--- a/docs/rd-cli/rd-acl.md
+++ b/docs/rd-cli/rd-acl.md
@@ -1,6 +1,6 @@
 # rd acl
 
-`rd acl` - Test and generate Rundeck ACL policy files.
+`rd acl` - Generate, test, and validate Rundeck ACL policy files.
 
 ## Synopsis
 
@@ -70,17 +70,23 @@ the Rundeck "etc" dir will be used as for the `--dir` option by default.
 In addition,
 the `test` command also takes the [Common Options](#common-options) and these options:
 
-`-V, --validate`
+`-V`
 : Validate all input files, and exit with non-zero exit code if validation fails. (`test` and `list` actions.)
 
 ### Create Command Options
 
 In addition to the [Common Options](#common-options), the `create` command takes these input options.
 
-`-i, --input <file | ->`
-: Parse the Rundeck AUDIT log input, and for any REJECTED decisions, generate the appropriate aclpolicy
-to allow the action. If the value of the `--input` option is `-` (dash character), then the STDIN is read.
-If `--input` is used, then the Common Options are ignored.
+`-f, --file <file>`
+: Parse the Rundeck AUDIT log input from the specified file, and for any REJECTED decisions, generate the
+appropriate aclpolicy to allow the action. (This reuses the same `-f/--file` option as the Test/Validate commands.)
+
+`--stdin`
+: Read the Rundeck AUDIT log input from STDIN, and for any REJECTED decisions, generate the appropriate
+aclpolicy to allow the action.
+
+If `-f/--file` or `--stdin` is used to supply AUDIT log input, the other [Common Options](#common-options) that
+define an explicit rule (context/subject/action/resource) are ignored.
 
 `-r, --regex`
 : Match the resource using regular expressions. (create command).
@@ -102,9 +108,8 @@ and to define a rule in the ACL Policy (for the `create` command).
 : Subject Groups names. Comma-separated list of user groups to
 validate (test command) or for by: clause (create command).
 
-`-u,--user <user,...>`
-: Subject User name. Comma-separated list of user names to
-validate (test command) or for by: clause (create command).
+`-u,--user <user>`
+: Subject User name to validate (test command) or for by: clause (create command).
 
 **Action options:**
 
@@ -118,7 +123,7 @@ validate (test command) or for by: clause (create command).
 
 Resources are characterized as either "specific resources", or "resource types"
 (see [Specific Resources and Resource Types](/administration/security/authorization.md#specific-resources-and-resource-types)). You can specify "resource types" using the `-G, --generic <kind>` option. All specific resources can
-be specified directly using one of the options, or by type using `-R, --resource <type>` in combination with `-b, --attributes <attr=val ...>`.
+be specified directly using one of the options, or by type using `-R, --resource <type>` in combination with `-b, --attrs <attr=val ...>`.
 
 `-G,--generic <kind>`
 : Generic resource kind.
@@ -126,7 +131,7 @@ be specified directly using one of the options, or by type using `-R, --resource
 `-R,--resource <type>`
 : Resource type name.
 
-`-b,--attributes <key=value ...>`
+`-b,--attrs <key=value ...>`
 : Attributes for the resource. A sequence of key=value pairs, multiple pairs can follow with a space. Use a value of '?' to see suggestions.
 
 The following define [Project scope resources](/administration/security/authorization.md#project-scope-resources-and-actions):
@@ -137,14 +142,14 @@ The following define [Project scope resources](/administration/security/authoriz
 `-j,--job <group/name>`
 : Job group/name. (project context)
 
-`-I,--jobUuid <uuid>`
+`-i,--jobUuid <uuid>`
 : Job uuid. (project context)
 
 `-n,--node <nodename>`
 : Node name. (project context)
 
 `-t,--tags <tag,..>`
-: Node tags. If specified, the resource match will be defined using 'contains'. (project context)
+: Node tags. If specified, the resource match will be defined using 'contains'. (project context). Accepts multiple values.
 
 The following define [Application scope resources](/administration/security/authorization.md#application-scope-resources-and-actions):
 
@@ -153,6 +158,9 @@ The following define [Application scope resources](/administration/security/auth
 
 `-p,--project <project>`
 : Name of project, used in project context or for application resource.
+
+`-P,--projectacl <project>`
+: Project name for ACL policy access, used in application context.
 
 ### List Command Options
 
@@ -165,10 +173,11 @@ The Subject options: `-g,--groups` and `-u,--user`
 These Resource options:
 
 - `-p,--project` name of a project to test
+- `-P,--projectacl` name of a project to test ACL policy access for
 - `-s,--storage` Storage path/name
 - `-n,--node` or `-t,--tags` name or tags of a node to tests
 - `-j,--job` Job group/name.
-- `-I,--jobUuid` Job uuid.
+- `-i,--jobUuid` Job uuid.
 
 ## Test Command
 
@@ -397,7 +406,7 @@ rd acl create
 -c/--context is required.
 Choose one of:
   -c application
-    Access to projects, users, storage, system info.
+    Access to projects, users, storage, system info, execution management.
   -c project
     Access to jobs, nodes, events, within a project.
 ```
@@ -430,7 +439,8 @@ rd acl create -c project -p '.*' -g test
 Project-context resource option is required.
 Possible options:
   Job: -j/--job <group/name>
-    View, modify, create*, delete*, run, and kill specific jobs.
+    View, modify, create*, delete*, run, and kill specific jobs,
+    and toggle whether schedule and/or execution are enabled.
     * Create and delete also require additional -G/--generic <kind> level access.
   Adhoc: -A/--adhoc
     View, run, and kill adhoc commands.
@@ -438,7 +448,7 @@ Possible options:
       : -t/--tags <tag,..>
     View and run on specific nodes by name or tag.
   Resource: -R/--resource <type>
-    Specify the resource type directly. -b/--attributes <key=value ...> should also be used.
+    Specify the resource type directly. -b/--attrs <key=value ...> should also be used.
     resource types in this context:
     node
     job

--- a/docs/rd-cli/scripting.md
+++ b/docs/rd-cli/scripting.md
@@ -10,7 +10,7 @@ Specifying formatted output for Job and Execution lists:
 
 ## Date Format
 
-For `rd executions` you can customize the default date format of `yyyy-MM-ddHH:mm:ssZ`:
+For `rd executions` you can customize the default date format of `yyyy-MM-dd'T'HH:mm:ssXX`:
 
     `RD_DATE_FORMAT="yyyy-MM-dd HH:mm z"`
 

--- a/docs/rd-cli/ssl.md
+++ b/docs/rd-cli/ssl.md
@@ -56,6 +56,6 @@ If you used a different trust store "type" you can also set that with this opt:
 
 Then, [Setup your Rundeck connection info](./configuration.md), and you can use `rd`.
 
-	export RD_URL="https://$HOST:$PORT/api/18"
+	export RD_URL="https://$HOST:$PORT/api/29"
 	export RD_TOKEN="..."
 	rd system


### PR DESCRIPTION
## Summary

Audited `docs/rd-cli/*.md` against the current `rundeck-cli` source
(`rd-cli-tool`, `rd-cli-acl`, `rd-cli-base`, `rd-api-client`) to catch
drift between the documented and actual CLI behavior. Includes:

- Added missing top-level commands (`metrics`, `retry`, `version`,
  `plugins`) and missing subcommand groups (`jobs files`,
  `executions metrics`, `projects acls`, `projects readme`,
  `projects archives async-import-status`, `users roles`).
- Replaced deprecated/hidden commands the docs incorrectly showed
  (`tokens reveal` → `tokens info`, `system acls upload` →
  `system acls update`) and fixed stale/wrong option flags, defaults,
  and descriptions across `commands.md` and `rd-acl.md` (e.g.
  `--attrs` vs `--attributes`, a fabricated `--input` option on
  `rd acl create`, `-i/--jobUuid` casing).
- Documented environment variables that exist in source but were
  missing from `configuration.md` (`RD_API_VERSION`, `RD_PROJECT`,
  `RD_API_DOWNGRADE`, `RD_ALLOW_CROSS_ORIGIN_REDIRECT`,
  `RD_INSECURE_SSL_NO_WARN`, `RD_YAML_FLOW`/`RD_YAML_PRETTY`,
  `RD_EXT_DISABLED`), and removed vars that no longer exist
  (`RD_COLOR_INFO`/`WARN`/`ERROR`).
- Rewrote `extensions.md`'s extension-development example, which
  showed a defunct CLI Toolbelt/JewelCLI annotation style; extensions
  are now built with picocli + `BaseCommand`, and are disabled by
  default (`RD_EXT_DISABLED`).
- Fixed the default date format in `scripting.md`, a deprecated
  Gradle `compile` config in `javalib.md`, and added the Java 17+
  requirement to `install.md`.