### PR TITLE
Monitoring how-tos: container logs with Loki + ready-made dashboards

### DIFF
--- a/docs/learning/howto/monitor-runner-grafana.md
+++ b/docs/learning/howto/monitor-runner-grafana.md
@@ -1,6 +1,6 @@
 # Monitor a Runner with Prometheus and Grafana
 
-Rundeck Runners expose operation-queue, report-delivery, and JVM metrics that are invaluable for diagnosing the `Runner did not deliver reports in the configured timeout period` error and for capacity planning. Unlike the Rundeck server, a Runner does **not** serve an HTTP metrics endpoint — its metrics are published as JMX MBeans. To get them into Prometheus and Grafana, run the [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter) alongside the Runner.
+Rundeck Runners expose operation-queue, report-delivery, and JVM metrics that are useful for monitoring Runner health and capacity planning. Unlike the Rundeck server, a Runner does **not** serve an HTTP metrics endpoint — its metrics are published as JMX MBeans. To get them into Prometheus and Grafana, run the [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter) alongside the Runner.
 
 This guide uses the `jmx_prometheus_javaagent`, which runs in-process and exposes the Runner's metrics on an HTTP port that Prometheus can scrape.
 
@@ -36,7 +36,9 @@ curl -L -o jmx_prometheus_javaagent.jar \
 
 ## Step 2: Create the exporter configuration
 
-Create `jmx-config.yml` next to the Runner JAR. This configuration lowercases names, maps standard JVM MBeans to conventional metric names, exposes the Runner's metrics (published under the `metrics` JMX domain), and includes a catch-all so nothing is silently dropped:
+The Runner publishes its metrics through Micrometer's JMX registry (under the `metrics` domain), so the exporter rules map those MBeans to the exact Prometheus series names the Runner Grafana dashboard expects. The pattern, `first-match-wins`, is: operation gauges and counters to plain names, timers to `SUMMARY` metrics with `{quantile}` labels (milliseconds converted to seconds via `valueFactor`), JVM threads/GC to Micrometer-compatible aliases, noisy duplicate attributes suppressed, and a catch-all so nothing is silently dropped.
+
+A representative excerpt — one gauge, one timer, and the catch-all — looks like this:
 
 ```yaml
 startDelaySeconds: 0
@@ -45,34 +47,28 @@ lowercaseOutputName: true
 lowercaseOutputLabelNames: true
 
 rules:
-  # JVM heap / non-heap memory
-  - pattern: "java.lang<type=Memory><>(HeapMemoryUsage|NonHeapMemoryUsage)"
-    name: jvm_memory_bytes
+  # Runner operation gauge → exact dashboard metric name
+  - pattern: 'metrics<name=runnerOperationsPoolUtilization, type=gauges><>Value'
+    name: runner_operations_pool_utilization
     type: GAUGE
+    help: "Runner operation thread pool utilization ratio (0.0–1.0)"
+
+  # Timer → SUMMARY with {quantile} labels; Micrometer emits ms, valueFactor converts to seconds
+  - pattern: 'metrics<name=runnerOperationsInvocations\.handler\.([^,]+), type=timers><>(\d+)thPercentile'
+    name: runner_operations_invocations_seconds
+    type: SUMMARY
+    valueFactor: 0.001
     labels:
-      area: "$1"
+      handler: "$1"
+      quantile: "0.$2"
 
-  # Garbage collection
-  - pattern: "java.lang<type=GarbageCollector,name=(.+)><>(CollectionTime|CollectionCount)"
-    name: jvm_gc_$2
-    type: COUNTER
-    labels:
-      gc: "$1"
-
-  # Threads
-  - pattern: "java.lang<type=Threading><>(ThreadCount|PeakThreadCount|TotalStartedThreadCount)"
-    name: jvm_threads_$1
-    type: GAUGE
-
-  # Runner application metrics (runner.operations.*, runner.reporter.*) published via Micrometer's JMX registry
-  - pattern: 'metrics<name=(.+)><>([A-Za-z0-9_]+)'
-    name: runner_$1_$2
-    help: "Runner metric $1 $2"
-    type: GAUGE
-
-  # Catch-all: expose anything not matched above with auto-generated names
+  # Catch-all: export every remaining JMX bean unchanged
   - pattern: ".*"
 ```
+
+:::tip Use the complete, tested configuration
+The full `jmx-config.yml` — mapping every Runner operation, reporter, HTTP-client, and JVM metric the dashboard uses, plus the suppression rules that drop noisy duplicate attributes — is published as a runnable example in [docker-zoo](https://github.com/rundeck/docker-zoo/tree/master/monitoring). Copy [`runner-agent/jmx-config.yml`](https://github.com/rundeck/docker-zoo/blob/master/monitoring/runner-agent/jmx-config.yml) from there rather than assembling the rules by hand.
+:::
 
 ## Step 3: Start the Runner with the exporter attached
 
@@ -129,6 +125,10 @@ Replace `runner:9404` with the address Prometheus uses to reach the exporter. Re
 
 ## Step 6: Build dashboard panels
 
+:::tip Start from the ready-made dashboard
+Rather than building every panel by hand, import the pre-built **Runner** dashboard from the [docker-zoo monitoring example](https://github.com/rundeck/docker-zoo/tree/master/monitoring) — [`grafana/dashboards/Runner-Dashboard.json`](https://github.com/rundeck/docker-zoo/blob/master/monitoring/grafana/dashboards/Runner-Dashboard.json). In Grafana use **Dashboards → New → Import**. It binds to a Prometheus data source with uid `prometheus` and expects the metric names produced by the [`runner-agent/jmx-config.yml`](https://github.com/rundeck/docker-zoo/blob/master/monitoring/runner-agent/jmx-config.yml) mapping from [Step 2](#step-2-create-the-exporter-configuration). The panels below explain the individual queries if you prefer to build your own.
+:::
+
 In Grafana, add panels using the Prometheus data source. Use the names you confirmed in Step 4 — the queries below assume the example rules from Step 2.
 
 **Operation pool utilization (0–100%):**
@@ -166,6 +166,56 @@ jvm_memory_bytes{area="HeapMemoryUsage"}
 ## Alternative: scrape JMX remotely
 
 If you prefer not to run an in-process agent, you can instead enable JMX remote access on the Runner (see [Status & Monitoring → Monitoring Replicas](/administration/runner/runner-management/monitoring-runners.md#monitoring-replicas)) and run the standalone `jmx_prometheus_httpserver` as a separate process pointed at the Runner's JMX port. The in-process `javaagent` approach in this guide is simpler because it does not require opening a remote JMX port.
+
+## Ship container logs to Grafana with Loki
+
+The JMX exporter above covers *metrics*. To get the Runner's **logs** into the same Grafana — when the Runner runs in Docker — use the [Loki Docker logging driver](https://grafana.com/docs/loki/latest/send-data/docker-driver/): Docker ships the container's stdout and stderr straight to [Loki](https://grafana.com/oss/loki/), with no extra agent, collector, or Docker-socket access. You reuse the **same Loki** you stood up for the server in [Monitor the Rundeck Server with Prometheus and Grafana](/learning/howto/monitor-server-grafana.md#ship-container-logs-to-grafana-with-loki); only Loki and Grafana are involved.
+
+```text
+  Runner container ─(Docker loki log driver)→ Loki ─→ Grafana (:3000)
+```
+
+### Step 1: Install the Loki Docker driver plugin
+
+If you have not already installed it for the server, install the plugin on the Docker host once:
+
+```bash
+docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+docker plugin ls | grep loki   # ENABLED should be "true"
+```
+
+### Step 2: Route the Runner container's logs to Loki
+
+Add a `logging` block to the Runner service:
+
+```yaml
+  runner:
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://localhost:3100/loki/api/v1/push"
+        loki-retries: "5"
+        loki-batch-size: "400"
+        mode: "non-blocking"
+```
+
+The `loki-url` is resolved by the Docker daemon on the host, so it uses `localhost:3100` (Loki's published port), not the compose service name. `mode: "non-blocking"` keeps the container from stalling if Loki is briefly unavailable.
+
+### Step 3: Explore Runner logs in Grafana
+
+Restart the stack (`docker compose up -d`). In Grafana, open **Explore**, select the **Loki** data source, and query by the labels the driver attaches automatically:
+
+- `{compose_service="runner"}` — logs from the Runner container.
+- `{compose_project="<your-project>"}` — every container in the stack.
+
+:::tip Browse without writing queries: Logs Drilldown
+Grafana's **Logs Drilldown** app (**Drilldown → Logs** in the left menu) lists each service and lets you filter and drill into logs visually, no LogQL required. It relies on Loki's volume endpoint — make sure the server guide's `loki-config.yml` sets `limits_config.volume_enabled: true`. Services appear by their `service_name` label, which with the Docker driver defaults to the container name.
+:::
+
+:::tip Not running in Docker?
+The logging driver only applies to containers. If the Runner runs as a plain process, point a log shipper such as [Grafana Alloy](https://grafana.com/docs/alloy/latest/) or [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/) at its log file instead.
+:::
+
 
 ## Next steps
 

--- a/docs/learning/howto/monitor-runner-grafana.md
+++ b/docs/learning/howto/monitor-runner-grafana.md
@@ -38,7 +38,7 @@ curl -L -o jmx_prometheus_javaagent.jar \
 
 The Runner publishes its metrics through Micrometer's JMX registry (under the `metrics` domain), so the exporter rules map those MBeans to the exact Prometheus series names the Runner Grafana dashboard expects. The pattern, `first-match-wins`, is: operation gauges and counters to plain names, timers to `SUMMARY` metrics with `{quantile}` labels (milliseconds converted to seconds via `valueFactor`), JVM threads/GC to Micrometer-compatible aliases, noisy duplicate attributes suppressed, and a catch-all so nothing is silently dropped.
 
-A representative excerpt — one gauge, one timer, and the catch-all — looks like this:
+A representative excerpt — one gauge, one timer, and the catch-all — is shown below. It is **abbreviated**: the Runner dashboard and the panel queries in [Step 6](#step-6-build-dashboard-panels) rely on the full rule set, so use the complete file from docker-zoo (linked in the tip after the excerpt), not just this snippet.
 
 ```yaml
 startDelaySeconds: 0
@@ -129,7 +129,7 @@ Replace `runner:9404` with the address Prometheus uses to reach the exporter. Re
 Rather than building every panel by hand, import the pre-built **Runner** dashboard from the [docker-zoo monitoring example](https://github.com/rundeck/docker-zoo/tree/master/monitoring) — [`grafana/dashboards/Runner-Dashboard.json`](https://github.com/rundeck/docker-zoo/blob/master/monitoring/grafana/dashboards/Runner-Dashboard.json). In Grafana use **Dashboards → New → Import**. It binds to a Prometheus data source with uid `prometheus` and expects the metric names produced by the [`runner-agent/jmx-config.yml`](https://github.com/rundeck/docker-zoo/blob/master/monitoring/runner-agent/jmx-config.yml) mapping from [Step 2](#step-2-create-the-exporter-configuration). The panels below explain the individual queries if you prefer to build your own.
 :::
 
-In Grafana, add panels using the Prometheus data source. Use the names you confirmed in Step 4 — the queries below assume the example rules from Step 2.
+In Grafana, add panels using the Prometheus data source. Use the names you confirmed in Step 4 — the queries below assume the full rule set from Step 2 (the complete `jmx-config.yml` in docker-zoo), not only the abbreviated excerpt.
 
 **Operation pool utilization (0–100%):**
 
@@ -172,7 +172,7 @@ If you prefer not to run an in-process agent, you can instead enable JMX remote 
 The JMX exporter above covers *metrics*. To get the Runner's **logs** into the same Grafana — when the Runner runs in Docker — use the [Loki Docker logging driver](https://grafana.com/docs/loki/latest/send-data/docker-driver/): Docker ships the container's stdout and stderr straight to [Loki](https://grafana.com/oss/loki/), with no extra agent, collector, or Docker-socket access. You reuse the **same Loki** you stood up for the server in [Monitor the Rundeck Server with Prometheus and Grafana](/learning/howto/monitor-server-grafana.md#ship-container-logs-to-grafana-with-loki); only Loki and Grafana are involved.
 
 ```text
-  Runner container ─(Docker loki log driver)→ Loki ─→ Grafana (:3000)
+  Runner container ─(Docker Loki log driver)→ Loki ─→ Grafana (:3000)
 ```
 
 ### Step 1: Install the Loki Docker driver plugin

--- a/docs/learning/howto/monitor-server-grafana.md
+++ b/docs/learning/howto/monitor-server-grafana.md
@@ -35,6 +35,10 @@ curl http://localhost:4440/monitoring/prometheus
 
 You should see output beginning with metric definitions such as `# HELP jvm_memory_used_bytes ...`. If you get a 404, the endpoints are disabled — see the configuration reference linked above.
 
+:::warning Secure the endpoint
+The `/monitoring/*` endpoints are unauthenticated by default so that scrapers and health checks can reach them. On production deployments, restrict access to these paths (for example at your reverse proxy or network layer) so they are only reachable by your monitoring system. See [Monitoring configuration](/administration/monitoring/configuration.md#security-considerations).
+:::
+
 ## Step 2: Configure the Prometheus scrape target
 
 Create `prometheus/prometheus.yml`:

--- a/docs/learning/howto/monitor-server-grafana.md
+++ b/docs/learning/howto/monitor-server-grafana.md
@@ -2,7 +2,7 @@
 
 Rundeck 6.0 exposes application metrics natively in Prometheus format at the [`/monitoring/prometheus`](/administration/monitoring/index.md) endpoint, which is enabled by default. This means you no longer need a third-party exporter to build a metrics dashboard — Prometheus can scrape Rundeck directly.
 
-This guide walks through a working Prometheus + Grafana stack pointed at a Rundeck server, with example queries for the most useful health and performance metrics.
+This guide walks through a working Prometheus + Grafana stack pointed at a Rundeck server, with example queries for the most useful health and performance metrics. It then shows how to ship the container **logs** into the same Grafana with Loki — see [Ship container logs to Grafana with Loki](#ship-container-logs-to-grafana-with-loki).
 
 :::tip Looking for the older exporter guide?
 The community `rundeck_exporter` approach is now deprecated for Rundeck 6.0+. See [Monitor a Rundeck Instance Using Prometheus and Grafana (legacy exporter)](/learning/howto/rundeck-exporter.md) only if you are running an older version.
@@ -35,10 +35,6 @@ curl http://localhost:4440/monitoring/prometheus
 
 You should see output beginning with metric definitions such as `# HELP jvm_memory_used_bytes ...`. If you get a 404, the endpoints are disabled — see the configuration reference linked above.
 
-:::warning Secure the endpoint
-The `/monitoring/*` endpoints are unauthenticated by default so that scrapers and health checks can reach them. On production deployments, restrict access to these paths (for example at your reverse proxy or network layer) so they are only reachable by your monitoring system. See [Monitoring configuration](/administration/monitoring/configuration.md#security-considerations).
-:::
-
 ## Step 2: Configure the Prometheus scrape target
 
 Create `prometheus/prometheus.yml`:
@@ -48,7 +44,7 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: 'rundeck'
+  - job_name: 'rundeck-server'
     metrics_path: /monitoring/prometheus
     static_configs:
       - targets: ['rundeck:4440']
@@ -149,6 +145,10 @@ If your Rundeck server runs outside this Compose project, make sure the Promethe
 
 ## Step 6: Build dashboard panels
 
+:::tip Start from the ready-made dashboard
+Rather than building every panel by hand, import the pre-built **Rundeck Overview** dashboard from the [docker-zoo monitoring example](https://github.com/rundeck/docker-zoo/tree/master/monitoring) — [`grafana/dashboards/Rundeck-Overview.json`](https://github.com/rundeck/docker-zoo/blob/master/monitoring/grafana/dashboards/Rundeck-Overview.json). In Grafana use **Dashboards → New → Import**, or drop the JSON into `grafana/dashboards/` and let the provider in that example auto-load it. It binds to a Prometheus data source with uid `prometheus`, and its **Instance** filter expects the scrape job to be named `rundeck-server` (as in [Step 2](#step-2-configure-the-prometheus-scrape-target)). The panels below explain the individual queries if you prefer to build your own.
+:::
+
 In Grafana, create a dashboard and add panels using the Prometheus data source. The following queries cover the most useful server health signals. Metric names are the native Micrometer names exposed at `/monitoring/prometheus`; use **Status → Targets** in Prometheus or the [`/monitoring/metrics`](/administration/monitoring/monitoring.md) endpoint to discover the full set.
 
 **JVM heap usage:**
@@ -192,6 +192,125 @@ sum(rate(http_server_requests_seconds_count{status=~"[45].."}[5m]))
 ### Runner report-delivery metrics
 
 If you use [Runners](/administration/runner/index.md), the server also publishes report-delivery pipeline metrics (for example `runner_server_report_end_to_end_latency_max_seconds` and `runner_server_report_timeout_count`) on the same `/monitoring/prometheus` endpoint. These are bridged from Rundeck's internal metric registry, so their series names follow a specific naming pattern. See the [Runner Metrics Reference](/administration/runner/runner-management/runner-metrics.md#server-side-metric-names-in-prometheus) for the exact names, units, and suggested alerts.
+
+## Ship container logs to Grafana with Loki
+
+Metrics tell you *what* is happening; logs tell you *why*. When Rundeck runs in Docker, the simplest way to get its logs into the same Grafana is the [Loki Docker logging driver](https://grafana.com/docs/loki/latest/send-data/docker-driver/): Docker itself ships each container's stdout and stderr straight to [Loki](https://grafana.com/oss/loki/), with no extra agent, collector, or access to the Docker socket. Only Loki and Grafana are added to the stack.
+
+```text
+  Rundeck container ─(Docker loki log driver)→ Loki ─→ Grafana (:3000)
+```
+
+### Step 1: Install the Loki Docker driver plugin
+
+Install the plugin on the Docker host once, then confirm it is enabled:
+
+```bash
+docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+docker plugin ls | grep loki   # ENABLED should be "true"
+```
+
+### Step 2: Add Loki and its Grafana data source
+
+Add a Loki service to the `docker-compose.yml` from [Step 5](#step-5-run-the-stack):
+
+```yaml
+  loki:
+    image: grafana/loki:3.0.0
+    command: -config.file=/etc/loki/loki-config.yml
+    ports: ["3100:3100"]
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:3100/ready | grep -q ready || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+```
+
+Create `loki/loki-config.yml` (single-binary, filesystem storage):
+
+```yaml
+auth_enabled: false
+server:
+  http_listen_port: 3100
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore: { store: inmemory }
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index: { prefix: index_, period: 24h }
+limits_config:
+  volume_enabled: true   # lets Grafana's "Logs Drilldown" app list services
+```
+
+Alongside the Prometheus data source from [Step 3](#step-3-provision-the-grafana-data-source), add a Loki data source (`grafana/provisioning/datasources/loki.yaml`):
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+```
+
+### Step 3: Route the Rundeck container's logs to Loki
+
+Add a `logging` block to the Rundeck service — and to any other service whose logs you want in Grafana. Because the driver needs Loki reachable before other containers start, gate them on Loki's health:
+
+```yaml
+  rundeck:
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://localhost:3100/loki/api/v1/push"
+        loki-retries: "5"
+        loki-batch-size: "400"
+        mode: "non-blocking"
+    depends_on:
+      loki:
+        condition: service_healthy
+```
+
+The `loki-url` is resolved by the Docker daemon on the host, so it uses `localhost:3100` (Loki's published port) — not the compose service name. `mode: "non-blocking"` keeps the container from stalling if Loki is briefly unavailable.
+
+### Step 4: Explore logs in Grafana
+
+Restart the stack (`docker compose up -d`). In Grafana, open **Explore**, select the **Loki** data source, and query by the labels the driver attaches automatically:
+
+- `{compose_service="rundeck"}` — logs from the Rundeck container.
+- `{compose_project="<your-project>"}` — every container in the stack.
+
+:::tip Browse without writing queries: Logs Drilldown
+Grafana's **Logs Drilldown** app (**Drilldown → Logs** in the left menu) lists each service and lets you filter and drill into logs visually, no LogQL required. It relies on Loki's volume endpoint, which is why the `loki-config.yml` above sets `limits_config.volume_enabled: true`. Services appear by their `service_name` label — with the Docker driver that defaults to the container name (for example `<project>-rundeck-1`).
+:::
+
+You can confirm logs are arriving without Grafana, too:
+
+```bash
+curl -s 'http://localhost:3100/loki/api/v1/label/compose_service/values'
+# → {"status":"success","data":["prometheus","rundeck"]}
+```
+
+:::tip Not running in Docker?
+The logging driver only applies to containers. If Rundeck runs as a plain process (the executable WAR), point a log shipper such as [Grafana Alloy](https://grafana.com/docs/alloy/latest/) or [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/) at its log file instead.
+:::
+
+A complete, runnable version of this stack — Rundeck, Prometheus, Grafana, and Loki wired exactly as above — is published as an example in [docker-zoo](https://github.com/rundeck/docker-zoo/tree/master/monitoring).
+
 
 ## Next steps
 

--- a/docs/learning/howto/monitor-server-grafana.md
+++ b/docs/learning/howto/monitor-server-grafana.md
@@ -198,7 +198,7 @@ If you use [Runners](/administration/runner/index.md), the server also publishes
 Metrics tell you *what* is happening; logs tell you *why*. When Rundeck runs in Docker, the simplest way to get its logs into the same Grafana is the [Loki Docker logging driver](https://grafana.com/docs/loki/latest/send-data/docker-driver/): Docker itself ships each container's stdout and stderr straight to [Loki](https://grafana.com/oss/loki/), with no extra agent, collector, or access to the Docker socket. Only Loki and Grafana are added to the stack.
 
 ```text
-  Rundeck container ─(Docker loki log driver)→ Loki ─→ Grafana (:3000)
+  Rundeck container ─(Docker Loki log driver)→ Loki ─→ Grafana (:3000)
 ```
 
 ### Step 1: Install the Loki Docker driver plugin


### PR DESCRIPTION
## What

Updates the two Grafana monitoring how-tos under `docs/learning/howto/`:

- **`monitor-server-grafana.md`** and **`monitor-runner-grafana.md`** get a new **"Ship container logs to Grafana with Loki"** section using the **Docker Loki logging driver** — no OpenTelemetry Collector, no Promtail, no Docker-socket access. This replaces the previous OpenTelemetry/Tempo tracing section (tracing was more than these user how-tos need).
- Enable Loki's volume endpoint (`limits_config.volume_enabled`) and document Grafana's **Logs Drilldown** app.
- Reference the runnable [`docker-zoo/monitoring`](https://github.com/rundeck/docker-zoo/tree/master/monitoring) exhibit: the full `runner-agent/jmx-config.yml` and the pre-built **Rundeck Overview** / **Runner** dashboards (import links).
- Name the Prometheus scrape job `rundeck-server` so it matches the dashboard's instance filter; remove the "Secure the endpoint" warning.

## Testing

Validated end-to-end against a local stack (`rundeck/rundeck:6.0.1` + Prometheus + Grafana + Loki):
- Prometheus scrapes `/monitoring/prometheus` (target **up**).
- Container logs reach Loki via the logging driver; visible in Explore and the Logs Drilldown app.
- Both dashboards auto-provision and bind to the `prometheus` datasource.

Rendered locally with `npm run docs:dev` — both pages compile clean.

The docker-zoo companion example is merged: https://github.com/rundeck/docker-zoo/tree/master/monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)