### PR TITLE
[RUN-4483] Add warning for job reference and runner configuration

### DIFF
--- a/docs/manual/jobs/job-plugins/node-steps/builtin.md
+++ b/docs/manual/jobs/job-plugins/node-steps/builtin.md
@@ -43,6 +43,13 @@ of the Job and its group.
 
 ![Job reference step type](/assets/img/fig0407.png)
 
+:::warning Runners affect referenced Jobs
+When you reference a Job from another project, Runner usage and configuration can affect the execution flow. The Runner is chosen by the **parent project's** [Runner Selection](/administration/runner/runner-management/project-dispatch-configuration.md) setting, not the referenced Job's project:
+
+- **Automatic:** Runner selection is made in the parent project; the referenced Job's project configuration is not taken into account.
+- **Manual:** Runner selection is made per Job, and the referenced Job's project configuration is honored.
+:::
+
 The Job Reference form provides a Job browser to make it easier to
 select from the existing set of saved Jobs.
 Click the "Choose A Job..." link and navigate to the desired Job.


### PR DESCRIPTION
PR: [https://pagerduty.atlassian.net/browse/RUN-4483](url)

This pull request adds important documentation about how Runner selection works when referencing Jobs from other projects. It clarifies that the Runner used is determined by the parent project's configuration, which can impact execution flow.

Documentation update on Runner selection:

* Added a warning to `job-plugins/node-steps/builtin.md` explaining that when a Job is referenced from another project, the Runner is selected based on the parent project's Runner Selection setting, not the referenced Job's project. It details the behavior for both Automatic and Manual selection modes.