### PR TITLE
Document the ServiceNow Change Note plugins

### DIFF
--- a/docs/manual/jobs/job-plugins/workflow-steps/servicenow.md
+++ b/docs/manual/jobs/job-plugins/workflow-steps/servicenow.md
@@ -238,9 +238,9 @@ Rundeck workflow step that creates a Change Request in ServiceNow
 
 ## ServiceNow / Change / Note
 
-Rundeck workflow step that adds a Note to a Change Reqwuest
+Rundeck workflow step that adds a Note to a Change Request
 
-![ServiceNow / Change / Check State](/assets/img/servicenow-change-note.png)
+![ServiceNow / Change / Note](/assets/img/servicenow-change-note.png)
 
 - **Change Request**
 : Number of the change.

--- a/docs/manual/notifications/servicenow.md
+++ b/docs/manual/notifications/servicenow.md
@@ -48,3 +48,14 @@ To use the plugin, configure this mandatory input:
 
 - assignment group: ServiceNow&reg; incident ID.
 - state: State code. If not set, the change will be in New status.
+
+## ServiceNow / Change / Note
+
+Notification plugin to add a note to a ServiceNow Change Request.
+
+### Usage
+
+To use the plugin, configure this mandatory input:
+
+- Change Request: ServiceNow Change Request number.
+- Note: Note to add.

--- a/docs/manual/plugins/servicenow-plugins-overview.md
+++ b/docs/manual/plugins/servicenow-plugins-overview.md
@@ -21,9 +21,11 @@ These integrations allow operations teams to provide self-service mechanisms to 
 |[**Check Change State**](/manual/jobs/job-plugins/workflow-steps/servicenow.md#servicenow-change-check-state)|Job Step|Change|
 |[**Update Change State**](/manual/jobs/job-plugins/workflow-steps/servicenow.md#servicenow-change-update-state)|Job Step|Change|
 |[**Create Change Request**](/manual/jobs/job-plugins/workflow-steps/servicenow.md#servicenow-change-create)|Job Step|Change|
+|[**Add Change Note**](/manual/jobs/job-plugins/workflow-steps/servicenow.md#servicenow-change-note)|Job Step|Change|
 |[**Create Incident**](/manual/notifications/servicenow.md#servicenow-incident-create)|Notification|Incident|
 |[**Comment Incident**](/manual/notifications/servicenow.md#servicenow®-notification-plugins)|Notification|Incident|
 |[**Create Change Request**](/manual/notifications/servicenow.md#servicenow-change-create)|Notification|Change|
+|[**Add Note to Change Request**](/manual/notifications/servicenow.md#servicenow-change-note)|Notification|Change|
 |[**ServiceNow Node Source**](/manual/projects/resource-model-sources/servicenow.md#servicenow-node-source-enterprise)|Node Source|CMDB|
 </details>
 <br>


### PR DESCRIPTION
## Summary
- Adds the missing **Add Change Note** (Job Step) and **Add Note to Change Request** (Notification) rows to the ServiceNow plugins overview table — both are registered in `rundeckpro-servicenow-plugins` (`Service-Now-Change-Note` / `Service-Now-Notification-Change-Note`) but weren't listed.
- Adds a `ServiceNow / Change / Note` section to the notifications page — this notification plugin (`NoteOnChangeNotification`) had no documentation anywhere.
- Fixes a typo ("Reqwuest") and a mislabeled screenshot caption on the workflow-steps page, under the existing `ServiceNow / Change / Note` step section.

## Verification
Cross-checked every `@Plugin`/`@PluginDescription` annotation in `plugins/servicenow-plugins/src/main/java/com/rundeck/plugins/servicenow/` in `rundeckpro/rundeckpro` against these three docs pages to confirm the fields/wording added here match the actual plugin properties (`id`/"Change Request", `note`/"Note").

This is a documentation-only change (no code, no new libraries).

cc @fdevans