### PR TITLE
RUN-4800: Document PropertyScope default behavior for step plugins

### DIFF
--- a/docs/developer/java-plugin-development.md
+++ b/docs/developer/java-plugin-development.md
@@ -413,7 +413,7 @@ private String endpoint;
 | `description` | String | Help text |
 | `required` | boolean | Whether value is required (default: false) |
 | `defaultValue` | String | Default value |
-| `scope` | PropertyScope | Resolution scope (default: InstanceOnly) |
+| `scope` | PropertyScope | Resolution scope. **The default when omitted depends on the service type** — `WorkflowStep`, `WorkflowNodeStep`, and `RemoteScriptNodeStep` default to `InstanceOnly` (no fallback to Project/System config), while `NodeExecutor`, `FileCopier`, `ResourceModelSource`, and `Notification` default to `Instance`. Always set `scope = PropertyScope.Instance` explicitly if the property should be configurable above the individual job/step level. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted) |
 
 ### Property Types
 

--- a/docs/developer/java-plugin-development.md
+++ b/docs/developer/java-plugin-development.md
@@ -413,7 +413,7 @@ private String endpoint;
 | `description` | String | Help text |
 | `required` | boolean | Whether value is required (default: false) |
 | `defaultValue` | String | Default value |
-| `scope` | PropertyScope | Resolution scope. **The default when omitted depends on the service type** — `WorkflowStep`, `WorkflowNodeStep`, and `RemoteScriptNodeStep` default to `InstanceOnly` (no fallback to Project/System config), while `NodeExecutor`, `FileCopier`, `ResourceModelSource`, and `Notification` default to `Instance`. Always set `scope = PropertyScope.Instance` explicitly if the property should be configurable above the individual job/step level. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted) |
+| `scope` | PropertyScope | Resolution scope. **The default when omitted depends on the service type** — `WorkflowStep`, `WorkflowNodeStep`, and `RemoteScriptNodeStep` default to `InstanceOnly` (no fallback to Project/Framework config), while `NodeExecutor`, `FileCopier`, `ResourceModelSource`, and `Notification` default to `Instance`. Always set `scope = PropertyScope.Instance` explicitly if the property should be configurable above the individual job/step level. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted) |
 
 ### Property Types
 

--- a/docs/developer/plugin-properties.md
+++ b/docs/developer/plugin-properties.md
@@ -86,10 +86,10 @@ If a property does not declare a `scope`, Rundeck applies a default — but **th
 
 This distinction matters because `InstanceOnly` and `Instance` behave very differently:
 
-- `Instance` resolves the job/step-level value, then falls back to Project-level configuration, then Framework/System-level configuration.
-- `InstanceOnly` resolves **only** the job/step-level value. It never falls back to Project or Framework/System configuration, even if a value is configured at those levels.
+- `Instance` resolves the instance-level value (for example, job/step configuration for step plugins), then falls back to Project-level configuration, then Framework-level configuration.
+- `InstanceOnly` resolves **only** the instance-level value. It never falls back to Project or Framework-level configuration, even if a value is configured at those levels.
 
-**Practical impact:** for the most common script-plugin service types — `WorkflowNodeStep` and `RemoteScriptNodeStep` — a property with no explicit `scope` will silently ignore any value configured at the Project or System level. There is no error or warning; the property simply resolves as if it were never configured outside the individual job step.
+**Practical impact:** for the most common script-plugin service types — `WorkflowNodeStep` and `RemoteScriptNodeStep` — a property with no explicit `scope` will silently ignore any value configured at the Project or Framework level. There is no error or warning; the property simply resolves as if it were never configured outside the individual job step.
 
 **Recommendation:** always declare `scope: Instance` explicitly for any property that should be configurable above the individual job/step level. Do not rely on the default, since it is inconsistent across plugin types and this is not obvious from the plugin.yaml format itself.
 

--- a/docs/developer/plugin-properties.md
+++ b/docs/developer/plugin-properties.md
@@ -74,6 +74,25 @@ config:
 
 When resolving the property value at execution time, the node attribute "my-prop" will be used for the value (if present), before resolving other allowed scopes.
 
+### Default Scope When `scope` Is Omitted
+
+If a property does not declare a `scope`, Rundeck applies a default — but **the default is not the same for every plugin service type**:
+
+| Service Type | Default scope when `scope` is omitted |
+|---|---|
+| `WorkflowNodeStep`, `WorkflowStep`, `RemoteScriptNodeStep` | `InstanceOnly` |
+| `NodeExecutor`, `FileCopier` | `Instance` |
+| `ResourceModelSource`, `Notification`, and most other plugin types | `Instance` |
+
+This distinction matters because `InstanceOnly` and `Instance` behave very differently:
+
+- `Instance` resolves the job/step-level value, then falls back to Project-level configuration, then Framework/System-level configuration.
+- `InstanceOnly` resolves **only** the job/step-level value. It never falls back to Project or Framework/System configuration, even if a value is configured at those levels.
+
+**Practical impact:** for the most common script-plugin service types — `WorkflowNodeStep` and `RemoteScriptNodeStep` — a property with no explicit `scope` will silently ignore any value configured at the Project or System level. There is no error or warning; the property simply resolves as if it were never configured outside the individual job step.
+
+**Recommendation:** always declare `scope: Instance` explicitly for any property that should be configurable above the individual job/step level. Do not rely on the default, since it is inconsistent across plugin types and this is not obvious from the plugin.yaml format itself.
+
 ## Property Rendering Options
 
 Rendering options define special attributes of a property, which can be used to declare how it is shown in the GUI, or how the value is loaded at resolution time.

--- a/docs/developer/script-plugin-development.md
+++ b/docs/developer/script-plugin-development.md
@@ -291,7 +291,7 @@ config:
 | `required` | No | If true, value must be provided (default: false) |
 | `default` | No | Default value to use |
 | `values` | For Select types | Comma-separated list of allowed values |
-| `scope` | No | Resolution scope (default: Instance). See [Property Scopes](/developer/plugin-properties.md#property-scopes) |
+| `scope` | No | Resolution scope. **The default when omitted depends on the service type** — `WorkflowNodeStep` and `RemoteScriptNodeStep` default to `InstanceOnly` (no fallback to Project/System config), while `NodeExecutor`, `FileCopier`, and `ResourceModelSource` default to `Instance`. Always set `scope: Instance` explicitly if the property should be configurable above the individual job/step level. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted) |
 | `renderingOptions` | No | Map of rendering options. See [Property Rendering Options](/developer/plugin-properties.md#property-rendering-options) |
 
 ### Example Properties

--- a/docs/developer/script-plugin-development.md
+++ b/docs/developer/script-plugin-development.md
@@ -291,7 +291,7 @@ config:
 | `required` | No | If true, value must be provided (default: false) |
 | `default` | No | Default value to use |
 | `values` | For Select types | Comma-separated list of allowed values |
-| `scope` | No | Resolution scope. **The default when omitted depends on the service type** — `WorkflowNodeStep` and `RemoteScriptNodeStep` default to `InstanceOnly` (no fallback to Project/System config), while `NodeExecutor`, `FileCopier`, and `ResourceModelSource` default to `Instance`. Always set `scope: Instance` explicitly if the property should be configurable above the individual job/step level. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted) |
+| `scope` | No | Resolution scope. **The default when omitted depends on the service type** — `WorkflowNodeStep` and `RemoteScriptNodeStep` default to `InstanceOnly` (no fallback to Project/Framework config), while `NodeExecutor`, `FileCopier`, and `ResourceModelSource` default to `Instance`. Always set `scope: Instance` explicitly if the property should be configurable above the individual job/step level. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted) |
 | `renderingOptions` | No | Map of rendering options. See [Property Rendering Options](/developer/plugin-properties.md#property-rendering-options) |
 
 ### Example Properties

--- a/docs/developer/step-plugins.md
+++ b/docs/developer/step-plugins.md
@@ -563,5 +563,5 @@ add a `scope` entry in the map for a configuration property:
 ```
 
 ::: warning Default Scope
-If `scope` is omitted, `WorkflowNodeStep` and `RemoteScriptNodeStep` properties default to `InstanceOnly` — the value is resolved **only** from the job/step configuration, with no fallback to Project- or System-level configuration. Explicitly set `scope: Instance` (or `Project`, if System-level fallback isn't needed) for any property that should be configurable above the individual job step. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted).
+If `scope` is omitted, `WorkflowNodeStep` and `RemoteScriptNodeStep` properties default to `InstanceOnly` — the value is resolved **only** from the job/step configuration, with no fallback to Project- or Framework-level configuration. Explicitly set `scope: Instance` (or `Project`, if Framework-level fallback isn't needed) for any property that should be configurable above the individual job step. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted).
 :::

--- a/docs/developer/step-plugins.md
+++ b/docs/developer/step-plugins.md
@@ -561,3 +561,7 @@ add a `scope` entry in the map for a configuration property:
       description: Enter the number of nodes to generate
       scope: Project
 ```
+
+::: warning Default Scope
+If `scope` is omitted, `WorkflowNodeStep` and `RemoteScriptNodeStep` properties default to `InstanceOnly` — the value is resolved **only** from the job/step configuration, with no fallback to Project- or System-level configuration. Explicitly set `scope: Instance` (or `Project`, if System-level fallback isn't needed) for any property that should be configurable above the individual job step. See [Default Scope When `scope` Is Omitted](/developer/plugin-properties.md#default-scope-when-scope-is-omitted).
+:::


### PR DESCRIPTION
## Summary
- Fixes RUN-4800: https://pagerduty.atlassian.net/browse/RUN-4800
- The default resolution scope for a plugin property that omits `scope` is not the same across plugin types. `WorkflowStep`, `WorkflowNodeStep`, and `RemoteScriptNodeStep` properties default to `InstanceOnly` (no fallback to Project/System config), while `NodeExecutor`, `FileCopier`, `ResourceModelSource`, and `Notification` default to `Instance`. This was previously undocumented.
- `script-plugin-development.md` and `java-plugin-development.md` each made an incorrect blanket claim that the default is a single universal value (`Instance` and `InstanceOnly` respectively) — both were wrong for at least some of the service types they cover.
- Originated from a customer support case where a script plugin only picked up project/system-level configuration after the customer explicitly declared `scope: Instance` on the property — confirmed against the `rundeck` core codebase (`PropertyScope.java`, `NodeStepPluginAdapter.java`, `StepPluginAdapter.java`, `RemoteScriptNodeStepPluginAdapter_Ext.java`, `AbstractDescribableScriptPlugin.java`) that this is expected, longstanding (traces to a Dec 2012 commit, unchanged since) behavior — not a bug — so the fix here is documentation, not code.

## Changes
- `docs/developer/plugin-properties.md` — new authoritative "Default Scope When `scope` Is Omitted" section with the full per-service-type table and practical impact.
- `docs/developer/script-plugin-development.md` — corrected the incorrect blanket "(default: Instance)" claim.
- `docs/developer/java-plugin-development.md` — corrected the incorrect blanket "(default: InstanceOnly)" claim (Java plugins can implement any service type, so a single default doesn't apply universally there either).
- `docs/developer/step-plugins.md` — added a `::: warning` callout at the exact `WorkflowNodeStep`/`RemoteScriptNodeStep` scope example, where a plugin author is most likely to omit `scope` by accident.

`groovy-plugin-development.md`'s existing "(default: Instance)" claim was checked and left unchanged — it's actually correct, since Groovy plugins only support Notification/logging/log-filter/content-converter service types, none of which are Workflow(Node)Step.

## Test plan
- [x] Verified heading hierarchy (no skipped levels) and admonition syntax (`::: warning ... :::`) match this repo's existing conventions
- [x] Verified cross-reference anchors resolve per VuePress's standard `markdown-it-anchor` slugification
- [ ] Recommend a maintainer with Cloudsmith access run `npm run docs:dev` to visually confirm rendering — I could not complete a full local VuePress build in my environment (no `CLOUDSMITH_NPM_TOKEN`)