### PR TITLE
RUN-4816: Document native Prometheus execution metrics

### DIFF
--- a/docs/.vuepress/sidebar-menus/administration.ts
+++ b/docs/.vuepress/sidebar-menus/administration.ts
@@ -212,7 +212,8 @@ export default [{
                 children: [
                   '/administration/monitoring/',
                   '/administration/monitoring/configuration.md',
-                  '/administration/monitoring/monitoring.md'
+                  '/administration/monitoring/monitoring.md',
+                  '/administration/monitoring/execution-metrics.md'
                 ]
               }
             ]},

--- a/docs/administration/monitoring/configuration.md
+++ b/docs/administration/monitoring/configuration.md
@@ -170,6 +170,7 @@ The monitoring endpoints expose operational metrics but do not expose sensitive 
 | `rundeck.metrics.legacy.enabled` | `false` | Enable legacy endpoints at `/metrics/*` (deprecated) |
 | `rundeck.metrics.enabled` | `true` | Master switch for metrics collection (required for all metrics features) |
 | `rundeck.metrics.jmxEnabled` | `false` | Enable JMX export of metrics as MBeans (requires restart) |
+| `rundeck.metrics.execution.job.dimension.enabled` | `false` | Add `job_id`/`job_name` tags to execution metrics. See [Execution Metrics Reference](/administration/monitoring/execution-metrics.md) for cardinality considerations |
 
 **Configuration Notes:**
 - HTTP endpoint properties (`monitoring.enabled`, `legacy.enabled`) take effect immediately without restart

--- a/docs/administration/monitoring/configuration.md
+++ b/docs/administration/monitoring/configuration.md
@@ -170,7 +170,7 @@ The monitoring endpoints expose operational metrics but do not expose sensitive 
 | `rundeck.metrics.legacy.enabled` | `false` | Enable legacy endpoints at `/metrics/*` (deprecated) |
 | `rundeck.metrics.enabled` | `true` | Master switch for metrics collection (required for all metrics features) |
 | `rundeck.metrics.jmxEnabled` | `false` | Enable JMX export of metrics as MBeans (requires restart) |
-| `rundeck.metrics.execution.job.dimension.enabled` | `false` | Add `job_id`/`job_name` tags to execution metrics. See [Execution Metrics Reference](/administration/monitoring/execution-metrics.md) for cardinality considerations |
+| `rundeck.metrics.execution.job.dimension.enabled` | `false` | Add `job_id`/`job_name` tags to execution metrics. See [Execution Metrics Reference](/administration/monitoring/execution-metrics.md) for details |
 
 **Configuration Notes:**
 - HTTP endpoint properties (`monitoring.enabled`, `legacy.enabled`) take effect immediately without restart

--- a/docs/administration/monitoring/execution-metrics.md
+++ b/docs/administration/monitoring/execution-metrics.md
@@ -44,11 +44,7 @@ rundeck.metrics.execution.job.dimension.enabled=true
 
 This can also be set from **System Configuration** in the admin UI (Execution category) and takes effect immediately, no restart required.
 
-:::warning Cardinality
-Enabling this adds one label series per distinct job in your **job catalog**, not per execution — a job that runs 30 million times still contributes only one `job_id` series. This is what makes the dimension tractable where a per-`execution_id` tag would not be: cardinality is bounded by the number of job definitions, not execution volume. Still, if you have a very large job catalog (tens of thousands of jobs), account for the added series count when sizing Prometheus.
-
 Ad-hoc (non-scheduled) executions never receive a `job_id`/`job_name` tag, even when this flag is enabled — they have no stable job identity to tag.
-:::
 
 When a job is deleted, its `job_id`-tagged series are removed from the live registry so they don't accumulate as unused ("zombie") series in the running process. This only affects what future scrapes report — any history already scraped into Prometheus is retained for as long as Prometheus's own retention policy keeps it, independent of the job's lifecycle in Rundeck.
 

--- a/docs/administration/monitoring/execution-metrics.md
+++ b/docs/administration/monitoring/execution-metrics.md
@@ -24,10 +24,6 @@ All metrics on this page are served at `/monitoring/prometheus`, the same endpoi
 | `rundeck_execution_duration_seconds_sum` | same | Total execution duration. Divide by `_count` to get the average. |
 | `rundeck_execution_duration_seconds_max` | same | Largest execution duration observed since the process started. |
 
-:::tip No percentile buckets
-This timer does not publish histogram buckets, so there is no `rundeck_execution_duration_seconds_bucket` series and no `histogram_quantile()` support (avoiding a dependency on HdrHistogram/LatencyUtils). Use `rate(_sum) / rate(_count)` for the average duration over a window, and `_max` for the worst case. If you need true percentiles, use the execution list API instead.
-:::
-
 ### Gauges
 
 | Metric | Tags | Description |

--- a/docs/administration/monitoring/execution-metrics.md
+++ b/docs/administration/monitoring/execution-metrics.md
@@ -1,6 +1,6 @@
 # Execution Metrics Reference
 
-Rundeck 6.0 adds native, tagged execution metrics on the modern monitoring endpoint (`/monitoring/prometheus`), so per-project and per-job execution counts, durations, and in-flight counts are queryable directly from Prometheus and Grafana — without the third-party `rundeck_exporter` (see [Monitor a Rundeck Instance Using Prometheus and Grafana (legacy exporter)](/learning/howto/rundeck-exporter.md)).
+Rundeck 6.0 adds native, tagged execution metrics on the modern monitoring endpoint (`/monitoring/prometheus`), so per-project and per-job execution counts, durations, and in-flight counts are queryable directly from Prometheus and Grafana.
 
 These metrics are registered directly on the Micrometer registry (not bridged from the legacy Dropwizard registry), so they follow standard Prometheus naming: dots become underscores, and counters get a `_total` suffix.
 

--- a/docs/administration/monitoring/execution-metrics.md
+++ b/docs/administration/monitoring/execution-metrics.md
@@ -1,0 +1,88 @@
+# Execution Metrics Reference
+
+Rundeck 6.0 adds native, tagged execution metrics on the modern monitoring endpoint (`/monitoring/prometheus`), so per-project and per-job execution counts, durations, and in-flight counts are queryable directly from Prometheus and Grafana — without the third-party `rundeck_exporter` (see [Monitor a Rundeck Instance Using Prometheus and Grafana (legacy exporter)](/learning/howto/rundeck-exporter.md)).
+
+These metrics are registered directly on the Micrometer registry (not bridged from the legacy Dropwizard registry), so they follow standard Prometheus naming: dots become underscores, and counters get a `_total` suffix.
+
+## Where these metrics are exposed
+
+All metrics on this page are served at `/monitoring/prometheus`, the same endpoint documented in [Using monitoring data](/administration/monitoring/monitoring.md). No separate endpoint or exporter is required.
+
+## Metrics
+
+### Counter
+
+| Metric | Tags | Description |
+|---|---|---|
+| `rundeck_executions_total` | `project`, `status` (`succeeded`, `failed`, `aborted`, `timedout`), and optionally `job_id`, `job_name` | Incremented once per execution, when the execution reaches its final persisted state. The `status` tag always reflects the final outcome — this metric never reports an in-progress execution. |
+
+### Timer
+
+| Metric | Tags | Description |
+|---|---|---|
+| `rundeck_execution_duration_seconds_count` | `project`, `status`, optionally `job_id`, `job_name` | Number of executions recorded. |
+| `rundeck_execution_duration_seconds_sum` | same | Total execution duration. Divide by `_count` to get the average. |
+| `rundeck_execution_duration_seconds_max` | same | Largest execution duration observed since the process started. |
+
+:::tip No percentile buckets
+This timer does not publish histogram buckets, so there is no `rundeck_execution_duration_seconds_bucket` series and no `histogram_quantile()` support (avoiding a dependency on HdrHistogram/LatencyUtils). Use `rate(_sum) / rate(_count)` for the average duration over a window, and `_max` for the worst case. If you need true percentiles, use the execution list API instead.
+:::
+
+### Gauges
+
+| Metric | Tags | Description |
+|---|---|---|
+| `rundeck_executions_running` | `project`, optionally `job_id`, `job_name` | Executions currently running, tracked in memory (incremented when an execution starts, decremented when it finishes). This is an **event-driven, per-instance** count — it reflects only executions started by the Rundeck process being scraped, not the whole cluster. In a cluster, aggregate across instances with `sum by (project) (rundeck_executions_running)`. |
+| `rundeck_system_info` | `version`, `build`, `node_uuid` | Constant `1` gauge exposing build metadata as labels (the value itself carries no information — a standard Prometheus "info metric" pattern). Registered once at startup. Useful for joining other metrics against version/build, or for tracking per-node rollout status with `count by (version) (rundeck_system_info)`. |
+| `rundeck_execution_mode_active` | none | `1` when the instance is in active execution mode, `0` when passive (see [cluster mode](/administration/cluster/)). |
+
+## The `job_id`/`job_name` dimension
+
+By default, `rundeck_executions_total`, `rundeck_execution_duration_seconds_*`, and `rundeck_executions_running` are tagged only with `project` and `status`. You can opt in to an additional `job_id`/`job_name` tag pair to get per-job breakdowns directly in Prometheus, instead of falling back to the executions API or database for per-job statistics.
+
+Enable it with:
+
+```properties
+rundeck.metrics.execution.job.dimension.enabled=true
+```
+
+This can also be set from **System Configuration** in the admin UI (Execution category) and takes effect immediately, no restart required.
+
+:::warning Cardinality
+Enabling this adds one label series per distinct job in your **job catalog**, not per execution — a job that runs 30 million times still contributes only one `job_id` series. This is what makes the dimension tractable where a per-`execution_id` tag would not be: cardinality is bounded by the number of job definitions, not execution volume. Still, if you have a very large job catalog (tens of thousands of jobs), account for the added series count when sizing Prometheus.
+
+Ad-hoc (non-scheduled) executions never receive a `job_id`/`job_name` tag, even when this flag is enabled — they have no stable job identity to tag.
+:::
+
+When a job is deleted, its `job_id`-tagged series are removed from the live registry so they don't accumulate as unused ("zombie") series in the running process. This only affects what future scrapes report — any history already scraped into Prometheus is retained for as long as Prometheus's own retention policy keeps it, independent of the job's lifecycle in Rundeck.
+
+## Example queries
+
+**Execution success rate over the last 5 minutes:**
+```promql
+sum(rate(rundeck_executions_total{status="succeeded"}[5m]))
+/
+sum(rate(rundeck_executions_total[5m]))
+```
+
+**Average execution duration by project:**
+```promql
+rate(rundeck_execution_duration_seconds_sum[5m])
+/
+rate(rundeck_execution_duration_seconds_count[5m])
+```
+
+**Executions currently running, by project (cluster-wide):**
+```promql
+sum by (project) (rundeck_executions_running)
+```
+
+**Top 10 jobs by failure count** (requires `rundeck.metrics.execution.job.dimension.enabled=true`):
+```promql
+topk(10, sum by (job_id, job_name) (rundeck_executions_total{status="failed"}))
+```
+
+**Rundeck version rollout across a cluster:**
+```promql
+count by (version) (rundeck_system_info)
+```

--- a/docs/administration/monitoring/execution-metrics.md
+++ b/docs/administration/monitoring/execution-metrics.md
@@ -34,7 +34,7 @@ All metrics on this page are served at `/monitoring/prometheus`, the same endpoi
 
 ## The `job_id`/`job_name` dimension
 
-By default, `rundeck_executions_total`, `rundeck_execution_duration_seconds_*`, and `rundeck_executions_running` are tagged only with `project` and `status`. You can opt in to an additional `job_id`/`job_name` tag pair to get per-job breakdowns directly in Prometheus, instead of falling back to the executions API or database for per-job statistics.
+By default, `rundeck_executions_total` and `rundeck_execution_duration_seconds_*` are tagged with `project` and `status`; `rundeck_executions_running` is tagged with `project` only (it tracks in-flight executions, which have no final status yet). All three accept an additional `job_id`/`job_name` tag pair when you opt in, to get per-job breakdowns directly in Prometheus instead of falling back to the executions API or database for per-job statistics.
 
 Enable it with:
 
@@ -59,9 +59,9 @@ sum(rate(rundeck_executions_total[5m]))
 
 **Average execution duration by project:**
 ```promql
-rate(rundeck_execution_duration_seconds_sum[5m])
+sum by (project) (rate(rundeck_execution_duration_seconds_sum[5m]))
 /
-rate(rundeck_execution_duration_seconds_count[5m])
+sum by (project) (rate(rundeck_execution_duration_seconds_count[5m]))
 ```
 
 **Executions currently running, by project (cluster-wide):**

--- a/docs/administration/monitoring/monitoring.md
+++ b/docs/administration/monitoring/monitoring.md
@@ -161,6 +161,13 @@ Rundeck exposes a wide variety of metrics. Some commonly monitored metrics inclu
 - `executor.completed` - Completed tasks
 - `executor.queued` - Queued tasks
 
+### Execution Metrics
+- `rundeck.executions` - Execution counts tagged by project and status
+- `rundeck.execution.duration` - Execution duration tagged by project and status
+- `rundeck.executions.running` - Executions currently running, tagged by project
+
+See the [Execution Metrics Reference](/administration/monitoring/execution-metrics.md) for the full list of series, tags, the optional `job_id`/`job_name` dimension, and example queries.
+
 :::tip Discovering Metrics
 Use `/monitoring/metrics` to get a complete list of available metrics for your Rundeck instance. Metric names may vary slightly between versions as new metrics are added.
 :::

--- a/docs/administration/monitoring/monitoring.md
+++ b/docs/administration/monitoring/monitoring.md
@@ -162,9 +162,9 @@ Rundeck exposes a wide variety of metrics. Some commonly monitored metrics inclu
 - `executor.queued` - Queued tasks
 
 ### Execution Metrics
-- `rundeck.executions` - Execution counts tagged by project and status
-- `rundeck.execution.duration` - Execution duration tagged by project and status
-- `rundeck.executions.running` - Executions currently running, tagged by project
+- `rundeck_executions_total` - Execution counts tagged by project and status
+- `rundeck_execution_duration_seconds_*` - Execution duration tagged by project and status
+- `rundeck_executions_running` - Executions currently running, tagged by project
 
 See the [Execution Metrics Reference](/administration/monitoring/execution-metrics.md) for the full list of series, tags, the optional `job_id`/`job_name` dimension, and example queries.
 


### PR DESCRIPTION
## Summary
- Adds an Execution Metrics Reference page covering `rundeck_executions_total`, `rundeck_execution_duration_seconds_*`, `rundeck_executions_running`, `rundeck_system_info`, and `rundeck_execution_mode_active` — the native Micrometer execution metrics added in Rundeck 6.0
- Documents the opt-in `job_id`/`job_name` dimension and cleanup behavior on job deletion
- Adds `rundeck.metrics.execution.job.dimension.enabled` to the monitoring configuration reference
- Links the new page from the monitoring overview and sidebar

Related to [RUN-4816](https://pagerduty.atlassian.net/browse/RUN-4816) (rundeck/rundeck PR #10486).

## Test plan
- [x] `npm run docs:build` passes with no dead-link warnings
- [x] Verified locally via `npm run docs:dev` at `/administration/monitoring/execution-metrics.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RUN-4816]: https://pagerduty.atlassian.net/browse/RUN-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ