### PR TITLE
Move monitoring HOWTOs into their own sidebar section

### DIFF
--- a/docs/.vuepress/sidebar-menus/learning.ts
+++ b/docs/.vuepress/sidebar-menus/learning.ts
@@ -147,9 +147,6 @@ export default [{
             '/learning/howto/config-sn-nodesource.md',
             '/learning/howto/configure-gcp-plugins.md',
             '/learning/howto/sn-midserver.md',
-            {link:'/learning/howto/monitor-server-grafana.md',text:'Monitor the Server with Prometheus and Grafana'},
-            {link:'/learning/howto/monitor-runner-grafana.md',text:'Monitor a Runner with Prometheus and Grafana'},
-            '/learning/howto/rundeck-exporter.md',
             '/learning/howto/vault-integration.md',
             '/learning/howto/howtojenkins.md',
             '/learning/howto/how2kube.md',
@@ -157,6 +154,15 @@ export default [{
             '/learning/howto/events-with-rba.md',
             '/learning/howto/email-gmail.md',
             '/learning/howto/email-outlook.md'
+          ]
+        },
+        {
+          text: 'Monitoring',
+          collapsible: true,
+          children: [
+            {link:'/learning/howto/monitor-server-grafana.md',text:'Monitor the Server with Prometheus and Grafana'},
+            {link:'/learning/howto/monitor-runner-grafana.md',text:'Monitor a Runner with Prometheus and Grafana'},
+            '/learning/howto/rundeck-exporter.md'
           ]
         },
         {

--- a/docs/learning/howto/monitor-server-grafana.md
+++ b/docs/learning/howto/monitor-server-grafana.md
@@ -1,5 +1,9 @@
 # Monitor the Rundeck Server with Prometheus and Grafana
 
+:::tip Full working example
+A complete, runnable Prometheus + Grafana + Rundeck stack (including the pre-built dashboard referenced in this guide) is available at [rundeck/docker-zoo](https://github.com/rundeck/docker-zoo/tree/master/monitoring).
+:::
+
 Rundeck 6.0 exposes application metrics natively in Prometheus format at the [`/monitoring/prometheus`](/administration/monitoring/index.md) endpoint, which is enabled by default. This means you no longer need a third-party exporter to build a metrics dashboard — Prometheus can scrape Rundeck directly.
 
 This guide walks through a working Prometheus + Grafana stack pointed at a Rundeck server, with example queries for the most useful health and performance metrics. It then shows how to ship the container **logs** into the same Grafana with Loki — see [Ship container logs to Grafana with Loki](#ship-container-logs-to-grafana-with-loki).


### PR DESCRIPTION
## Summary
- Splits the Prometheus/Grafana/`rundeck_exporter` HOWTO guides out of the "Integrating" sidebar section into a new "Monitoring" section under Learning > HOWTO, since they're a distinct topic from the other integrations listed there
- Adds a callout to [Monitor the Rundeck Server with Prometheus and Grafana](/learning/howto/monitor-server-grafana.md) pointing to the runnable example stack at [rundeck/docker-zoo](https://github.com/rundeck/docker-zoo/tree/master/monitoring)

## Test plan
- [x] `npm run docs:build` passes with no dead-link warnings
- [x] Verified locally via `npm run docs:dev`: sidebar shows "Monitoring" as its own section, callout renders on the server-monitoring guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)