### PR TITLE
Update remote job execution documentation

### DIFF
--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -165,7 +165,7 @@ ratio and the percentage of CPU.
 rundeck.clusterMode.remoteExecution.config.criteria = threadRatio,load
 ```
 
-Each criteria can be weighted using a relative value:
+Each criterion can be weighted using a relative value:
 
 ```properties
 rundeck.clusterMode.remoteExecution.config.weights = 1.0,1.5

--- a/docs/administration/configuration/remote-job-execution.md
+++ b/docs/administration/configuration/remote-job-execution.md
@@ -165,8 +165,6 @@ ratio and the percentage of CPU.
 rundeck.clusterMode.remoteExecution.config.criteria = threadRatio,load
 ```
 
-> **Note:** These are the only criteria available so far.
-
 Each criteria can be weighted using a relative value:
 
 ```properties


### PR DESCRIPTION
Removed note about available criteria for remote execution. It was saying that only threadRatio and Load are available but a few lines below it mentions`threadRatio`,`load`, `systemLoadAverage` and `processors`.