### PR TITLE
[RUN-4579] Document sshExportQuoting control

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -602,6 +602,21 @@ Enables dynamic conditional execution in workflows based on runtime conditions. 
 
 **See also:** [User Management Guide](/manual/user-management/user-mgmt.md#manage-local-users)
 
+#### SSH Exported Variable Quoting
+
+**Purpose:** Optionally POSIX shell-quote the values exported to remote nodes via a node's `ssh-variable-export-pattern` attribute, to prevent command injection through those values (for example a job option value containing `;`, `$()`, or backticks).
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `rundeck.execution.sshExportQuoting` | `false` | When `true`, values interpolated into a node's `ssh-variable-export-pattern` (the `export {key}={value}` prefix prepended to the remote SSH command) are shell-quoted before dispatch. |
+
+**Behavior:**
+
+- **Opt-in.** Default `false` preserves the current behavior; the control has no effect until enabled. System-level only (not per-project).
+- When enabled, only values that contain whitespace or shell metacharacters are quoted — values without them are emitted unchanged, so typical configurations are unaffected.
+- When enabling, node export patterns must reference `{value}` **without** surrounding quotes (e.g. `export {key}={value}`, not `export {key}='{value}'`). The framework performs the quoting; a self-quoting pattern would double-quote the value.
+- Only nodes that define the (non-default) `ssh-variable-export-pattern` attribute are affected.
+
 ### Security HTTP Headers
 
 **Purpose:** Add security headers to HTTP responses to protect against common web vulnerabilities.


### PR DESCRIPTION
## Summary

Documents the new system control `rundeck.execution.sshExportQuoting` (product PR rundeck/rundeck#10534).

When enabled, values exported to remote nodes via a node's `ssh-variable-export-pattern` are POSIX shell-quoted, preventing command injection through job option values (RUN-4579). Opt-in, default off, system-level.

## Changes

- `docs/administration/configuration/config-file-reference.md` — new "SSH Exported Variable Quoting" subsection under **Security**: property table, opt-in/default-off semantics, that only whitespace/metacharacter-bearing values are quoted, and that patterns must reference `{value}` without surrounding quotes.

Scope note: only the new property is documented. The pre-existing `ssh-variable-export-pattern` node attribute is referenced for context but not newly documented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)