### PR TITLE
RUN-4780: Clarify Groovy plugin hot reload requires plugin.refreshDelay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ hope/.vuepress/.cache/
 hope/.vuepress/.temp/
 hope/.vuepress/dist/
 .claude/.sdlc-setup-done
+.atl/

--- a/docs/developer/groovy-plugin-development.md
+++ b/docs/developer/groovy-plugin-development.md
@@ -641,7 +641,7 @@ plugin.refreshDelay=5000
 See [Config File Reference](/administration/configuration/config-file-reference.md) for its location per installation type. Alternatively, set it as a JVM system property via `RDECK_JVM_OPTS` - see [System Properties Configuration](/administration/configuration/system-properties.md).
 
 ::: warning Hot Reloading Caveat
-Enabling `plugin.refreshDelay` makes Rundeck watch every Groovy plugin in `libext`, not just the one you're editing. If any of those files is empty or fails to evaluate, the application can fail to start. Verify your `libext` directory doesn't contain broken or empty `.groovy` files before enabling this in a shared environment.
+Broken or empty `.groovy` files in `libext` can prevent Rundeck from starting, regardless of whether `plugin.refreshDelay` is set. Enabling `plugin.refreshDelay` extends periodic refresh-checking to every Groovy plugin in `libext`, not just the one you're editing - verify the whole directory is clean before enabling this in a shared environment.
 :::
 
 ### Debugging

--- a/docs/developer/groovy-plugin-development.md
+++ b/docs/developer/groovy-plugin-development.md
@@ -619,27 +619,26 @@ try {
 
 ### Iterative Development
 
-By default, Rundeck does **not** reload a Groovy plugin after its initial load — restarting is required to pick up any edit, the same as with Java plugins. Hot reloading is **opt-in**, controlled by the JVM system property `plugin.refreshDelay`.
-
-`plugin.refreshDelay` sets, in milliseconds, how often Rundeck checks the `.groovy` file for changes. Enable it based on how you run Rundeck:
-
-**RPM (CentOS/RHEL)** — add to `/etc/sysconfig/rundeckd`:
-
-```bash
-export RDECK_JVM_OPTS="-Dplugin.refreshDelay=5000"
-```
-
-**DEB (Ubuntu/Debian)** — add the same line to `/etc/default/rundeckd`.
-
-**Docker** — add `-Dplugin.refreshDelay=5000` to the container's `command`.
-
-**Rundeck development (`bootRun`)** — pass `-Dplugin.refreshDelay=5000` as a gradle command argument.
-
-Once enabled:
+After the initial load:
 
 1. Edit the `.groovy` file
-2. Wait up to the configured `plugin.refreshDelay` interval — changes take effect on next use
+2. **Enable hot reloading** (see below) - or restart Rundeck to pick up the change
 3. Test your changes
+
+::: tip Hot Reloading
+Groovy plugins support hot reloading after the initial load, but it's **opt-in** - you must set the `plugin.refreshDelay` JVM system property first. See below to enable it.
+:::
+
+#### Enabling Hot Reloading
+
+`plugin.refreshDelay` sets, in milliseconds, how often Rundeck checks the `.groovy` file for changes. Set it via `RDECK_JVM_OPTS` (see [System Properties Configuration](/administration/configuration/system-properties.md) for how to set JVM system properties for your installation type):
+
+```bash
+# /etc/sysconfig/rundeckd (RPM) or /etc/default/rundeckd (DEB)
+RDECK_JVM_OPTS="-Dplugin.refreshDelay=5000"
+```
+
+For Docker, add `-Dplugin.refreshDelay=5000` to the container's `command`.
 
 ::: warning Hot Reloading Caveat
 Enabling `plugin.refreshDelay` makes Rundeck watch every Groovy plugin in `libext`, not just the one you're editing. If any of those files is empty or fails to evaluate, the application can fail to start. Verify your `libext` directory doesn't contain broken or empty `.groovy` files before enabling this in a shared environment.

--- a/docs/developer/groovy-plugin-development.md
+++ b/docs/developer/groovy-plugin-development.md
@@ -635,10 +635,10 @@ Groovy plugins support hot reloading after the initial load, but it's **opt-in**
 
 ```bash
 # /etc/sysconfig/rundeckd (RPM) or /etc/default/rundeckd (DEB)
-RDECK_JVM_OPTS="-Dplugin.refreshDelay=5000"
+RDECK_JVM_OPTS="$RDECK_JVM_OPTS -Dplugin.refreshDelay=5000"
 ```
 
-For Docker, add `-Dplugin.refreshDelay=5000` to the container's `command`.
+For Docker, Rundeck's official images configure the JVM through environment variables and templated config rather than a direct `-D` flag — see [Extending Docker Configuration](/administration/configuration/docker/extending-configuration.md) to add this property via a derived image.
 
 ::: warning Hot Reloading Caveat
 Enabling `plugin.refreshDelay` makes Rundeck watch every Groovy plugin in `libext`, not just the one you're editing. If any of those files is empty or fails to evaluate, the application can fail to start. Verify your `libext` directory doesn't contain broken or empty `.groovy` files before enabling this in a shared environment.

--- a/docs/developer/groovy-plugin-development.md
+++ b/docs/developer/groovy-plugin-development.md
@@ -7,7 +7,7 @@ Groovy plugins provide a middle ground between Script and Java plugins, offering
 - **Simple Development** - Create plugins in a single `.groovy` file
 - **Dynamic Scripting** - Groovy's powerful scripting features
 - **Java Ecosystem Access** - Use Java libraries and classes
-- **Hot Reloading** - Update plugins without restarting Rundeck (after initial load)
+- **Hot Reloading** - Optionally reload plugin changes without restarting Rundeck (after initial load)
 - **DSL Syntax** - Simplified domain-specific language for plugin definition
 
 **Limitations:**
@@ -619,14 +619,30 @@ try {
 
 ### Iterative Development
 
-After the initial load:
+By default, Rundeck does **not** reload a Groovy plugin after its initial load — restarting is required to pick up any edit, the same as with Java plugins. Hot reloading is **opt-in**, controlled by the JVM system property `plugin.refreshDelay`.
+
+`plugin.refreshDelay` sets, in milliseconds, how often Rundeck checks the `.groovy` file for changes. Enable it based on how you run Rundeck:
+
+**RPM (CentOS/RHEL)** — add to `/etc/sysconfig/rundeckd`:
+
+```bash
+export RDECK_JVM_OPTS="-Dplugin.refreshDelay=5000"
+```
+
+**DEB (Ubuntu/Debian)** — add the same line to `/etc/default/rundeckd`.
+
+**Docker** — add `-Dplugin.refreshDelay=5000` to the container's `command`.
+
+**Rundeck development (`bootRun`)** — pass `-Dplugin.refreshDelay=5000` as a gradle command argument.
+
+Once enabled:
 
 1. Edit the `.groovy` file
-2. **No restart needed!** - Changes take effect on next use
+2. Wait up to the configured `plugin.refreshDelay` interval — changes take effect on next use
 3. Test your changes
 
-::: tip Hot Reloading
-Groovy plugins support hot reloading after the initial load. This makes development much faster than Java plugins.
+::: warning Hot Reloading Caveat
+Enabling `plugin.refreshDelay` makes Rundeck watch every Groovy plugin in `libext`, not just the one you're editing. If any of those files is empty or fails to evaluate, the application can fail to start. Verify your `libext` directory doesn't contain broken or empty `.groovy` files before enabling this in a shared environment.
 :::
 
 ### Debugging

--- a/docs/developer/groovy-plugin-development.md
+++ b/docs/developer/groovy-plugin-development.md
@@ -626,19 +626,19 @@ After the initial load:
 3. Test your changes
 
 ::: tip Hot Reloading
-Groovy plugins support hot reloading after the initial load, but it's **opt-in** - you must set the `plugin.refreshDelay` JVM system property first. See below to enable it.
+Groovy plugins support hot reloading after the initial load, but it's **opt-in** - you must set the `plugin.refreshDelay` property first. See below to enable it.
 :::
 
 #### Enabling Hot Reloading
 
-`plugin.refreshDelay` sets, in milliseconds, how often Rundeck checks the `.groovy` file for changes. Set it via `RDECK_JVM_OPTS` (see [System Properties Configuration](/administration/configuration/system-properties.md) for how to set JVM system properties for your installation type):
+`plugin.refreshDelay` sets, in milliseconds, how often Rundeck checks the `.groovy` file for changes. It's read once at startup, so a restart is still required after changing it. Set it in `rundeck-config.properties` - Rundeck's primary configuration file, present in every installation type (RPM, DEB, Docker, self-hosted):
 
-```bash
-# /etc/sysconfig/rundeckd (RPM) or /etc/default/rundeckd (DEB)
-RDECK_JVM_OPTS="$RDECK_JVM_OPTS -Dplugin.refreshDelay=5000"
+```properties
+# $RDECK_BASE/server/config/rundeck-config.properties
+plugin.refreshDelay=5000
 ```
 
-For Docker, Rundeck's official images configure the JVM through environment variables and templated config rather than a direct `-D` flag — see [Extending Docker Configuration](/administration/configuration/docker/extending-configuration.md) to add this property via a derived image.
+See [Config File Reference](/administration/configuration/config-file-reference.md) for its location per installation type. Alternatively, set it as a JVM system property via `RDECK_JVM_OPTS` - see [System Properties Configuration](/administration/configuration/system-properties.md).
 
 ::: warning Hot Reloading Caveat
 Enabling `plugin.refreshDelay` makes Rundeck watch every Groovy plugin in `libext`, not just the one you're editing. If any of those files is empty or fails to evaluate, the application can fail to start. Verify your `libext` directory doesn't contain broken or empty `.groovy` files before enabling this in a shared environment.


### PR DESCRIPTION
## Summary

Fixes RUN-4780 ("Hot reloading groovy plugin is not working"). The docs claimed Groovy plugins hot-reload automatically after their initial load; in practice Rundeck never re-checks a loaded Groovy plugin unless `plugin.refreshDelay` is explicitly set (root cause: `resources.groovy` defaults the Spring `refresh-check-delay` to `-1`, disabling the refresh check entirely — this has been the behavior since the feature was introduced, not a regression).

- Hot reloading is now documented as **opt-in** via the `plugin.refreshDelay` JVM system property.
- Added an "Enabling Hot Reloading" subsection pointing to the canonical System Properties Configuration page for RPM/DEB setup, plus a Docker note.
- Added a caution that enabling this makes Rundeck watch every Groovy plugin in `libext`, not just the one being edited, and can break startup if any of them are empty or invalid.

## Changes

- `docs/developer/groovy-plugin-development.md` — corrected the Overview bullet and rewrote the "Iterative Development" section under Development Workflow.
- `.gitignore` — ignore local `.atl/` directory.


<img width="969" height="780" alt="image" src="https://github.com/user-attachments/assets/8ae6e00f-ad3b-46ad-8ad0-e71abcdbd497" />

