### PR TITLE
[RUN-4890] Document ACE editor manual resize default change

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -1119,15 +1119,19 @@ Sets the maximum amount of runner report data the server will store in the datab
 ```properties
 rundeck.runner.compactProcessor.maxReportDataSize=1gb
 ```
-=======
+
 ### Code Editor Settings
 
-Controls the height of the ACE code editor rendered inside plugin configuration forms (for example, inline script steps, orchestrator configuration, and execution lifecycle plugins).
+Controls the sizing behavior of the ACE code editor rendered inside plugin configuration forms (for example, inline script steps, orchestrator configuration, and execution lifecycle plugins).
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `rundeck.feature.guiAceEditorMinLines` | `12` | Minimum number of visible lines shown in the editor, which sets its minimum visible height. |
-| `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Set to `0` for unlimited. |
+| `rundeck.feature.guiAceEditorMinLines` | `0` | Minimum number of visible lines in the editor. `0` (default) makes the editor manually resizable via a drag handle instead of auto-sizing. Set to a non-zero value to disable manual resize and have the editor auto-size to that minimum line count instead. |
+| `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Only applies when `guiAceEditorMinLines` is non-zero. Set to `0` for unlimited. |
+
+:::tip
+Manual resize is available now on Runbook Automation **SaaS**. On **Self-Hosted**, the default changes from `12` to `0` (manually resizable) starting in **Rundeck 6.3.0**.
+:::
 
 These settings can be changed at runtime via **System Configuration → GUI** without restarting Rundeck. The new values take effect on the next page load.
 

--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -1126,11 +1126,11 @@ Controls the sizing behavior of the ACE code editor rendered inside plugin confi
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `rundeck.feature.guiAceEditorMinLines` | `0` | Minimum number of visible lines in the editor. `0` (default) makes the editor manually resizable via a drag handle instead of auto-sizing. Set to a non-zero value to disable manual resize and have the editor auto-size to that minimum line count instead. |
-| `rundeck.feature.guiAceEditorMaxLines` | `0` | Maximum number of lines the editor auto-expands to. Only applies when `guiAceEditorMinLines` is non-zero. Set to `0` for unlimited. |
+| `rundeck.feature.guiAceEditorMinLines` | `0` | Minimum number of visible lines in the editor. `0` (default) makes the editor manually resizable via a drag handle. A non-zero value disables manual resize; the editor starts with enough height to show that many lines and auto-expands as lines are added. |
+| `rundeck.feature.guiAceEditorMaxLines` | `0` | Only applies when `guiAceEditorMinLines` is non-zero. Caps how far the editor auto-expands: once content reaches this many lines, a scrollbar appears instead of the editor growing further. Set to `0` for unlimited. |
 
 :::tip
-Manual resize is available now on Runbook Automation **SaaS**. On **Self-Hosted**, the default changes from `12` to `0` (manually resizable) starting in **Rundeck 6.3.0**.
+Manual resize is available now on Runbook Automation **SaaS**. On Runbook Automation **Self-Hosted**, the default changes from `12` to `0` (manually resizable) starting in **Rundeck 6.3.0**.
 :::
 
 These settings can be changed at runtime via **System Configuration → GUI** without restarting Rundeck. The new values take effect on the next page load.


### PR DESCRIPTION
## Summary
- Updates the Code Editor Settings section in `config-file-reference.md` for [rundeck/rundeck#10551](https://github.com/rundeck/rundeck/pull/10551) ([RUN-4890](https://pagerduty.atlassian.net/browse/RUN-4890)): `guiAceEditorMinLines` now defaults to `0`, making the ACE editor manually resizable via drag handle instead of auto-sizing; `guiAceEditorMaxLines` is clarified to only apply when auto-sizing is active (non-zero `guiAceEditorMinLines`).
- Notes rollout: available now on Runbook Automation SaaS; Self-Hosted default changes from `12` to `0` starting in Rundeck 6.3.0.
- Removes a stray leftover merge-conflict marker (`=======`) found in the same section, unrelated to this change.

## Test plan
- [ ] Verify wording against rundeck/rundeck#10551 once merged (PR was still open at time of writing)
- [ ] Confirm 6.3.0 is the correct self-hosted target version at release time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RUN-4890]: https://pagerduty.atlassian.net/browse/RUN-4890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ