### PR TITLE
[RUN-4930] Clarify legacy JAAS package usage for LDAP modules and log4j2 loggers

### DIFF
--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -154,7 +154,7 @@ Rundeck includes two JAAS login modules you can use for LDAP directory authentic
 These are an enhanced version of the default Jetty JAAS Ldap login module that caches authorization results for a period of time.
 
 :::tip
-`JettyCachingLdapLoginModule` and `JettyCombinedLdapLoginModule` are Rundeck-authored modules, not part of Jetty's built-in JAAS SPI. They are unaffected by the Jetty 12 changes described above, so they intentionally remain in the `com.dtolabs.rundeck.jetty.jaas` package on Rundeck 6.0+ — do not change these class names to `org.rundeck.jaas.*` when migrating your JAAS configuration.
+`JettyCachingLdapLoginModule` and `JettyCombinedLdapLoginModule` are Rundeck-authored modules, not part of Jetty's built-in JAAS SPI that Jetty 12 removed. They're unaffected by that removal, so on Rundeck 6.0+ they intentionally remain in the `com.dtolabs.rundeck.jetty.jaas` package — for example, `com.dtolabs.rundeck.jetty.jaas.JettyCachingLdapLoginModule`. Do not change these class names to `org.rundeck.jaas.*` when migrating your JAAS configuration.
 :::
 
 JAAS supports evaluating `MD5`, `BCRYPT` and `CRYPT` password hashes.

--- a/docs/administration/security/authentication.md
+++ b/docs/administration/security/authentication.md
@@ -153,6 +153,10 @@ Rundeck includes two JAAS login modules you can use for LDAP directory authentic
 
 These are an enhanced version of the default Jetty JAAS Ldap login module that caches authorization results for a period of time.
 
+:::tip
+`JettyCachingLdapLoginModule` and `JettyCombinedLdapLoginModule` are Rundeck-authored modules, not part of Jetty's built-in JAAS SPI. They are unaffected by the Jetty 12 changes described above, so they intentionally remain in the `com.dtolabs.rundeck.jetty.jaas` package on Rundeck 6.0+ — do not change these class names to `org.rundeck.jaas.*` when migrating your JAAS configuration.
+:::
+
 JAAS supports evaluating `MD5`, `BCRYPT` and `CRYPT` password hashes.
 
 You must change some configuration values to change the authentication module to use.

--- a/docs/upgrading/upgrading-to-6.0.md
+++ b/docs/upgrading/upgrading-to-6.0.md
@@ -105,13 +105,16 @@ Internal review also **raised defaults** or **made behaviors permanent** for fea
 
 ## JAAS authentication configuration (Jetty 12) {#jaas-authentication-jetty-12}
 
-Rundeck 6.0 upgrades to **Jetty 12**, which removes the legacy Jetty JAAS packages. Custom JAAS configurations must now reference **`org.rundeck.jaas.*`** modules instead of the old Jetty classes.
+Rundeck 6.0 upgrades to **Jetty 12**, which removes Jetty's built-in JAAS SPI classes (`org.eclipse.jetty.jaas.spi.*`). Rundeck's own `PropertyFileLoginModule` and PAM login modules now live under **`org.rundeck.jaas.*`** instead of the old Jetty classes.
+
+The LDAP login modules (`JettyCachingLdapLoginModule` and `JettyCombinedLdapLoginModule`) are Rundeck-authored and were never part of Jetty's JAAS SPI, so they are **not affected** by this change — they remain in the `com.dtolabs.rundeck.jetty.jaas` package. Do not rename these classes in your JAAS config.
 
 **Action required for JAAS users:**
 
-1. **Update `jaas-loginmodule.conf`** to reference `org.rundeck.jaas.PropertyFileLoginModule` instead of the old Jetty class names
+1. **Update `jaas-loginmodule.conf`** to reference `org.rundeck.jaas.PropertyFileLoginModule` instead of the old Jetty class names (leave any LDAP module entries referencing `com.dtolabs.rundeck.jetty.jaas.*` unchanged)
 2. **Jetty OBF passwords are no longer supported** - if you use obfuscated passwords, migrate to MD5, CRYPT, or BCRYPT password hashing
 3. **Docker and Kubernetes deployments** that mount custom JAAS configurations must update their config files before upgrading to 6.0
+4. **`log4j2.properties` JAAS logger categories are unchanged** - the shipped config defines two separate logger categories: `logger.rundeck_jaas.name = com.dtolabs.rundeck.jetty.jaas` (LDAP modules) and `logger.jaas.name = org.rundeck.jaas` (`PropertyFileLoginModule` and PAM modules). Keep both as-is; there is no need to rename the `com.dtolabs.rundeck.jetty.jaas` logger category.
 
 See the [Authentication documentation](/administration/security/authentication.md) for current JAAS configuration examples and supported password formats.
 


### PR DESCRIPTION
## PR Details

Rundeck 6.0's Jetty 12 upgrade moved `PropertyFileLoginModule` and the PAM JAAS modules to `org.rundeck.jaas.*`. The LDAP modules (`JettyCachingLdapLoginModule`, `JettyCombinedLdapLoginModule`) are Rundeck-authored and were never part of Jetty's built-in JAAS SPI, so they were intentionally left under `com.dtolabs.rundeck.jetty.jaas` — confirmed against the [rundeck/rundeck](https://github.com/rundeck/rundeck) source (`org/rundeck/jaas/jetty/` contains only the PropertyFile/PAM modules; the LDAP modules still live under `com/dtolabs/rundeck/jetty/jaas/`).

Similarly, the shipped `log4j2.properties` intentionally keeps two separate JAAS logger categories (one per package) — nothing needs to be renamed there either.

Without an explicit note, this reads as an incomplete migration. This PR adds clarifying notes to:
- [administration/security/authentication.md](docs/administration/security/authentication.md) — LDAP module section
- [upgrading/upgrading-to-6.0.md](docs/upgrading/upgrading-to-6.0.md) — JAAS authentication configuration (Jetty 12) section

No product behavior changes; docs-only clarification. Not tagged `release-notes/include` since there's no customer-facing change to report.

Closes https://github.com/rundeck/docs/issues/1958
Closes https://github.com/rundeck/docs/issues/1959