### PR TITLE
[RUN-4693] rejectUndeclaredOptions defaults to false (opt-in)

### DIFF
--- a/docs/administration/configuration/config-file-reference.md
+++ b/docs/administration/configuration/config-file-reference.md
@@ -634,11 +634,11 @@ This control is opt-in. With no pattern configured (the default), option values 
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `rundeck.execution.rejectUndeclaredOptions` | `true` | When enabled, an execution that provides an option not defined on the job is created and then failed at start, with a message in the execution log. |
+| `rundeck.execution.rejectUndeclaredOptions` | `false` | When enabled, an execution that provides an option not defined on the job is created and then failed at start, with a message in the execution log. |
 
-Options not declared on a job would otherwise bypass all server-side option validation yet still reach the option data context and `RD_OPTION_*` environment variables. With this control enabled (the default), such executions are rejected before any workflow step runs. Disable it only if you must allow undeclared options to pass through — for example, re-running a job whose option set has since changed. Disabling it weakens protection against option injection, and Rundeck logs a security warning at startup when it is set to `false`. Scope: top-level executions (UI, API, webhook, and scheduled).
+Options not declared on a job bypass all server-side option validation yet still reach the option data context and `RD_OPTION_*` environment variables. This control is **opt-in and off by default**, so undeclared options pass through — preserving the behavior expected by workflows that rely on it (for example, re-running a job whose option set has since changed, or callers passing extra options). Set it to `true` to reject such executions before any workflow step runs, as a hardening against option injection. Scope: top-level executions (UI, API, webhook, and scheduled).
 
-Scope includes re-running a prior execution, including automatic retry via `retryExecId` — the original option string is replayed verbatim and is checked again against the job's current option definitions. Job reference (`jobref`) workflow steps are exempt from this check: an undeclared option passed from one job to another via a job-reference step is not rejected, only options supplied to a job's own top-level execution (its own API/UI/webhook/scheduled run) are.
+When enabled, the check also applies when re-running a prior execution, including automatic retry via `retryExecId` — the original option string is replayed verbatim and is checked again against the job's current option definitions. Job reference (`jobref`) workflow steps are exempt from this check: an undeclared option passed from one job to another via a job-reference step is not rejected; only options supplied to a job's own top-level execution (its own API/UI/webhook/scheduled run) are.
 
 ### Security HTTP Headers
 

--- a/docs/manual/jobs/job-options.md
+++ b/docs/manual/jobs/job-options.md
@@ -435,7 +435,7 @@ Because option values are user input, a value containing shell metacharacters ca
 
 - **Per option** — set a **Match Regular Expression** or an **Enforced** allowed-values list on the option (see the option Restrictions described in [Defining an option](#defining-an-option) above). These constrain that single option.
 - **Project- or system-wide default allowlist** — configure a default regular expression applied to every option value that does not already have its own regex or enforced list. Set `project.option.input.validation.default.pattern` for a project, or `rundeck.option.input.validation.default.pattern` instance-wide. A value that does not fully match the pattern causes the execution to be rejected before it runs.
-- **Reject undeclared options** — by default (`rundeck.execution.rejectUndeclaredOptions=true`), an execution that supplies an option the job does not declare is rejected, so unvalidated values cannot reach scripts or `RD_OPTION_*` environment variables.
+- **Reject undeclared options** — opt-in (off by default). Set `rundeck.execution.rejectUndeclaredOptions=true` to reject any execution that supplies an option the job does not declare, so unvalidated values cannot reach scripts or `RD_OPTION_*` environment variables.
 
 See [Job Option Injection Controls](/administration/configuration/config-file-reference.md#job-option-injection-controls) for the full property reference, precedence rules, and pattern caveats (full-match behavior, multi-line matching, international characters, and fail-closed handling of an invalid pattern).
 


### PR DESCRIPTION
## Summary

Follows the product change (rundeck/rundeck#10568) that flips `rundeck.execution.rejectUndeclaredOptions` to **default `false` (opt-in)**.

Updates the docs merged earlier (from #1946) so they no longer describe the control as on-by-default:

- `docs/administration/configuration/config-file-reference.md` — property default `true` → `false`; reworded to "opt-in, off by default"; removed the "logs a security warning at startup when false" note (that startup warning was removed with the default flip); the retry/`jobref` scope details now say they apply "when enabled".
- `docs/manual/jobs/job-options.md` — the "Reject undeclared options" bullet now describes it as opt-in (`=true` to reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)